### PR TITLE
feat: implement autonomous agent, journal, and MCP write tools

### DIFF
--- a/src/lorekeep/agent.py
+++ b/src/lorekeep/agent.py
@@ -1,0 +1,154 @@
+"""Autonomous agent operations: lint, suggest, status, watch.
+
+The agent keeps the knowledge graph current: lint checks structural health,
+suggest identifies improvement opportunities, status provides a dashboard,
+and watch runs a daemon that auto-compiles and resolves on filesystem changes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from lorekeep.store.graph import GraphStore
+
+
+@dataclass
+class LintReport:
+    contradictions: list[dict] = field(default_factory=list)
+    orphans: list[str] = field(default_factory=list)
+    stale: list[str] = field(default_factory=list)
+    missing_endpoints: list[dict] = field(default_factory=list)
+    coverage_gaps: list[str] = field(default_factory=list)
+
+    @property
+    def has_issues(self) -> bool:
+        return bool(self.contradictions or self.orphans or self.stale
+                    or self.missing_endpoints or self.coverage_gaps)
+
+    @property
+    def issue_count(self) -> int:
+        return (len(self.contradictions) + len(self.orphans)
+                + len(self.stale) + len(self.missing_endpoints)
+                + len(self.coverage_gaps))
+
+
+def lint(store: GraphStore) -> LintReport:
+    report = LintReport()
+
+    # Orphans: nodes with zero inbound or outbound edges
+    for nid in store.node_ids():
+        if not store.out_edges(nid) and not store.in_edges(nid):
+            report.orphans.append(nid)
+
+    # Missing endpoints: edges referencing non-existent nodes
+    for e in store.all_edges():
+        f = e.from_
+        t = e.to
+        missing = []
+        if f not in store.node_ids():
+            missing.append(f)
+        if t not in store.node_ids():
+            missing.append(t)
+        if missing:
+            report.missing_endpoints.append({"edge_id": e.id, "missing": missing})
+
+    # Stale facts: nodes/edges with expired valid_to, no superseding edge
+    from datetime import date
+    today = date.today()
+    for e in store.all_edges():
+        if e.valid_to is not None and e.valid_to < today:
+            report.stale.append(e.id)
+
+    # Coverage gaps: count facts per namespace
+    ns_counts: dict[str, int] = {}
+    for n in store.all_nodes():
+        for ns in n.ns:
+            ns_counts[ns] = ns_counts.get(ns, 0) + 1
+    if ns_counts:
+        avg = sum(ns_counts.values()) / len(ns_counts)
+        for ns, cnt in ns_counts.items():
+            if cnt < avg * 0.25 and cnt < 3:
+                report.coverage_gaps.append(ns)
+
+    # Contradictions: facts with same id but conflicting props
+    id_nodes: dict[str, list] = {}
+    for n in store.all_nodes():
+        id_nodes.setdefault(n.id, []).append(n)
+    for nid, nodes in id_nodes.items():
+        if len(nodes) > 1:
+            props_sets = [set(n.props.items()) for n in nodes]
+            for i in range(len(props_sets)):
+                for j in range(i + 1, len(props_sets)):
+                    if props_sets[i] != props_sets[j]:
+                        report.contradictions.append({
+                            "id": nid,
+                            "props_a": dict(props_sets[i]),
+                            "props_b": dict(props_sets[j]),
+                        })
+
+    return report
+
+
+@dataclass
+class SuggestionReport:
+    gaps: list[str] = field(default_factory=list)
+    under_sourced: list[str] = field(default_factory=list)
+    suggestions: list[str] = field(default_factory=list)
+
+
+def suggest(store: GraphStore) -> SuggestionReport:
+    report = SuggestionReport()
+
+    # Under-sourced areas: facts with few src entries
+    for n in store.all_nodes():
+        if len(n.src) <= 1:
+            report.under_sourced.append(n.id)
+        if not n.valid_from and len(n.src) <= 1:
+            report.gaps.append(f"{n.id}: missing valid_from, single src")
+
+    # Graphs with only one namespace suggest expansion
+    ns_set: set[str] = set()
+    for n in store.all_nodes():
+        ns_set.update(n.ns)
+    if len(ns_set) <= 1:
+        report.suggestions.append("Only one namespace active — consider adding more raw/ directories")
+
+    if not store.all_edges():
+        report.suggestions.append("No edges in graph — consider linking related entities")
+
+    return report
+
+
+@dataclass
+class StatusDashboard:
+    node_count: int = 0
+    edge_count: int = 0
+    namespace_count: int = 0
+    namespaces: list[str] = field(default_factory=list)
+    lint_issues: int = 0
+    pending_journals: int = 0
+
+
+def agent_status(
+    store: GraphStore,
+    pending_dir: Path | None = None,
+) -> StatusDashboard:
+    dash = StatusDashboard(
+        node_count=len(store.node_ids()),
+        edge_count=len(store.all_edges()),
+    )
+    ns_set: set[str] = set()
+    for n in store.all_nodes():
+        ns_set.update(n.ns)
+    dash.namespace_count = len(ns_set)
+    dash.namespaces = sorted(ns_set)
+
+    lr = lint(store)
+    dash.lint_issues = lr.issue_count
+
+    if pending_dir and pending_dir.exists():
+        from lorekeep.journal import load_journals
+        journals = load_journals(pending_dir)
+        dash.pending_journals = len([j for j in journals if j.status == "pending"])
+
+    return dash

--- a/src/lorekeep/agent.py
+++ b/src/lorekeep/agent.py
@@ -2,7 +2,8 @@
 
 The agent keeps the knowledge graph current: lint checks structural health,
 suggest identifies improvement opportunities, status provides a dashboard,
-and watch runs a daemon that auto-compiles and resolves on filesystem changes.
+and watch runs a daemon that monitors filesystem changes (auto-compile
+and auto-resolve are handled in the CLI layer).
 """
 from __future__ import annotations
 

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -116,6 +116,101 @@ def check() -> None:
 
 
 @app.command()
+def resolve(
+    archive: bool = typer.Option(
+        False, "--archive",
+        help="Archive processed journal entries instead of truncating",
+    ),
+) -> None:
+    """Merge pending journal entries into facts.jsonl (full resolve pass)."""
+    p = resolve_paths()
+    from lorekeep.store.graph import GraphStore
+    from lorekeep.facts_io import read_facts
+    from lorekeep.compile.resolve import resolve as resolve_facts, merge_journals
+    from lorekeep.compile.writer import write_graph
+    from lorekeep.journal import load_journals, update_journal_status
+    from lorekeep.models import Manifest
+
+    facts_path = p["out"] / "facts.jsonl"
+    pending = p.get("pending")
+    if not pending or not pending.exists():
+        typer.echo("resolve: no pending directory, nothing to do")
+        return
+
+    journals = load_journals(pending)
+    pending_entries = [j for j in journals if j.status == "pending"]
+    if not pending_entries:
+        typer.echo("resolve: no pending journal entries")
+        return
+
+    # Load current facts
+    existing_nodes = []
+    existing_edges = []
+    if facts_path.exists():
+        facts = read_facts(facts_path)
+        from lorekeep.models import Edge, Node
+        for f in facts:
+            if isinstance(f, Node):
+                existing_nodes.append(f)
+            else:
+                existing_edges.append(f)
+
+    # Merge journals
+    merged = merge_journals(existing_nodes, existing_edges, pending_entries)
+
+    # Run standard resolve over merged facts
+    resolved = resolve_facts(merged.nodes, merged.edges)
+
+    # Build manifest
+    manifest = Manifest(
+        schema_version=0,
+        chunk_count=0,
+        node_count=len(resolved.nodes),
+        edge_count=len(resolved.edges),
+        run_id="resolve",
+        facts_hash="",
+        merged_count=merged.merge_count,
+        quarantined_count=merged.quarantine_count,
+        flagged_count=merged.flagged_count,
+        quarantine=[{"fact": q[0].fact, "reason": q[1]} for q in resolved.quarantined],
+        review=[{"fact_id": f[0].fact.get("id", ""), "reason": f[1]}
+                for f in merged.flagged],
+    )
+    write_graph(p["out"], resolved.nodes, resolved.edges, manifest)
+
+    # Update journal status per namespace
+    ns_to_merged: dict[str, set[str]] = {}
+    ns_to_flagged: dict[str, set[str]] = {}
+    ns_to_quarantined: dict[str, set[str]] = {}
+    for entry, _ in merged.merged:
+        ns_to_merged.setdefault(entry.ns, set()).add(entry.proposed_at)
+    for entry, _ in merged.flagged:
+        ns_to_flagged.setdefault(entry.ns, set()).add(entry.proposed_at)
+    for entry, _ in merged.quarantined:
+        ns_to_quarantined.setdefault(entry.ns, set()).add(entry.proposed_at)
+
+    # Flagged entries are still merged into the graph (just flagged for review)
+    for ns, timestamps in ns_to_flagged.items():
+        existing = ns_to_merged.get(ns, set())
+        ns_to_merged[ns] = existing | timestamps
+
+    for ns, timestamps in ns_to_merged.items():
+        update_journal_status(pending, ns, timestamps, "merged")
+    for ns, timestamps in ns_to_quarantined.items():
+        # Don't overwrite merged status for entries already handled
+        already = ns_to_merged.get(ns, set())
+        to_quarantine = timestamps - already
+        if to_quarantine:
+            update_journal_status(pending, ns, to_quarantine, "quarantined")
+
+    typer.echo(
+        f"resolve: {len(resolved.nodes)} nodes, {len(resolved.edges)} edges — "
+        f"{merged.merge_count} merged, {merged.flagged_count} flagged, "
+        f"{merged.quarantine_count} quarantined"
+    )
+
+
+@app.command()
 def serve(
     transport: str = typer.Option("stdio", "--transport", help="stdio (default) | http"),
 ) -> None:
@@ -127,7 +222,7 @@ def serve(
     else:
         allowed = load_config(p["config"]).ns.default
     from lorekeep.mcp_server import configure, mcp
-    configure(graph_dir=p["out"], allowed_ns=allowed, schema_path=p["schema"])
+    configure(graph_dir=p["out"], allowed_ns=allowed, schema_path=p["schema"], pending_dir=p.get("pending"))
     mcp.run(transport=transport)
 
 
@@ -190,7 +285,7 @@ def doctor() -> None:
 
     try:
         from lorekeep.mcp_server import configure, list_namespaces
-        configure(graph_dir=p["out"], allowed_ns=allowed, schema_path=p["schema"])
+        configure(graph_dir=p["out"], allowed_ns=allowed, schema_path=p["schema"], pending_dir=p.get("pending"))
         ns = list_namespaces()
     except Exception as exc:
         problems.append(f"mcp configure/tool failed: {exc}")
@@ -350,6 +445,161 @@ def import_cmd(
                    f"{ses_count} session files -> raw/{session_ns}/")
         if not quick:
             typer.echo("next: lorekeep compile")
+
+
+# --- Agent subcommand group -----------------------------------------------
+
+agent_app = typer.Typer(help="Autonomous agent operations: lint, suggest, status, watch.")
+app.add_typer(agent_app, name="agent")
+
+
+@agent_app.command()
+def lint(
+    auto_fix: bool = typer.Option(
+        False, "--auto-fix",
+        help="Auto-apply high-confidence fixes",
+    ),
+    focus: str = typer.Option(
+        None, "--focus",
+        help="Lint a specific entity by id",
+    ),
+) -> None:
+    """Run semantic health checks on the graph."""
+    p = resolve_paths()
+    facts_path = p["out"] / "facts.jsonl"
+    if not facts_path.exists():
+        typer.echo("lint: no graph — run `lorekeep compile` first")
+        raise typer.Exit(code=1)
+
+    from lorekeep.store.graph import GraphStore
+    from lorekeep.agent import lint as agent_lint
+    store = GraphStore.from_jsonl(facts_path)
+    report = agent_lint(store)
+
+    if focus:
+        report.orphans = [o for o in report.orphans if o == focus]
+        report.stale = [s for s in report.stale if s == focus]
+        report.missing_endpoints = [m for m in report.missing_endpoints
+                                     if m["edge_id"] == focus]
+
+    if not report.has_issues:
+        typer.echo("lint: no issues found")
+        return
+
+    if report.contradictions:
+        typer.echo(f"contradictions: {len(report.contradictions)}")
+        for c in report.contradictions[:10]:
+            typer.echo(f"  {c['id']}")
+    if report.orphans:
+        typer.echo(f"orphans: {len(report.orphans)}")
+        for o in report.orphans[:10]:
+            typer.echo(f"  {o}")
+    if report.stale:
+        typer.echo(f"stale: {len(report.stale)}")
+    if report.missing_endpoints:
+        typer.echo(f"missing endpoints: {len(report.missing_endpoints)}")
+    if report.coverage_gaps:
+        typer.echo(f"coverage gaps: {report.coverage_gaps}")
+
+    if auto_fix:
+        typer.echo("auto-fix: not yet implemented (planned)")
+
+    typer.echo(f"total issues: {report.issue_count}")
+
+
+@agent_app.command()
+def suggest() -> None:
+    """Generate improvement suggestions for the graph."""
+    p = resolve_paths()
+    facts_path = p["out"] / "facts.jsonl"
+    if not facts_path.exists():
+        typer.echo("suggest: no graph — run `lorekeep compile` first")
+        raise typer.Exit(code=1)
+
+    from lorekeep.store.graph import GraphStore
+    from lorekeep.agent import suggest as agent_suggest
+    store = GraphStore.from_jsonl(facts_path)
+    report = agent_suggest(store)
+
+    if report.gaps:
+        typer.echo("knowledge gaps:")
+        for g in report.gaps:
+            typer.echo(f"  {g}")
+    if report.under_sourced:
+        typer.echo(f"under-sourced entities: {len(report.under_sourced)}")
+        for u in report.under_sourced[:10]:
+            typer.echo(f"  {u}")
+    if report.suggestions:
+        typer.echo("suggestions:")
+        for s in report.suggestions:
+            typer.echo(f"  {s}")
+
+    if not report.gaps and not report.under_sourced and not report.suggestions:
+        typer.echo("suggest: no suggestions (graph looks healthy)")
+
+
+@agent_app.command()
+def status() -> None:
+    """Print a graph health dashboard."""
+    p = resolve_paths()
+    facts_path = p["out"] / "facts.jsonl"
+    if not facts_path.exists():
+        typer.echo("status: no graph — run `lorekeep compile` first")
+        raise typer.Exit(code=1)
+
+    from lorekeep.store.graph import GraphStore
+    from lorekeep.agent import agent_status
+    store = GraphStore.from_jsonl(facts_path)
+    dash = agent_status(store, p.get("pending"))
+
+    typer.echo(f"nodes: {dash.node_count}")
+    typer.echo(f"edges: {dash.edge_count}")
+    typer.echo(f"namespaces: {dash.namespace_count} ({', '.join(dash.namespaces)})")
+    typer.echo(f"lint issues: {dash.lint_issues}")
+    typer.echo(f"pending journals: {dash.pending_journals}")
+
+
+@agent_app.command()
+def watch(
+    interval: int = typer.Option(
+        60, "--interval",
+        help="Polling interval in seconds",
+    ),
+) -> None:
+    """Run the autonomous agent daemon: watch raw/ and pending/ for changes."""
+    import time
+    p = resolve_paths()
+    raw_dir = p["raw"]
+    pending_dir = p.get("pending")
+
+    typer.echo(f"agent watch: monitoring raw={raw_dir}, pending={pending_dir}, interval={interval}s")
+    last_raw_mtime = 0.0
+    last_pending_mtime = 0.0
+
+    while True:
+        try:
+            # Check raw/ for changes
+            raw_files = sorted(raw_dir.rglob("*.md")) if raw_dir.exists() else []
+            raw_mtime = max((f.stat().st_mtime for f in raw_files), default=0.0)
+            if raw_mtime > last_raw_mtime and last_raw_mtime > 0:
+                typer.echo("agent: raw/ changed — run `lorekeep compile` to incorporate changes")
+            last_raw_mtime = raw_mtime
+
+            # Check pending/ for new journals
+            if pending_dir and pending_dir.exists():
+                journal_files = sorted(pending_dir.rglob("journal.jsonl"))
+                pending_mtime = max((f.stat().st_mtime for f in journal_files), default=0.0)
+                if pending_mtime > last_pending_mtime and last_pending_mtime > 0:
+                    typer.echo("agent: pending/ changed — run `lorekeep resolve` to merge pending facts")
+                last_pending_mtime = pending_mtime
+
+            time.sleep(interval)
+        except KeyboardInterrupt:
+            typer.echo("\nagent: shutting down")
+            break
+        except Exception as exc:
+            typer.echo(f"agent: error: {exc}")
+            time.sleep(interval)
 
 
 if __name__ == "__main__":

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -573,24 +573,88 @@ def watch(
     pending_dir = p.get("pending")
 
     typer.echo(f"agent watch: monitoring raw={raw_dir}, pending={pending_dir}, interval={interval}s")
+    typer.echo("agent: auto-compile (raw/) and auto-resolve (pending/) enabled")
+    typer.echo("agent: MCP server lazy-reloads facts.jsonl — no reconnect needed")
     last_raw_mtime = 0.0
     last_pending_mtime = 0.0
+    has_raw = raw_dir.exists()
+    has_pending = pending_dir and pending_dir.exists()
 
     while True:
         try:
-            # Check raw/ for changes
-            raw_files = sorted(raw_dir.rglob("*.md")) if raw_dir.exists() else []
+            # Check raw/ for changes → auto-compile
+            raw_files = sorted(raw_dir.rglob("*.md")) if has_raw else []
             raw_mtime = max((f.stat().st_mtime for f in raw_files), default=0.0)
             if raw_mtime > last_raw_mtime and last_raw_mtime > 0:
-                typer.echo("agent: raw/ changed — run `lorekeep compile` to incorporate changes")
+                typer.echo(f"agent: raw/ changed ({len(raw_files)} files) — compiling...")
+                try:
+                    from pathlib import Path
+                    from lorekeep.pipeline import compile_graph
+                    from lorekeep.compile.providers import get_provider
+                    from lorekeep.defaults import default_schema
+                    schema = default_schema()
+                    provider = get_provider(p["config"])
+                    cache = p.get("cache", p["out"].parent / ".lorekeep" / "cache.json")
+                    compile_graph(raw_dir, p["out"], schema, provider, Path(cache))
+                    typer.echo("agent: compile done")
+                except Exception as exc:
+                    typer.echo(f"agent: compile error: {exc}")
             last_raw_mtime = raw_mtime
 
-            # Check pending/ for new journals
-            if pending_dir and pending_dir.exists():
+            # Check pending/ for new journals → auto-resolve
+            if has_pending:
                 journal_files = sorted(pending_dir.rglob("journal.jsonl"))
                 pending_mtime = max((f.stat().st_mtime for f in journal_files), default=0.0)
                 if pending_mtime > last_pending_mtime and last_pending_mtime > 0:
-                    typer.echo("agent: pending/ changed — run `lorekeep resolve` to merge pending facts")
+                    typer.echo("agent: pending/ changed — resolving...")
+                    try:
+                        from lorekeep.store.graph import GraphStore
+                        from lorekeep.facts_io import read_facts
+                        from lorekeep.compile.resolve import resolve as resolve_facts, merge_journals
+                        from lorekeep.compile.writer import write_graph
+                        from lorekeep.journal import load_journals, update_journal_status
+                        from lorekeep.models import Edge, Manifest, Node
+
+                        facts_path = p["out"] / "facts.jsonl"
+                        existing_nodes = []
+                        existing_edges = []
+                        if facts_path.exists():
+                            for f in read_facts(facts_path):
+                                if isinstance(f, Node):
+                                    existing_nodes.append(f)
+                                else:
+                                    existing_edges.append(f)
+
+                        journals = load_journals(pending_dir)
+                        pending_entries = [j for j in journals if j.status == "pending"]
+                        if pending_entries:
+                            merged = merge_journals(existing_nodes, existing_edges, pending_entries)
+                            resolved = resolve_facts(merged.nodes, merged.edges)
+                            manifest = Manifest(
+                                schema_version=0, chunk_count=0,
+                                node_count=len(resolved.nodes),
+                                edge_count=len(resolved.edges),
+                                run_id="auto-resolve", facts_hash="",
+                                merged_count=merged.merge_count,
+                                quarantined_count=merged.quarantine_count,
+                                flagged_count=merged.flagged_count,
+                            )
+                            write_graph(p["out"], resolved.nodes, resolved.edges, manifest)
+
+                            # Update journal status
+                            for ns in set(entry.ns for entry, _ in merged.merged):
+                                timestamps = {e.proposed_at for e, _ in merged.merged if e.ns == ns}
+                                if timestamps:
+                                    update_journal_status(pending_dir, ns, timestamps, "merged")
+                            for ns in set(entry.ns for entry, _ in merged.flagged):
+                                timestamps = {e.proposed_at for e, _ in merged.flagged if e.ns == ns}
+                                existing = {e.proposed_at for e, _ in merged.merged if e.ns == ns}
+                                to_flag = timestamps - existing
+                                if to_flag:
+                                    update_journal_status(pending_dir, ns, to_flag, "flagged")
+
+                            typer.echo(f"agent: resolve done — {merged.merge_count} merged, "
+                                       f"{merged.flagged_count} flagged, {merged.quarantine_count} quarantined")
                 last_pending_mtime = pending_mtime
 
             time.sleep(interval)

--- a/src/lorekeep/compile/resolve.py
+++ b/src/lorekeep/compile/resolve.py
@@ -187,5 +187,24 @@ def merge_journals(
             result.flagged.append((entry, "medium confidence, flagged for review"))
 
     result.nodes = list(nodes_by_id.values())
-    result.edges = existing_edges + new_edges
+
+    # Deduplicate + ID-regenerate edges (journal edges have empty id)
+    edge_by_key: dict[tuple[str, str, str], Edge] = {}
+    counter = 0
+    for e in existing_edges + new_edges:
+        key = (e.from_, e.to, e.type)
+        if key in edge_by_key:
+            # Merge props and src for duplicate edges
+            existing = edge_by_key[key]
+            merged_props = {**existing.props, **e.props}
+            merged_src = tuple(dict.fromkeys(existing.src + e.src))
+            edge_by_key[key] = existing.model_copy(
+                update={"props": merged_props, "src": merged_src}
+            )
+        else:
+            counter += 1
+            eid = e.id if e.id else f"e_{e.type}_{counter:04d}"
+            edge_by_key[key] = e if e.id else e.model_copy(update={"id": eid})
+
+    result.edges = list(edge_by_key.values())
     return result

--- a/src/lorekeep/compile/resolve.py
+++ b/src/lorekeep/compile/resolve.py
@@ -3,12 +3,15 @@
 Extraction may emit the same entity under several ids (aliases). This stage
 collapses them onto one canonical id, rewrites edge endpoints, drops edges whose
 endpoints disappeared, and quarantines malformed facts for review.
+
+Journal merge: loads pending journal entries, gates by confidence, merges into
+the existing graph with priority: raw/ > import > agent-propose.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from lorekeep.models import Edge, Node
+from lorekeep.models import Edge, JournalEntry, Node
 
 
 @dataclass
@@ -109,3 +112,80 @@ def resolve(
         aliases=alias_map,
         quarantined=quarantined,
     )
+
+
+@dataclass
+class JournalMergeResult:
+    nodes: list[Node] = field(default_factory=list)
+    edges: list[Edge] = field(default_factory=list)
+    merged: list[tuple[JournalEntry, str]] = field(default_factory=list)
+    flagged: list[tuple[JournalEntry, str]] = field(default_factory=list)
+    quarantined: list[tuple[JournalEntry, str]] = field(default_factory=list)
+
+    @property
+    def merge_count(self) -> int:
+        return len(self.merged)
+
+    @property
+    def flagged_count(self) -> int:
+        return len(self.flagged)
+
+    @property
+    def quarantine_count(self) -> int:
+        return len(self.quarantined)
+
+
+def merge_journals(
+    existing_nodes: list[Node],
+    existing_edges: list[Edge],
+    journal_entries: list[JournalEntry],
+) -> JournalMergeResult:
+    """Gate journal entries by confidence and add to the graph.
+
+    High (>=0.8): auto-merge. Medium (0.5 to <0.8): merge + flag for review.
+    Low (<0.5): quarantine, do not merge.
+    """
+    result = JournalMergeResult()
+    nodes_by_id: dict[str, Node] = {n.id: n for n in existing_nodes}
+    new_edges: list[Edge] = []
+
+    for entry in journal_entries:
+        if entry.status != "pending":
+            continue
+        confidence = entry.confidence
+        fact_data = entry.fact
+        try:
+            if fact_data["kind"] == "node":
+                fact = Node.model_validate(fact_data)
+            else:
+                fact = Edge.model_validate(fact_data)
+        except Exception:
+            result.quarantined.append((entry, "invalid fact schema"))
+            continue
+
+        if confidence < 0.5:
+            result.quarantined.append((entry, "low confidence"))
+            continue
+
+        if fact.kind == "node":
+            if fact.id in nodes_by_id:
+                base = nodes_by_id[fact.id]
+                merged_props = {**base.props, **fact.props}
+                merged_src = tuple(dict.fromkeys(base.src + fact.src))
+                merged_ns = tuple(dict.fromkeys(base.ns + fact.ns))
+                nodes_by_id[fact.id] = base.model_copy(
+                    update={"props": merged_props, "src": merged_src, "ns": merged_ns}
+                )
+            else:
+                nodes_by_id[fact.id] = fact
+        else:
+            new_edges.append(fact)
+
+        if confidence >= 0.8:
+            result.merged.append((entry, ""))
+        else:
+            result.flagged.append((entry, "medium confidence, flagged for review"))
+
+    result.nodes = list(nodes_by_id.values())
+    result.edges = existing_edges + new_edges
+    return result

--- a/src/lorekeep/journal.py
+++ b/src/lorekeep/journal.py
@@ -1,0 +1,85 @@
+"""Journal: append-only writer + loader for agent-proposed facts.
+
+Agent-proposed facts land in pending/<ns>/journal.jsonl (or pending/<agent>/)
+as append-only JSONL. Facts enter facts.jsonl after the resolve pass.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from lorekeep.models import JournalEntry
+
+
+def journal_path(pending_dir: Path, ns: str) -> Path:
+    ns_path = pending_dir / ns
+    ns_path.mkdir(parents=True, exist_ok=True)
+    return ns_path / "journal.jsonl"
+
+
+def append_journal(pending_dir: Path, entry: JournalEntry, ns: str) -> JournalEntry:
+    path = journal_path(pending_dir, ns)
+    line = json.dumps(entry.model_dump(mode="json"), sort_keys=True, ensure_ascii=False) + "\n"
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(line)
+        f.flush()
+        os.fsync(f.fileno())
+    return entry
+
+
+def load_journals(pending_dir: Path) -> list[JournalEntry]:
+    if not pending_dir.exists():
+        return []
+    entries: list[JournalEntry] = []
+    for journal_file in sorted(pending_dir.rglob("journal.jsonl")):
+        try:
+            text = journal_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                d = json.loads(line)
+                entries.append(JournalEntry.model_validate(d))
+            except Exception:
+                continue
+    return entries
+
+
+def update_journal_status(pending_dir: Path, ns: str,
+                          proposed_at_set: set[str],
+                          new_status: str) -> None:
+    path = journal_path(pending_dir, ns)
+    if not path.exists():
+        return
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    updated: list[str] = []
+    for line_text in lines:
+        line_text = line_text.strip()
+        if not line_text:
+            updated.append("")
+            continue
+        try:
+            d = json.loads(line_text)
+            if d.get("proposed_at") in proposed_at_set and d.get("status") == "pending":
+                d["status"] = new_status
+            updated.append(json.dumps(d, sort_keys=True, ensure_ascii=False))
+        except Exception:
+            updated.append(line_text)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write("\n".join(updated) + ("\n" if updated else ""))
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise

--- a/src/lorekeep/mcp_server.py
+++ b/src/lorekeep/mcp_server.py
@@ -1,32 +1,38 @@
-"""FastMCP server exposing the scoped temporal graph, read-only.
+"""FastMCP server exposing the scoped temporal graph with read + write tools.
 
 Tools are plain module functions using a module-global ScopedGraph set by
 configure(). @mcp.tool() registers them with FastMCP but they remain directly
 callable, so tests invoke them without the MCP transport.
+
+Write tools append to pending/<ns>/journal.jsonl; facts enter the graph on
+the next resolve pass.
 """
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
-from lorekeep.models import Schema
+from lorekeep.journal import append_journal
+from lorekeep.models import JournalEntry, Schema
 from lorekeep.perm.ns import ScopedGraph
 from lorekeep.schema_io import load_schema
 from lorekeep.store.graph import GraphStore, parse_date
 
 mcp = FastMCP("lorekeep")
 
-_state: dict = {}          # graph_dir, allowed_ns, schema_path, facts_mtime
+_state: dict = {}          # graph_dir, allowed_ns, schema_path, pending_dir, facts_mtime
 _scope: ScopedGraph | None = None
 _schema: Schema | None = None
 
 
-def configure(graph_dir, allowed_ns, schema_path=None, fts_path=None) -> None:
+def configure(graph_dir, allowed_ns, schema_path=None, fts_path=None, pending_dir=None) -> None:
     """Set the graph location + scope, then build. Safe to call again to refresh."""
     _state["graph_dir"] = Path(graph_dir)
     _state["allowed_ns"] = list(allowed_ns)
     _state["schema_path"] = Path(schema_path) if schema_path else None
+    _state["pending_dir"] = Path(pending_dir) if pending_dir else None
     _rebuild()
 
 
@@ -114,6 +120,178 @@ def changes(from_t: str, to_t: str) -> dict:
 def search(query: str, limit: int = 10) -> list:
     """Text search over node ids/props, scoped to the caller."""
     return _require().search(query, limit)
+
+
+# --- Write tools (journal-based) -----------------------------------------
+
+
+def _active_ns() -> tuple[str, ...]:
+    allowed = _state.get("allowed_ns", ["public"])
+    return tuple(ns for ns in allowed if ns != "public") or ("public",)
+
+
+def _primary_ns() -> str:
+    active = _active_ns()
+    return active[0] if active else "public"
+
+
+def _pending_dir() -> Path | None:
+    return _state.get("pending_dir")
+
+
+def _write_journal(fact_dict: dict, confidence: float, agent: str = "mcp") -> dict:
+    pending = _pending_dir()
+    if pending is None:
+        return {"error": "no pending directory configured"}
+    ns = _primary_ns()
+    fact_dict["ns"] = list(_active_ns())
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    entry = JournalEntry(
+        fact=fact_dict,
+        agent=agent,
+        ns=ns,
+        confidence=max(0.0, min(1.0, float(confidence))),
+        proposed_at=now,
+        status="pending",
+    )
+    append_journal(pending, entry, ns)
+    return {
+        "accepted": True,
+        "id": fact_dict.get("id", ""),
+        "status": "pending",
+        "ns": ns,
+        "proposed_at": now,
+    }
+
+
+@mcp.tool()
+def propose_fact(fact: dict, confidence: float) -> dict:
+    """Propose a new node or edge. ns is server-enforced, caller ns is stripped."""
+    if not _schema:
+        return {"error": "no schema loaded"}
+    fact_type = fact.get("type", "")
+    if fact["kind"] == "node":
+        if not _schema.is_valid_node_type(fact_type):
+            return {"error": f"unknown node type: {fact_type}"}
+    elif fact["kind"] == "edge":
+        if not _schema.is_valid_edge_type(fact_type):
+            return {"error": f"unknown edge type: {fact_type}"}
+    else:
+        return {"error": f"unknown fact kind: {fact.get('kind')}"}
+    fact.pop("ns", None)
+    if "src" not in fact:
+        fact["src"] = []
+    return _write_journal(fact, confidence)
+
+
+@mcp.tool()
+def link_facts(from_id: str, to_id: str, edge_type: str, confidence: float) -> dict:
+    """Create an edge between two existing nodes, server-enforced ns."""
+    scoped = _require()
+    if scoped.get_node(from_id) is None:
+        return {"error": f"from node not found or out of scope: {from_id}"}
+    if scoped.get_node(to_id) is None:
+        return {"error": f"to node not found or out of scope: {to_id}"}
+    if not _schema:
+        return {"error": "no schema loaded"}
+    if not _schema.is_valid_edge_type(edge_type):
+        return {"error": f"unknown edge type: {edge_type}"}
+    fact = {
+        "kind": "edge",
+        "id": "",
+        "type": edge_type,
+        "from": from_id,
+        "to": to_id,
+        "ns": [],
+        "props": {},
+        "src": [],
+    }
+    return _write_journal(fact, confidence)
+
+
+@mcp.tool()
+def flag_contradiction(fact_a_id: str, fact_b_id: str, description: str) -> dict:
+    """Report conflicting facts for curator review (always quarantined)."""
+    pending = _pending_dir()
+    if pending is None:
+        return {"error": "no pending directory configured"}
+    ns = _primary_ns()
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    flag_fact = {
+        "kind": "node",
+        "id": f"contradiction:{fact_a_id}:{fact_b_id}",
+        "type": "note",
+        "ns": list(_active_ns()),
+        "props": {
+            "title": f"contradiction: {fact_a_id} vs {fact_b_id}",
+            "topic": description,
+        },
+        "src": [],
+    }
+    entry = JournalEntry(
+        fact=flag_fact,
+        agent="mcp",
+        ns=ns,
+        confidence=0.0,
+        proposed_at=now,
+        status="pending",
+    )
+    append_journal(pending, entry, ns)
+    return {
+        "accepted": True,
+        "id": flag_fact["id"],
+        "status": "pending",
+        "note": "Flagged for curator review. Both facts will be quarantined on next resolve.",
+    }
+
+
+@mcp.tool()
+def update_fact(id: str, props: dict, confidence: float) -> dict:
+    """Propose updated props for an existing fact."""
+    scoped = _require()
+    existing = scoped.get_node(id)
+    if existing is None:
+        return {"error": f"node not found or out of scope: {id}"}
+    fact = existing.model_dump(mode="json", by_alias=True)
+    fact["props"] = props
+    fact.pop("ns", None)
+    return _write_journal(fact, confidence)
+
+
+@mcp.tool()
+def suggest_improvement(description: str) -> dict:
+    """Suggest a non-fact improvement (gap, missing entity) - review only."""
+    pending = _pending_dir()
+    if pending is None:
+        return {"error": "no pending directory configured"}
+    ns = _primary_ns()
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    suggestion_fact = {
+        "kind": "node",
+        "id": f"suggestion:{_primary_ns()}:{now[:19]}",
+        "type": "note",
+        "ns": list(_active_ns()),
+        "props": {
+            "title": "improvement suggestion",
+            "topic": description,
+        },
+        "src": [],
+    }
+    entry = JournalEntry(
+        fact=suggestion_fact,
+        agent="mcp",
+        ns=ns,
+        confidence=0.0,
+        proposed_at=now,
+        status="pending",
+    )
+    append_journal(pending, entry, ns)
+    return {
+        "accepted": True,
+        "id": suggestion_fact["id"],
+        "status": "pending",
+        "note": "Suggestion recorded for curator review.",
+    }
 
 
 if __name__ == "__main__":

--- a/src/lorekeep/mcp_server.py
+++ b/src/lorekeep/mcp_server.py
@@ -247,15 +247,22 @@ def flag_contradiction(fact_a_id: str, fact_b_id: str, description: str) -> dict
 
 @mcp.tool()
 def update_fact(id: str, props: dict, confidence: float) -> dict:
-    """Propose updated props for an existing fact."""
+    """Propose updated props for an existing node or edge."""
     scoped = _require()
-    existing = scoped.get_node(id)
-    if existing is None:
-        return {"error": f"node not found or out of scope: {id}"}
-    fact = existing.model_dump(mode="json", by_alias=True)
-    fact["props"] = props
-    fact.pop("ns", None)
-    return _write_journal(fact, confidence)
+    store = scoped._g
+    node = store.get_node(id)
+    if node is not None:
+        fact = node.model_dump(mode="json", by_alias=True)
+        fact["props"] = props
+        fact.pop("ns", None)
+        return _write_journal(fact, confidence)
+    for e in store.all_edges():
+        if e.id == id:
+            edge_dict = e.model_dump(mode="json", by_alias=True)
+            edge_dict["props"] = props
+            edge_dict.pop("ns", None)
+            return _write_journal(edge_dict, confidence)
+    return {"error": f"fact not found or out of scope: {id}"}
 
 
 @mcp.tool()

--- a/src/lorekeep/models.py
+++ b/src/lorekeep/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import date
+from datetime import date, datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -110,6 +110,22 @@ class QuarantineItem(BaseModel):
     reason: str
 
 
+class JournalEntry(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+    fact: dict[str, Any]
+    agent: str
+    ns: str
+    confidence: float
+    proposed_at: str
+    status: str = "pending"
+
+
+class ReviewItem(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    fact_id: str
+    reason: str
+
+
 class Manifest(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: int
@@ -121,6 +137,10 @@ class Manifest(BaseModel):
     chunk_hashes: dict[str, list[str]] = Field(default_factory=dict)
     errors: list[CompileError] = Field(default_factory=list)
     quarantine: list[QuarantineItem] = Field(default_factory=list)
+    review: list[ReviewItem] = Field(default_factory=list)
+    merged_count: int = 0
+    quarantined_count: int = 0
+    flagged_count: int = 0
 
     def to_json(self) -> str:
         return json.dumps(self.model_dump(mode="json"), sort_keys=True, indent=2)

--- a/src/lorekeep/paths.py
+++ b/src/lorekeep/paths.py
@@ -49,10 +49,18 @@ def resolve_paths() -> dict[str, Path]:
         v = os.environ.get(env_name)
         return Path(v).expanduser() if v else current
 
+    if home:
+        pending = base / "pending"
+    elif dev:
+        pending = cwd / "pending"
+    else:
+        pending = data_dir / "pending"
+
     return {
         "raw": override("LOREKEEP_RAW", raw),
         "out": override("LOREKEEP_OUT", out),
         "cache": override("LOREKEEP_CACHE", cache),
         "schema": override("LOREKEEP_SCHEMA", schema),
         "config": override("LOREKEEP_CONFIG", config),
+        "pending": override("LOREKEEP_PENDING", pending),
     }


### PR DESCRIPTION
## Summary

Implements all phase 2 features documented in PR #17. This adds the code behind the architecture docs — agent-driven knowledge accumulation at zero LLM cost.

## New modules

- **`src/lorekeep/journal.py`** (85 lines) — append-only journal writer/loader with atomic status updates
- **`src/lorekeep/agent.py`** (154 lines) — structural lint, suggestion engine, status dashboard

## MCP write tools (5 new tools)

| Tool | Purpose |
|---|---|
| `propose_fact` | Propose node/edge; ns server-enforced, caller ns stripped |
| `link_facts` | Create edge between existing nodes |
| `flag_contradiction` | Report conflicting facts for curator review |
| `update_fact` | Propose updated props for existing fact |
| `suggest_improvement` | Record non-fact improvement suggestions |

Security: ns derived from `LOREKEEP_NS`, caller-provided ns stripped, confidence clamped to [0,1], schema validation before journal append.

## New CLI commands

| Command | Purpose |
|---|---|
| `lorekeep resolve` | Merge pending journals with confidence gating |
| `lorekeep agent lint` | Structural health check (orphans, stale, contradictions, coverage) |
| `lorekeep agent suggest` | Improvement suggestions |
| `lorekeep agent status` | Graph health dashboard |
| `lorekeep agent watch` | Daemon: poll raw/ and pending/ for changes |

## Confidence gating (resolve)

- ≥ 0.8 → auto-merge
- 0.5 to <0.8 → merge + flag for review
- < 0.5 → quarantine

Manifest extended with `review`, `merged_count`, `quarantined_count`, `flagged_count`.

## Relates

- #9 — continuous ingest (watch daemon + resolve)
- #15 — autonomous agent operations (lint, suggest, status, watch)