### PR TITLE
fix: use workflow_dispatch to trigger release.yml, avoid OIDC name mismatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,13 +4,12 @@ name: release-please
 # last release. If a version bump is warranted (feat = minor, fix = patch,
 # ! = major), it creates or updates a "Release PR" that auto-merges.
 #
-# When the Release PR merges, this workflow runs again and release-please
-# creates the git tag + GitHub Release. The publish job then builds and
-# publishes to PyPI via OIDC trusted publishing (zero-trust, no API token).
+# When the Release PR merges, this workflow runs again. release-please creates
+# the git tag + GitHub Release. The publish job then triggers release.yml via
+# workflow_dispatch to publish to PyPI via OIDC trusted publishing.
 #
-# Publish steps are inline here (not a reusable workflow call) to avoid
-# startup_failure caused by referencing .github/workflows/release.yml via
-# `uses:` — see PR #18.
+# dispatch is used instead of `uses:` because calling release.yml as a reusable
+# workflow caused startup_failure (see PR #18). dispatch works with GITHUB_TOKEN.
 on:
   push:
     branches: [main]
@@ -18,7 +17,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write          # required for PyPI OIDC trusted publishing
+  actions: write            # needed to dispatch release.yml
 
 jobs:
   release-please:
@@ -36,19 +35,12 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
-    environment: pypi
     steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Build sdist + wheel
-        run: uv build
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Trigger release.yml publish
+        run: |
+          gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.ref }}" \
+            -f ref="${{ needs.release-please.outputs.tag_name }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,27 +4,16 @@ name: release
 # "pending trusted publisher" configured on PyPI (project = lorekeep,
 # repo = manhhailua/lorekeep, workflow = release.yml, environment = pypi).
 #
-# Triggered two ways:
-#   1. workflow_call from release-please.yml — the reliable auto-publish path.
-#      release-please creates releases with GITHUB_TOKEN, whose events do NOT
-#      spawn other workflows, so a `release: published` trigger never fires for
-#      them. Calling this workflow directly from the release-please run (a job
-#      call, not an event) sidesteps that anti-loop rule.
-#   2. release: published + workflow_dispatch — manual / fallback paths.
+# Triggered by:
+#   1. release-please.yml dispatches this workflow when a release is created.
+#      dispatch is used instead of `uses:` to avoid startup_failure (PR #18).
+#   2. workflow_dispatch — manual fallback.
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       ref:
         description: Git ref (tag/branch/SHA) to build and publish
         required: false
-        default: ""
-  workflow_call:
-    inputs:
-      ref:
-        required: false
-        type: string
         default: ""
 
 permissions:
@@ -38,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.ref || github.event.release.tag_name || github.ref }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Problem

1. PR #20 inlined publish steps in release-please.yml → PyPI OIDC rejected because trusted publisher expects `workflow=release.yml`, not `workflow=release-please.yml`
2. Calling release.yml via `uses:` causes `startup_failure` (since 06e58c5, PR #18)

## Fix

release-please.yml dispatches release.yml via `gh workflow run` instead of:
- ❌ `uses:` (startup_failure)
- ❌ inline steps (OIDC workflow name mismatch)

This preserves the `release.yml` workflow name that PyPI's trusted publisher is configured for.

Release-please.yml gets `actions: write` permission to dispatch.