### PR TITLE
feat: add agent watch sessions for continuous live ingest

### DIFF
--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -740,8 +740,17 @@ def watch(
         60, "--interval",
         help="Polling interval in seconds",
     ),
+    watch_sessions: bool = typer.Option(
+        True, "--watch-sessions/--no-watch-sessions",
+        help="Watch agent session dirs for live continuous ingest",
+    ),
 ) -> None:
-    """Run the autonomous agent daemon: watch raw/ and pending/ for changes."""
+    """Run the autonomous agent daemon: watch raw/, pending/, and agent sessions.
+
+    Watches raw/ for new/changed markdown sources → auto-compile.
+    Watches pending/ for new journal entries → auto-resolve.
+    Watches agent session dirs (Claude memory/) → delta quick import → raw/.
+    """
     import time
     p = resolve_paths()
     raw_dir = p["raw"]
@@ -749,17 +758,35 @@ def watch(
 
     typer.echo(f"agent watch: monitoring raw={raw_dir}, pending={pending_dir}, interval={interval}s")
     typer.echo("agent: auto-compile (raw/) and auto-resolve (pending/) enabled")
+
+    # Attempt session discovery once at startup
+    session_dir = None
+    session_memory_dir = None
+    if watch_sessions:
+        try:
+            from lorekeep.importer.claude import find_current_session
+            sd = find_current_session()
+            if sd is not None and (sd / "memory").is_dir():
+                session_dir = sd
+                session_memory_dir = sd / "memory"
+                typer.echo(f"agent: watching session memory={session_memory_dir}")
+        except Exception:
+            pass
+
     typer.echo("agent: MCP server lazy-reloads facts.jsonl — no reconnect needed")
     last_raw_mtime = 0.0
     last_pending_mtime = 0.0
+    last_session_mtime = 0.0
+    last_session_import = 0.0          # debounce timer (seconds since epoch)
     has_raw = raw_dir.exists()
     has_pending = pending_dir and pending_dir.exists()
 
     while True:
         try:
-            # Check raw/ for changes → auto-compile
+            # --- raw/ watch → auto-compile ----------------------------------
             raw_files = sorted(raw_dir.rglob("*.md")) if has_raw else []
             raw_mtime = max((f.stat().st_mtime for f in raw_files), default=0.0)
+            compiled = False
             if raw_mtime > last_raw_mtime and last_raw_mtime > 0:
                 typer.echo(f"agent: raw/ changed ({len(raw_files)} files) — compiling...")
                 try:
@@ -772,67 +799,45 @@ def watch(
                     cache = p.get("cache", p["out"].parent / ".lorekeep" / "cache.json")
                     compile_graph(raw_dir, p["out"], schema, provider, Path(cache))
                     typer.echo("agent: compile done")
+                    compiled = True
                 except Exception as exc:
                     typer.echo(f"agent: compile error: {exc}")
             last_raw_mtime = raw_mtime
 
-            # Check pending/ for new journals → auto-resolve
+            # --- After compile, re-merge pending journals -------------------
+            # compile is a destructive overwrite that regenerates facts.jsonl
+            # from raw/ only.  Re-merge pending journal entries so facts
+            # approved via agent ingest / MCP write tools are not lost.
+            if compiled and has_pending:
+                _do_auto_resolve(p["out"], pending_dir)
+
+            # --- pending/ watch → auto-resolve ------------------------------
             if has_pending:
                 journal_files = sorted(pending_dir.rglob("journal.jsonl"))
                 pending_mtime = max((f.stat().st_mtime for f in journal_files), default=0.0)
                 if pending_mtime > last_pending_mtime and last_pending_mtime > 0:
                     typer.echo("agent: pending/ changed — resolving...")
-                    try:
-                        from lorekeep.store.graph import GraphStore
-                        from lorekeep.facts_io import read_facts
-                        from lorekeep.compile.resolve import resolve as resolve_facts, merge_journals
-                        from lorekeep.compile.writer import write_graph
-                        from lorekeep.journal import load_journals, update_journal_status
-                        from lorekeep.models import Edge, Manifest, Node
-
-                        facts_path = p["out"] / "facts.jsonl"
-                        existing_nodes = []
-                        existing_edges = []
-                        if facts_path.exists():
-                            for f in read_facts(facts_path):
-                                if isinstance(f, Node):
-                                    existing_nodes.append(f)
-                                else:
-                                    existing_edges.append(f)
-
-                        journals = load_journals(pending_dir)
-                        pending_entries = [j for j in journals if j.status == "pending"]
-                        if pending_entries:
-                            merged = merge_journals(existing_nodes, existing_edges, pending_entries)
-                            resolved = resolve_facts(merged.nodes, merged.edges)
-                            manifest = Manifest(
-                                schema_version=0, chunk_count=0,
-                                node_count=len(resolved.nodes),
-                                edge_count=len(resolved.edges),
-                                run_id="auto-resolve", facts_hash="",
-                                merged_count=merged.merge_count,
-                                quarantined_count=merged.quarantine_count,
-                                flagged_count=merged.flagged_count,
-                            )
-                            write_graph(p["out"], resolved.nodes, resolved.edges, manifest)
-
-                            # Update journal status
-                            for ns in set(entry.ns for entry, _ in merged.merged):
-                                timestamps = {e.proposed_at for e, _ in merged.merged if e.ns == ns}
-                                if timestamps:
-                                    update_journal_status(pending_dir, ns, timestamps, "merged")
-                            for ns in set(entry.ns for entry, _ in merged.flagged):
-                                timestamps = {e.proposed_at for e, _ in merged.flagged if e.ns == ns}
-                                existing = {e.proposed_at for e, _ in merged.merged if e.ns == ns}
-                                to_flag = timestamps - existing
-                                if to_flag:
-                                    update_journal_status(pending_dir, ns, to_flag, "flagged")
-
-                            typer.echo(f"agent: resolve done — {merged.merge_count} merged, "
-                                       f"{merged.flagged_count} flagged, {merged.quarantine_count} quarantined")
-                    except Exception as exc:
-                        typer.echo(f"agent: resolve error: {exc}")
+                    _do_auto_resolve(p["out"], pending_dir)
                 last_pending_mtime = pending_mtime
+
+            # --- session watch → delta quick import → raw/ ------------------
+            if session_memory_dir and session_memory_dir.is_dir():
+                mem_files = sorted(session_memory_dir.glob("*.md"))
+                session_mtime = max((f.stat().st_mtime for f in mem_files), default=0.0)
+                now = time.monotonic()
+                # Debounce: max once per 30 seconds
+                if (session_mtime > last_session_mtime and last_session_mtime > 0
+                        and now - last_session_import >= 30):
+                    typer.echo(f"agent: session memory changed ({len(mem_files)} files) — importing...")
+                    try:
+                        from lorekeep.importer.claude import import_memories
+                        written = import_memories(session_dir, raw_dir, "claude-memory")
+                        if written:
+                            typer.echo(f"agent: session import done — {len(written)} files -> raw/claude-memory/")
+                            last_session_import = now
+                    except Exception as exc:
+                        typer.echo(f"agent: session import error: {exc}")
+                last_session_mtime = session_mtime
 
             time.sleep(interval)
         except KeyboardInterrupt:
@@ -841,6 +846,62 @@ def watch(
         except Exception as exc:
             typer.echo(f"agent: error: {exc}")
             time.sleep(interval)
+
+
+def _do_auto_resolve(out_dir: Path, pending_dir: Path) -> None:
+    """Merge pending journal entries into facts.jsonl.
+
+    Extracted as a helper so both the pending/ watch loop and the
+    post-compile re-merge path share the same logic.
+    """
+    try:
+        from lorekeep.facts_io import read_facts
+        from lorekeep.compile.resolve import resolve as resolve_facts, merge_journals
+        from lorekeep.compile.writer import write_graph
+        from lorekeep.journal import load_journals, update_journal_status
+        from lorekeep.models import Edge, Manifest, Node
+
+        facts_path = out_dir / "facts.jsonl"
+        existing_nodes = []
+        existing_edges = []
+        if facts_path.exists():
+            for f in read_facts(facts_path):
+                if isinstance(f, Node):
+                    existing_nodes.append(f)
+                else:
+                    existing_edges.append(f)
+
+        journals = load_journals(pending_dir)
+        pending_entries = [j for j in journals if j.status == "pending"]
+        if pending_entries:
+            merged = merge_journals(existing_nodes, existing_edges, pending_entries)
+            resolved = resolve_facts(merged.nodes, merged.edges)
+            manifest = Manifest(
+                schema_version=0, chunk_count=0,
+                node_count=len(resolved.nodes),
+                edge_count=len(resolved.edges),
+                run_id="auto-resolve", facts_hash="",
+                merged_count=merged.merge_count,
+                quarantined_count=merged.quarantine_count,
+                flagged_count=merged.flagged_count,
+            )
+            write_graph(out_dir, resolved.nodes, resolved.edges, manifest)
+
+            for ns in set(entry.ns for entry, _ in merged.merged):
+                timestamps = {e.proposed_at for e, _ in merged.merged if e.ns == ns}
+                if timestamps:
+                    update_journal_status(pending_dir, ns, timestamps, "merged")
+            for ns in set(entry.ns for entry, _ in merged.flagged):
+                timestamps = {e.proposed_at for e, _ in merged.flagged if e.ns == ns}
+                existing = {e.proposed_at for e, _ in merged.merged if e.ns == ns}
+                to_flag = timestamps - existing
+                if to_flag:
+                    update_journal_status(pending_dir, ns, to_flag, "flagged")
+
+            typer.echo(f"agent: resolve done — {merged.merge_count} merged, "
+                       f"{merged.flagged_count} flagged, {merged.quarantine_count} quarantined")
+    except Exception as exc:
+        typer.echo(f"agent: resolve error: {exc}")
 
 
 if __name__ == "__main__":

--- a/tests/test_watch_sessions.py
+++ b/tests/test_watch_sessions.py
@@ -1,0 +1,205 @@
+"""Tests for agent watch session import and auto-resolve chain."""
+import json
+import time
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from lorekeep.cli import app, _do_auto_resolve
+
+runner = CliRunner()
+
+
+# ── _do_auto_resolve ──────────────────────────────────────────────────────
+
+def test_auto_resolve_merges_pending_journals(tmp_path: Path, fixtures: Path):
+    """_do_auto_resolve reads pending journals and merges into facts.jsonl."""
+    out_dir = tmp_path / "graph"
+    out_dir.mkdir()
+    pending_dir = tmp_path / "pending"
+    pending_dir.mkdir()
+
+    # Pre-populate facts.jsonl with gold data
+    gold = fixtures / "gold" / "payments.facts.jsonl"
+    import shutil
+    shutil.copy(gold, out_dir / "facts.jsonl")
+
+    # Add a pending journal entry
+    ns_dir = pending_dir / "backend"
+    ns_dir.mkdir()
+    now = "2026-06-22T00:00:00Z"
+    entry = {
+        "agent": "test",
+        "ns": "backend",
+        "confidence": 1.0,
+        "proposed_at": now,
+        "status": "pending",
+        "fact": {
+            "kind": "node",
+            "id": "svc:test-service",
+            "type": "service",
+            "ns": ["backend"],
+            "props": {"name": "test"},
+            "src": ["test.md"],
+        },
+    }
+    (ns_dir / "journal.jsonl").write_text(json.dumps(entry, sort_keys=True) + "\n")
+
+    # Run auto-resolve
+    _do_auto_resolve(out_dir, pending_dir)
+
+    # Facts should now include the new node
+    lines = (out_dir / "facts.jsonl").read_text().strip().splitlines()
+    nodes_in_graph = []
+    for line in lines:
+        f = json.loads(line)
+        if f["kind"] == "node":
+            nodes_in_graph.append(f["id"])
+    assert "svc:payments-api" in nodes_in_graph  # original preserved
+    assert "svc:test-service" in nodes_in_graph  # merged from journal
+
+    # Journal status updated
+    jlines = (ns_dir / "journal.jsonl").read_text().strip().splitlines()
+    je = json.loads(jlines[0])
+    assert je["status"] == "merged"
+
+
+def test_auto_resolve_handles_empty_pending(tmp_path: Path, fixtures: Path):
+    """_do_auto_resolve is a no-op when no pending entries exist."""
+    out_dir = tmp_path / "graph"
+    out_dir.mkdir()
+    pending_dir = tmp_path / "pending"
+    pending_dir.mkdir()
+
+    # No journal files
+    _do_auto_resolve(out_dir, pending_dir)
+
+    # No crash, no facts.jsonl created (since nothing to write)
+    assert not (out_dir / "facts.jsonl").exists()
+
+
+def test_auto_resolve_preserves_graph_on_no_pending_entries(tmp_path: Path, fixtures: Path):
+    """_do_auto_resolve keeps facts.jsonl unchanged when no pending entries."""
+    import shutil
+    out_dir = tmp_path / "graph"
+    out_dir.mkdir()
+    pending_dir = tmp_path / "pending"
+    pending_dir.mkdir()
+
+    gold = fixtures / "gold" / "payments.facts.jsonl"
+    shutil.copy(gold, out_dir / "facts.jsonl")
+    original = (out_dir / "facts.jsonl").read_text()
+
+    # Pending dir has ns dir but journal has only already-merged entries
+    ns_dir = pending_dir / "backend"
+    ns_dir.mkdir()
+    merged_entry = {
+        "agent": "test",
+        "ns": "backend",
+        "confidence": 1.0,
+        "proposed_at": "2026-06-22T00:00:00Z",
+        "status": "merged",
+        "fact": {"kind": "node", "id": "svc:dummy", "type": "service", "ns": [], "props": {}, "src": []},
+    }
+    (ns_dir / "journal.jsonl").write_text(json.dumps(merged_entry, sort_keys=True) + "\n")
+
+    _do_auto_resolve(out_dir, pending_dir)
+
+    # Facts unchanged (no pending entries → skip write)
+    assert (out_dir / "facts.jsonl").read_text() == original
+
+
+# ── agent watch CLI ───────────────────────────────────────────────────────
+
+
+def test_watch_help_shows_session_flag():
+    """agent watch --help mentions --watch-sessions."""
+    result = runner.invoke(app, ["agent", "watch", "--help"])
+    assert result.exit_code == 0
+    assert "--watch-sessions" in result.stdout
+
+
+def test_watch_boots_and_shuts_down_cleanly(monkeypatch, tmp_path: Path):
+    """agent watch starts without error and exits cleanly on timeout."""
+    # Use a minimal env with no raw/ or pending/ so nothing happens
+    monkeypatch.setenv("LOREKEEP_RAW", str(tmp_path / "raw"))
+    monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "graph"))
+    monkeypatch.setenv("LOREKEEP_CACHE", str(tmp_path / "cache.json"))
+    monkeypatch.setenv("LOREKEEP_PENDING", str(tmp_path / "pending"))
+    monkeypatch.setenv("LOREKEEP_PROVIDER", "fake")
+    monkeypatch.setenv("LOREKEEP_DEV", "1")
+
+    (tmp_path / "raw").mkdir()
+    (tmp_path / "graph").mkdir()
+    (tmp_path / "pending").mkdir()
+
+    # Run with a tight interval, should exit on KeyboardInterrupt via timeout
+    import subprocess
+    import os
+    result = subprocess.run(
+        ["timeout", "2", "python3", "-m", "lorekeep.cli", "agent", "watch",
+         "--interval", "1", "--no-watch-sessions"],
+        capture_output=True, text=True,
+        cwd=str(tmp_path.parent),
+        env={**os.environ,
+             "LOREKEEP_RAW": str(tmp_path / "raw"),
+             "LOREKEEP_OUT": str(tmp_path / "graph"),
+             "LOREKEEP_CACHE": str(tmp_path / "cache.json"),
+             "LOREKEEP_PENDING": str(tmp_path / "pending"),
+             "LOREKEEP_PROVIDER": "fake",
+             "LOREKEEP_DEV": "1",
+             "PYTHONPATH": str(Path(__file__).parent.parent / "src"),
+             },
+        timeout=5,
+    )
+    # Exit 124 = timeout (normal shutdown)
+    assert result.returncode in (0, 124), f"stderr: {result.stderr}"
+
+
+# ── Session delta import (import_memories) ────────────────────────────────
+
+
+def test_import_memories_delta_imports_only_new_files(tmp_path: Path, fixtures: Path):
+    """import_memories copies only new/changed files (idempotent delta)."""
+    from lorekeep.importer.claude import import_memories
+
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    mem_dir = session_dir / "memory"
+    mem_dir.mkdir()
+
+    raw_root = tmp_path / "raw"
+    exported_files = import_memories(session_dir, raw_root, "test-ns")
+
+    # Nothing to import
+    assert exported_files == []
+
+    # Write a new memory file
+    (mem_dir / "new.md").write_text("# New\ncontent\n")
+    exported_files = import_memories(session_dir, raw_root, "test-ns")
+    assert len(exported_files) == 1
+    assert (raw_root / "test-ns" / "new.md").exists()
+
+    # Run again — should be idempotent (no new copies)
+    exported_files = import_memories(session_dir, raw_root, "test-ns")
+    assert exported_files == []
+
+    # Modify the file — should detect change and re-import
+    time.sleep(0.1)
+    (mem_dir / "new.md").write_text("# Modified\ncontent v2\n")
+    exported_files = import_memories(session_dir, raw_root, "test-ns")
+    assert len(exported_files) == 1
+    assert "content v2" in (raw_root / "test-ns" / "new.md").read_text()
+
+
+def test_import_memories_handles_missing_memory_dir(tmp_path: Path):
+    """import_memories returns empty when session/memory/ doesn't exist."""
+    from lorekeep.importer.claude import import_memories
+
+    session_dir = tmp_path / "no-memory"
+    session_dir.mkdir()
+    raw_root = tmp_path / "raw"
+
+    exported_files = import_memories(session_dir, raw_root, "ns")
+    assert exported_files == []


### PR DESCRIPTION
## What

Add session watching to `lorekeep agent watch` for continuous live ingest (closes #9).

### Changes

1. **Session watcher** in agent watch daemon:
   - Detects Claude session dir at startup via `find_current_session()`
   - Watches `memory/*.md` mtime for changes
   - Delta quick import (content-hash idempotent via `import_memories`) into `raw/claude-memory/`
   - 30s debounce to avoid rapid LLM-extract calls

2. **Post-compile auto-resolve** fix:
   - Extracted `_do_auto_resolve()` helper shared by both watch loops
   - After auto-compile (destructive overwrite), immediately re-merges pending journal entries
   - Prevents journal-merged facts from being lost on recompile

3. **Flag**: `--watch-sessions / --no-watch-sessions` (default: on)

### Flow

```
agent watch:
  raw/ changed      → auto-compile  → auto-resolve (re-merge journals)
  pending/ changed   → auto-resolve
  session changed    → delta quick import → raw/ (caught by raw/ watch next tick)
```

### Tests: 7 new tests, 166 total pass