### PR TITLE
fix: inline PyPI publish in release-please, OIDC zero-trust, no PAT

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,14 +2,15 @@ name: release-please
 
 # On every push to main, release-please analyzes conventional commits since the
 # last release. If a version bump is warranted (feat = minor, fix = patch,
-# ! = major), it creates or updates a "Release PR" that auto-merges. On merge:
-# - Git tag + GitHub Release are created
-# - release.yml publishes to PyPI via OIDC trusted publishing
+# ! = major), it creates or updates a "Release PR" that auto-merges.
 #
-# For PyPI auto-publish: set RELEASE_PLEASE_TOKEN to a PAT with repo+workflow
-# scope. PAT-created releases trigger downstream workflows (GITHUB_TOKEN does
-# not, per GitHub's anti-recursion rule). Without the PAT, trigger release.yml
-# manually via `gh workflow run release.yml` after the Release PR merges.
+# When the Release PR merges, this workflow runs again and release-please
+# creates the git tag + GitHub Release. The publish job then builds and
+# publishes to PyPI via OIDC trusted publishing (zero-trust, no API token).
+#
+# Publish steps are inline here (not a reusable workflow call) to avoid
+# startup_failure caused by referencing .github/workflows/release.yml via
+# `uses:` — see PR #18.
 on:
   push:
     branches: [main]
@@ -17,11 +18,37 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write          # required for PyPI OIDC trusted publishing
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: rp
+        uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
+      - name: Build sdist + wheel
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Problem

1. Commit `06e58c5` added `publish` job calling `release.yml` as reusable workflow → `startup_failure` on all subsequent runs
2. PR #18 fixed the `startup_failure` by removing the publish job, but Release PR #19 auto-merged without creating GitHub Release or publishing to PyPI
3. User wants OIDC zero-trust publishing (no PAT, no API token)

## Fix

Publish steps are now **inline** in `release-please.yml` (not calling release.yml as a reusable workflow). This avoids the `startup_failure` and uses OIDC trusted publishing:

- `id-token: write` permission at top level (required for PyPI OIDC)
- `publish` job runs only when `release_created == 'true'`
- `environment: pypi` for OIDC scope
- Builds with `uv build`, publishes with `pypa/gh-action-pypi-publish@release/v1`

Zero tokens. Zero PAT. Pure OIDC trust.