### PR TITLE
ci: auto-publish to PyPI by calling release.yml from release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,8 +3,10 @@ name: release-please
 # On every push to main, release-please analyzes conventional commits since the
 # last release. If a version bump is warranted (feat = minor, fix = patch,
 # ! = major), it creates or updates a "Release PR". When that PR merges, it
-# creates the git tag + GitHub Release. The release.yml workflow then publishes
-# to PyPI via OIDC trusted publisher.
+# creates the git tag + GitHub Release AND, in the same run, calls release.yml
+# to publish to PyPI. (release-please creates releases with GITHUB_TOKEN, whose
+# `release: published` event does not spawn workflows — so we call release.yml
+# directly instead of relying on that trigger.)
 on:
   push:
     branches: [main]
@@ -16,7 +18,18 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: rp
+        uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/release.yml
+    with:
+      ref: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,31 @@
 name: release
 
-# Publish to PyPI via OIDC trusted publishing (no API token).
-# Triggers on a published GitHub Release. Requires a "pending trusted publisher"
-# configured on PyPI (project = lorekeep, repo = manhhailua/lorekeep,
-# workflow = release.yml, environment = blank) before the first release.
+# Publish to PyPI via OIDC trusted publishing (no API token). Requires a
+# "pending trusted publisher" configured on PyPI (project = lorekeep,
+# repo = manhhailua/lorekeep, workflow = release.yml, environment = pypi).
+#
+# Triggered two ways:
+#   1. workflow_call from release-please.yml — the reliable auto-publish path.
+#      release-please creates releases with GITHUB_TOKEN, whose events do NOT
+#      spawn other workflows, so a `release: published` trigger never fires for
+#      them. Calling this workflow directly from the release-please run (a job
+#      call, not an event) sidesteps that anti-loop rule.
+#   2. release: published + workflow_dispatch — manual / fallback paths.
 on:
   release:
     types: [published]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (tag/branch/SHA) to build and publish
+        required: false
+        default: ""
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -19,6 +37,8 @@ jobs:
     environment: pypi
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.event.release.tag_name || github.ref }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
## Problem

Only **0.1.0** is on PyPI. **0.1.2** and **0.1.3** have git tags + GitHub Releases but were never published.

Root cause: release-please creates GitHub Releases using `GITHUB_TOKEN`, and GitHub does not let an event spawned by `GITHUB_TOKEN` trigger another workflow. So the `release: published` trigger on `release.yml` never fires for release-please-created releases.

## Fix

Make `release.yml` a **reusable workflow** (`workflow_call`) and call it from `release-please.yml` in the **same run**, gated on `release_created == true`. A `workflow_call` is a job invocation, not an event — it is not subject to the anti-loop rule.

- `release.yml`: add `workflow_call` + a `ref` input; pin `checkout` to the tag. `release: published` + `workflow_dispatch` stay as fallbacks.
- `release-please.yml`: capture `release_created` / `tag_name` outputs, add a `publish` job that `uses: ./.github/workflows/release.yml` with `ref: <tag>`.

`release.yml` remains the publishing workflow file, so the PyPI trusted-publisher config (`workflow = release.yml`, `environment = pypi`) needs **no change**, and **no PAT / new secret** is required.

## Verification

- Both workflow YAMLs parse.
- Next merge that triggers a release → `release-please.yml` run shows a `publish` → `release` job that publishes.
- Backfill 0.1.3 separately via `gh workflow run release.yml --ref v0.1.3` (manual dispatch; may need `pypi` environment approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)