### PR TITLE
ci: bump actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -11,14 +11,14 @@ jobs:
   pr-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   commit-messages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.event.release.tag_name || github.ref }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 


### PR DESCRIPTION
GitHub Actions deprecated the Node 20 runtime — runners force these actions onto Node 24 with a deprecation warning.

## Bumps
- `actions/checkout` v4 → **v5** (release.yml, lint-commits.yml)
- `astral-sh/setup-uv` v5 → **v8** (release.yml)
- `amannn/action-semantic-pull-request` v5 → **v6** (lint-commits.yml)

## Left as-is
- `wagoid/commitlint-github-action@v6` — latest major; no Node-24 release exists yet.
- `pypa/gh-action-pypi-publish@release/v1` — floats to latest (v1.14, already Node 24).
- `googleapis/release-please-action@v4` — composite action, not a Node runtime.

## Inputs
Our inputs are unchanged across these majors — `checkout` (`fetch-depth`, `ref`), `setup-uv` (`enable-cache`). setup-uv v6/v8 breaking changes (cache-dependency-glob default, `manifest-file` format) don't touch our usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)