### PR TITLE
fix: revert release-please to simple model, use PAT fallback for PyPI auto-publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,11 +2,14 @@ name: release-please
 
 # On every push to main, release-please analyzes conventional commits since the
 # last release. If a version bump is warranted (feat = minor, fix = patch,
-# ! = major), it creates or updates a "Release PR". When that PR merges, it
-# creates the git tag + GitHub Release AND, in the same run, calls release.yml
-# to publish to PyPI. (release-please creates releases with GITHUB_TOKEN, whose
-# `release: published` event does not spawn workflows — so we call release.yml
-# directly instead of relying on that trigger.)
+# ! = major), it creates or updates a "Release PR" that auto-merges. On merge:
+# - Git tag + GitHub Release are created
+# - release.yml publishes to PyPI via OIDC trusted publishing
+#
+# For PyPI auto-publish: set RELEASE_PLEASE_TOKEN to a PAT with repo+workflow
+# scope. PAT-created releases trigger downstream workflows (GITHUB_TOKEN does
+# not, per GitHub's anti-recursion rule). Without the PAT, trigger release.yml
+# manually via `gh workflow run release.yml` after the Release PR merges.
 on:
   push:
     branches: [main]
@@ -18,18 +21,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.rp.outputs.release_created }}
-      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
-      - id: rp
-        uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-  publish:
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    uses: ./.github/workflows/release.yml
-    with:
-      ref: ${{ needs.release-please.outputs.tag_name }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

All release-please runs since commit `06e58c5` fail with `startup_failure`. The `publish` job added in that commit calls `release.yml` as a reusable workflow via `uses: ./.github/workflows/release.yml`, which causes workflow validation failure.

## Fix

Revert release-please.yml to the working single-job model. The `publish` job is removed from release-please.yml.

For PyPI auto-publish:
- **With PAT**: set `RELEASE_PLEASE_TOKEN` secret (PAT with repo+workflow scope). PAT-created releases trigger downstream workflows, so `release.yml` (triggered by `release: published`) will auto-publish to PyPI.
- **Without PAT**: the workflow falls back to `GITHUB_TOKEN`. Release PRs still auto-merge and create GitHub Releases. Manually run `gh workflow run release.yml` to publish to PyPI.

The `${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}` expression provides the fallback.

## Verification

Previous working state (before `06e58c5`) used this same single-job model with GITHUB_TOKEN and all runs succeeded.