### PR TITLE
fix: use setup-uv@v7, @v8 tag does not exist

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,7 +43,7 @@ jobs:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           ref: ${{ inputs.ref || github.event.release.tag_name || github.ref }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 


### PR DESCRIPTION
astral-sh/setup-uv does not have a `v8` major version tag. Latest is `v7`.

Fixes publish failure: `Unable to resolve action astral-sh/setup-uv@v8, unable to find version v8`