### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,14 @@ Pure (no I/O), 4-tier precedence high→low: explicit `LOREKEEP_RAW/OUT/CACHE/SC
 ## Tests
 
 `~140` tests, no network. Gold corpus in `tests/fixtures/gold/`, raw fixtures in `tests/fixtures/raw/`. Compile/serve/import tests set `LOREKEEP_*` env vars and `LOREKEEP_PROVIDER=fake` to pin paths and avoid the LLM — follow this pattern for any new CLI test rather than hitting a real provider.
+
+## Cursor Cloud specific instructions
+
+The startup update script already runs `uv sync`; the toolchain (Python 3.11+ via `uv`) is ready. Standard commands live in the `## Commands` table above — use those.
+
+Non-obvious caveats for running/testing here:
+
+- **No API key needed for any dev work.** Export `LOREKEEP_PROVIDER=fake` to run `compile`/`import` and the full end-to-end flow offline with `FakeProvider` (canned facts). To avoid polluting the repo's `raw/`+`graph/`, run demos against a throwaway data home: `LOREKEEP_HOME=/tmp/lk uv run lorekeep <cmd>`.
+- **End-to-end smoke flow** (offline): `init` → drop a markdown file under `raw/<ns>/` → `compile` → `check`/`doctor`. Then query the graph by calling the `mcp_server.py` tools directly after `ms.configure(graph_dir=..., allowed_ns=[...], schema_path=...)` — the read tools (`search`, `get_node`, `neighbors`, `at_time`, `history`, `list_namespaces`) are plain functions, no MCP transport required. `search` returns a list of node-id strings; `get_node` returns a dict; `neighbors`/`at_time`/`changes` return `{"nodes": [...], "edges": [...]}`.
+- **`lorekeep serve` blocks on stdio** waiting for an MCP client — it won't return on its own. To just confirm it boots, run it under `timeout` with stdin closed (`timeout 3 uv run lorekeep serve --transport stdio </dev/null`); a clean timeout with no error output means success.
+- **`tests/test_mcp_reload.py::test_lazy_reload_on_facts_change` is timing-flaky** — lazy-reload triggers off `facts.jsonl` mtime, and the test can rewrite the file within one mtime tick on fast filesystems, so it intermittently fails then passes on re-run. Treat an isolated failure of just this test as a flake, not a regression.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the development environment for Lorekeep on Cursor Cloud and documents durable, non-obvious run/test caveats for future agents.

## Environment setup

- Installs `uv` (was missing on the base image) and runs `uv sync` to provision the Python 3.11+ toolchain and dev deps.
- Startup update script (minimal, idempotent):
  ```
  command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
  PATH="$HOME/.local/bin:$PATH" uv sync
  ```

## Verification (offline, `LOREKEEP_PROVIDER=fake`)

| Check | Command | Result |
|---|---|---|
| Tests | `uv run pytest -q` | 152 passed, 1 flaky (see below) |
| Lint | `uv run pre-commit run --all-files` | pass |
| Build | `uv build` | sdist + wheel built |
| Run | `lorekeep init/compile/check/doctor/serve/eval` + MCP read tools | full graph compile + temporal/permission queries verified |

End-to-end: compiled a markdown doc into the temporal knowledge graph, then queried it via the MCP read tools — confirmed temporal validity (a `depends_on` edge active at `2024-06-01`, expired by `2025-06-01`) and the deny-by-default permission boundary (a `frontend`-scoped agent cannot see `backend` facts).

`tests/test_mcp_reload.py::test_lazy_reload_on_facts_change` is timing-flaky (lazy-reload mtime granularity) and passes on re-run — documented in AGENTS.md, not a regression.

## Changes

- `AGENTS.md`: added `## Cursor Cloud specific instructions` (offline fake-provider flow, direct MCP tool-call return shapes, `serve` stdio-blocking note, and the flaky-test caveat). `CLAUDE.md` is a symlink to this file.

No application code changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-563879a4-002c-4cd2-a808-2d872953645f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-563879a4-002c-4cd2-a808-2d872953645f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

