### PR TITLE
feat(init): onboard a me namespace with a user profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ uv run lorekeep <command>                    # run the CLI in dev mode
 
 | Command | Purpose |
 |---|---|
-| `init` | Bootstrap data home (config + schema + raw/graph dirs) |
+| `init [--no-onboard] [--force]` | Bootstrap data home + onboard a `me` namespace (interactive profile on a tty) |
 | `compile` | `raw/*.md` → `graph/facts.jsonl` + `manifest.json` (runs the LLM pipeline) |
 | `check` | Validate compiled graph loads, no dangling edges (exit 1 on failure) |
 | `eval` | Tier-1 construction P/R/F1 vs gold corpus + structure metrics |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -49,6 +49,15 @@ Verify the install:
 uvx lorekeep doctor       # graph loads, schema valid, a tool responds
 ```
 
+> **First run:** when `init` creates a fresh config, it onboards a `me`
+> namespace — on a terminal it prompts for your name, role, what you work on,
+> and timezone, then writes `raw/me/profile.md` and scopes `ns.default` to
+> `[me, public]`. Non-interactive shells (CI) get a template profile to fill in
+> later; `--no-onboard` skips onboarding entirely (no profile written); `--force`
+> overwrites an existing `raw/me/profile.md` on a fresh config. Onboarding only
+> runs on a just-created config, so re-running `init` on an existing data home
+> leaves `ns.default` and the profile untouched.
+
 ## 3. Add your raw docs
 
 Drop markdown under `<data-home>/raw/<namespace>/`. A namespace is the

--- a/docs/superpowers/plans/2026-06-26-onboard-me-namespace.md
+++ b/docs/superpowers/plans/2026-06-26-onboard-me-namespace.md
@@ -1,0 +1,416 @@
+# me-Namespace Onboarding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `lorekeep init` create a personal `me` namespace with a profile (interactive prompts on a tty, template otherwise) and set `ns.default=[me, public]`.
+
+**Architecture:** New `src/lorekeep/onboard.py` holds pure helpers (`profile_markdown`, `write_profile`, `update_ns_default`) + an orchestrator (`run_onboarding`) that takes an injected `prompt` callable so interactive logic is testable without a tty. `cli.py init` gains `--no-onboard` / `--force` flags and calls the orchestrator with `interactive = sys.stdin.isatty() and not no_onboard`.
+
+**Tech Stack:** Python 3.11+, Typer, Pydantic (Config), PyYAML, pytest.
+
+## Global Constraints
+
+- Determinism is a hard requirement (n/a — no compile/extract changes).
+- Conventional Commits enforced (`feat|fix|refactor|docs|...`); merge commits exempt.
+- API keys never in committed files (n/a — onboarding writes only `raw/me/profile.md` + `config.yaml`'s `ns.default`).
+- Tests run offline, no real LLM (n/a — onboarding writes raw source, does not compile).
+- Git workflow is PR-only — work on branch `feat/onboard-me-namespace` (already created, stacked on `feat/dotdir-backup`).
+- `ns.default` update uses `yaml.safe_dump`, which drops comments from a hand-edited `config.yaml` — accepted per spec.
+
+---
+
+### Task 1: `lorekeep.onboard` module (TDD)
+
+**Files:**
+- Create: `src/lorekeep/onboard.py`
+- Test: `tests/test_onboard.py`
+
+**Interfaces:**
+- Produces:
+  - `PROFILE_NS = "me"`
+  - `profile_markdown(name: str, role: str, what: str, tz: str) -> str`
+  - `write_profile(raw_root: Path, md: str) -> Path` — writes `raw_root/"me"/"profile.md"`, parents created.
+  - `update_ns_default(config_path: Path, ns_list: list[str]) -> None` — loads Config, sets `ns.default`, rewrites via `yaml.safe_dump`.
+  - `run_onboarding(home: Path, config_path: Path, *, interactive: bool, prompt=None, force: bool = False) -> bool` — orchestrator; returns True if profile written, False if skipped.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_onboard.py`:
+
+```python
+from pathlib import Path
+
+import yaml
+
+from lorekeep.onboard import (
+    PROFILE_NS,
+    profile_markdown,
+    write_profile,
+    update_ns_default,
+    run_onboarding,
+)
+
+
+def test_profile_markdown_exact():
+    md = profile_markdown("Alice", "Eng", "Backend", "UTC")
+    assert md == (
+        "# Alice\n\n"
+        "- **Role**: Eng\n"
+        "- **What I do**: Backend\n"
+        "- **Timezone**: UTC\n"
+        "\n"
+        "Personal namespace — facts about me live here (`raw/me/`).\n"
+    )
+
+
+def test_write_profile_creates_file(tmp_path: Path):
+    raw = tmp_path / "raw"
+    p = write_profile(raw, "# Alice\n")
+    assert p == raw / PROFILE_NS / "profile.md"
+    assert p.read_text(encoding="utf-8") == "# Alice\n"
+
+
+def test_update_ns_default_preserves_rest(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "provider:\n"
+        "  model: openai/gpt-4o-mini\n"
+        "  backend: openai\n"
+        "ns:\n"
+        "  default: [public]\n"
+        "install_source: pypi\n",
+        encoding="utf-8",
+    )
+    update_ns_default(cfg, [PROFILE_NS, "public"])
+    data = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert data["ns"]["default"] == ["me", "public"]
+    assert data["provider"]["model"] == "openai/gpt-4o-mini"
+    assert data["install_source"] == "pypi"
+
+
+def test_run_onboarding_interactive_writes_profile_and_ns(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    cfg = home / "config.yaml"
+    cfg.write_text("ns:\n  default: [public]\n", encoding="utf-8")
+    answers = iter(["Alice", "Eng", "Backend", "UTC"])
+    ran = run_onboarding(home, cfg, interactive=True, prompt=lambda _: next(answers))
+    assert ran is True
+    assert (home / "raw" / "me" / "profile.md").exists()
+    assert yaml.safe_load(cfg.read_text(encoding="utf-8"))["ns"]["default"] == ["me", "public"]
+
+
+def test_run_onboarding_non_interactive_template(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    cfg = home / "config.yaml"
+    cfg.write_text("ns:\n  default: [public]\n", encoding="utf-8")
+    ran = run_onboarding(home, cfg, interactive=False)
+    assert ran is True
+    md = (home / "raw" / "me" / "profile.md").read_text(encoding="utf-8")
+    assert "**Role**: \n" in md  # empty value preserved
+
+
+def test_run_onboarding_idempotent_skip(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "raw" / "me").mkdir(parents=True)
+    (home / "raw" / "me" / "profile.md").write_text("existing", encoding="utf-8")
+    cfg = home / "config.yaml"
+    cfg.write_text("ns:\n  default: [public]\n", encoding="utf-8")
+    # prompt must NOT be called when skipping
+    ran = run_onboarding(home, cfg, interactive=True, prompt=lambda _: (_ for _ in ()).throw(AssertionError("prompt called")))
+    assert ran is False
+    assert (home / "raw" / "me" / "profile.md").read_text(encoding="utf-8") == "existing"
+
+
+def test_run_onboarding_force_overwrites(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "raw" / "me").mkdir(parents=True)
+    (home / "raw" / "me" / "profile.md").write_text("old", encoding="utf-8")
+    cfg = home / "config.yaml"
+    cfg.write_text("ns:\n  default: [public]\n", encoding="utf-8")
+    answers = iter(["Alice", "Eng", "Backend", "UTC"])
+    ran = run_onboarding(
+        home, cfg, interactive=True, prompt=lambda _: next(answers), force=True
+    )
+    assert ran is True
+    assert "Alice" in (home / "raw" / "me" / "profile.md").read_text(encoding="utf-8")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_onboard.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'lorekeep.onboard'`.
+
+- [ ] **Step 3: Implement `src/lorekeep/onboard.py`**
+
+```python
+"""First-run onboarding: create a personal `me` namespace + profile.
+
+Called from `cli.init`. Interactive prompts run only on a tty; non-tty / CI
+gets a template profile with empty values. `ns.default` is updated to
+`[me, public]` so an agent scoped to the default sees the user's profile.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import yaml
+
+PROFILE_NS = "me"
+
+
+def profile_markdown(name: str, role: str, what: str, tz: str) -> str:
+    return (
+        f"# {name}\n\n"
+        f"- **Role**: {role}\n"
+        f"- **What I do**: {what}\n"
+        f"- **Timezone**: {tz}\n"
+        "\n"
+        "Personal namespace — facts about me live here (`raw/me/`).\n"
+    )
+
+
+def write_profile(raw_root: Path, md: str) -> Path:
+    ns_dir = raw_root / PROFILE_NS
+    ns_dir.mkdir(parents=True, exist_ok=True)
+    path = ns_dir / "profile.md"
+    path.write_text(md, encoding="utf-8")
+    return path
+
+
+def update_ns_default(config_path: Path, ns_list: list[str]) -> None:
+    from lorekeep.config import load_config
+
+    cfg = load_config(config_path)
+    cfg.ns.default = list(ns_list)
+    config_path.write_text(
+        yaml.safe_dump(cfg.model_dump(), sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def run_onboarding(
+    home: Path,
+    config_path: Path,
+    *,
+    interactive: bool,
+    prompt: Callable[[str], str] | None = None,
+    force: bool = False,
+) -> bool:
+    profile = home / "raw" / PROFILE_NS / "profile.md"
+    if profile.exists() and not force:
+        return False
+
+    if interactive:
+        p = prompt or input
+        name = p("Your name: ")
+        role = p("Your role/title: ")
+        what = p("What do you work on? ")
+        tz = p("Your timezone (e.g. Asia/Ho_Chi_Minh): ")
+    else:
+        name = role = what = tz = ""
+
+    write_profile(home / "raw", profile_markdown(name, role, what, tz))
+    update_ns_default(config_path, [PROFILE_NS, "public"])
+    return True
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_onboard.py -v`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lorekeep/onboard.py tests/test_onboard.py
+git commit -m "feat(onboard): add me-namespace onboarding module"
+```
+
+---
+
+### Task 2: Wire onboarding into `lorekeep init` (TDD)
+
+**Files:**
+- Modify: `src/lorekeep/cli.py` (the `init` command)
+- Test: `tests/test_init_cli.py` (extend)
+
+**Interfaces:**
+- Consumes: `resolve_paths()["home"]` + `["config"]` (from the dotdir-backup branch), `lorekeep.onboard.run_onboarding` (Task 1).
+- Produces: `lorekeep init [--no-onboard] [--force]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_init_cli.py`:
+
+```python
+def test_init_writes_me_profile_non_tty(tmp_path: Path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0, result.stdout
+    assert (home / "raw" / "me" / "profile.md").exists()
+    import yaml
+    data = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+    assert data["ns"]["default"] == ["me", "public"]
+
+
+def test_init_no_onboard_skips_profile(tmp_path: Path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    result = runner.invoke(app, ["init", "--no-onboard"])
+    assert result.exit_code == 0, result.stdout
+    assert not (home / "raw" / "me" / "profile.md").exists()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_init_cli.py -v`
+Expected: the two new tests FAIL — `raw/me/profile.md` not created; `--no-onboard` is an unknown option.
+
+- [ ] **Step 3: Modify the `init` command in `src/lorekeep/cli.py`**
+
+First ensure `sys` is imported near the top of the file (the existing imports include `json` and `os`; add `import sys` if absent). Check the current import block — if `import sys` is missing, add it alongside `import os`.
+
+Change the `init` command signature and body. The current command is:
+
+```python
+@app.command()
+def init() -> None:
+    """Bootstrap the data home: config + schema + raw/graph dirs."""
+    p = resolve_paths()
+    created = []
+    p["config"].parent.mkdir(parents=True, exist_ok=True)
+    if not p["config"].exists():
+        p["config"].write_text(DEFAULT_CONFIG_YAML)
+        created.append(str(p["config"]))
+    p["schema"].parent.mkdir(parents=True, exist_ok=True)
+    if not p["schema"].exists():
+        p["schema"].write_text(json.dumps(DEFAULT_SCHEMA, indent=2))
+        created.append(str(p["schema"]))
+    p["raw"].mkdir(parents=True, exist_ok=True)
+    p["out"].mkdir(parents=True, exist_ok=True)
+    typer.echo(f"home ready: config={p['config']}")
+    typer.echo(f"  schema={p['schema']}  raw={p['raw']}  graph={p['out']}")
+    if created:
+        typer.echo(f"  wrote defaults: {created}")
+    else:
+        typer.echo("  (existing config/schema preserved)")
+```
+
+Replace it with:
+
+```python
+@app.command()
+def init(
+    no_onboard: bool = typer.Option(
+        False, "--no-onboard", help="skip the me-namespace onboarding prompt"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="overwrite an existing raw/me/profile.md"
+    ),
+) -> None:
+    """Bootstrap the data home: config + schema + raw/graph dirs + me profile."""
+    p = resolve_paths()
+    created = []
+    p["config"].parent.mkdir(parents=True, exist_ok=True)
+    if not p["config"].exists():
+        p["config"].write_text(DEFAULT_CONFIG_YAML)
+        created.append(str(p["config"]))
+    p["schema"].parent.mkdir(parents=True, exist_ok=True)
+    if not p["schema"].exists():
+        p["schema"].write_text(json.dumps(DEFAULT_SCHEMA, indent=2))
+        created.append(str(p["schema"]))
+    p["raw"].mkdir(parents=True, exist_ok=True)
+    p["out"].mkdir(parents=True, exist_ok=True)
+
+    from lorekeep.onboard import run_onboarding
+    interactive = sys.stdin.isatty() and not no_onboard
+    ran = run_onboarding(p["home"], p["config"], interactive=interactive, force=force)
+
+    typer.echo(f"home ready: config={p['config']}")
+    typer.echo(f"  schema={p['schema']}  raw={p['raw']}  graph={p['out']}")
+    if created:
+        typer.echo(f"  wrote defaults: {created}")
+    else:
+        typer.echo("  (existing config/schema preserved)")
+    if ran:
+        typer.echo("  wrote raw/me/profile.md; ns.default=[me, public]")
+        typer.echo("  next: `lorekeep compile`, then `lorekeep mcp add --ns me`")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_init_cli.py -v`
+Expected: PASS (existing tests + the 2 new ones). The existing `test_init_creates_home` and `test_init_preserves_existing_config` still pass (profile creation is additive; the existing assertions on `config.yaml`/`schema.json`/`raw`/`graph` remain true). Note: `test_init_creates_home` also asserts `ns.default` is the default — if it reads the config, it now sees `[me, public]`; if it asserts `[public]`, update that assertion to `[me, public]`.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `uv run pytest -q`
+Expected: PASS. (The known macOS `test_watch_boots_and_shuts_down_cleanly` flake may still fail — pre-existing, not a finding.) If any other test asserts `ns.default == [public]` after a fresh `init`, update it to `[me, public]`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lorekeep/cli.py tests/test_init_cli.py
+git commit -m "feat(init): onboard a me namespace on first run"
+```
+
+---
+
+### Task 3: Update docs
+
+**Files:**
+- Modify: `docs/guides/getting-started.md`
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Update `docs/guides/getting-started.md` step 2**
+
+Find step 2 ("Bootstrap the data home"). After the `uvx lorekeep init` code block, add a note that on a tty `init` prompts for a personal profile (name, role, what you do, timezone) and creates `raw/me/profile.md`, setting `ns.default=[me, public]`; on non-tty it writes a template to fill in later; `--no-onboard` skips it, `--force` overwrites. Keep it to 3-4 lines, matching the surrounding tone.
+
+Example insertion (place right after the `uvx lorekeep doctor` verify line of step 2):
+
+```markdown
+> **First run:** on a terminal, `init` prompts for your name, role, what you
+> work on, and timezone, then writes `raw/me/profile.md` and scopes your
+> default namespace to `me` + `public`. Non-interactive shells get a template
+> to fill in later; `--no-onboard` skips it, `--force` overwrites.
+```
+
+- [ ] **Step 2: Update `AGENTS.md` `init` row**
+
+In the CLI commands table, change the `init` row's Purpose from:
+
+```
+| `init` | Bootstrap data home (config + schema + raw/graph dirs) |
+```
+
+to:
+
+```
+| `init [--no-onboard] [--force]` | Bootstrap data home + onboard a `me` namespace (interactive profile on a tty) |
+```
+
+- [ ] **Step 3: Verify docs build / links**
+
+Run: `grep -n "onboard\|me/profile\|ns.default" docs/guides/getting-started.md AGENTS.md`
+Expected: matches in both files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/guides/getting-started.md AGENTS.md
+git commit -m "docs: document me-namespace onboarding in init"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** spec "onboard.py module" → Task 1. "cli.py init integration + flags" → Task 2. "profile format" → Task 1 (`profile_markdown`). "ns.default update" → Task 1 (`update_ns_default`). "tty + flags" → Task 2 (`interactive = sys.stdin.isatty() and not no_onboard`). "testing" → Tasks 1 + 2. "docs" → Task 3. All covered.
+- **Placeholder scan:** none; every code step shows full code.
+- **Type consistency:** `PROFILE_NS = "me"`, `run_onboarding(home, config_path, *, interactive, prompt=None, force=False) -> bool` consistent across Task 1 (produced) and Task 2 (consumed). `prompt` callable signature matches the injected lambdas in tests.

--- a/docs/superpowers/specs/2026-06-26-onboard-me-namespace-design.md
+++ b/docs/superpowers/specs/2026-06-26-onboard-me-namespace-design.md
@@ -1,0 +1,136 @@
+# Design: Onboarding flow with a `me` namespace + user profile
+
+**Date:** 2026-06-26
+**Status:** Approved (approach A)
+**Author:** manhpt1
+
+## Goal
+
+Make `lorekeep init` immediately personal: on a fresh data home it creates a
+`me` namespace, asks a few questions, and writes a structured profile
+(`raw/me/profile.md`) so the compiled graph starts with facts about the user —
+instead of an empty `raw/` that the user must seed with an irrelevant example
+namespace like `backend`.
+
+## Non-goals
+
+- Auto-running `compile` during `init` (compile needs a configured provider;
+  `init` stays a bootstrap-only command that prints the next-step hint).
+- A separate `lorekeep onboard` command (onboarding lives inside `init`).
+- Changing the schema or the extract pipeline. The profile is ordinary raw
+  markdown; the existing extractor turns it into a `person` node (+ context).
+
+## Decisions
+
+- **Integration:** interactive prompts inside `init`; non-tty/`--no-onboard`
+  writes a template profile instead. `--force` overwrites an existing profile.
+- **Questions (4):** name, role, "what I do" (skills/focus), timezone.
+- **Profile format:** structured markdown (labels), human + LLM friendly.
+- **`ns.default`:** updated to `[me, public]` so an agent scoped to the default
+  sees the user's profile immediately.
+- **Module shape:** new `src/lorekeep/onboard.py` with pure helpers + an
+  orchestrator that takes an injected `prompt` callable (testable without tty).
+- **Config write:** `update_ns_default` loads the Pydantic `Config`, sets
+  `ns.default`, and rewrites `config.yaml` via `yaml.safe_dump`. **Known cost:**
+  this drops comments from a hand-edited `config.yaml`. Accepted because the
+  generated default config has no comments; users who keep comments accept the
+  loss on the one onboarding run (or edit `ns.default` by hand).
+
+## Design
+
+### `src/lorekeep/onboard.py` (new)
+
+```
+PROFILE_NS = "me"
+
+def profile_markdown(name: str, role: str, what: str, tz: str) -> str
+def write_profile(raw_root: Path, md: str) -> Path          # writes raw_root/"me"/"profile.md"
+def update_ns_default(config_path: Path, ns_list: list[str]) -> None
+def run_onboarding(
+    home: Path, config_path: Path, *,
+    interactive: bool, prompt: Callable[[str], str] = typer.prompt,
+    force: bool = False,
+) -> bool
+```
+
+`run_onboarding` logic (takes `home`; derives `raw_root = home / "raw"`):
+1. `profile = home / "raw" / "me" / "profile.md"`. If it exists and not `force` →
+   return `False` (skip, idempotent).
+2. If `interactive`: call `prompt` for each of the 4 fields. Else: all `""`.
+3. `write_profile(home / "raw", profile_markdown(...))`.
+4. `update_ns_default(config_path, [PROFILE_NS, "public"])`.
+5. Return `True`.
+
+`update_ns_default`:
+```
+from lorekeep.config import load_config
+cfg = load_config(config_path)
+cfg.ns.default = [PROFILE_NS, "public"]
+config_path.write_text(yaml.safe_dump(cfg.model_dump(), sort_keys=False))
+```
+
+### `cli.py init` — integration
+
+Two new options: `--no-onboard` (skip), `--force` (overwrite profile). After
+the existing dir/config/schema bootstrap:
+```
+interactive = sys.stdin.isatty() and not no_onboard
+ran = run_onboarding(p["home"], p["config"], interactive=interactive, force=force)
+if ran:
+    typer.echo("  wrote raw/me/profile.md; next: `lorekeep compile`, then `lorekeep mcp add --ns me`")
+```
+
+### Profile format
+
+```markdown
+# {name}
+
+- **Role**: {role}
+- **What I do**: {what}
+- **Timezone**: {tz}
+
+Personal namespace — facts about me live here (`raw/me/`).
+```
+
+The extractor turns this into a `person` node (`name` + `role` props) plus any
+extra context the LLM infers. Fake-compile ignores the actual content (curated
+source, not the compiled output).
+
+### tty + flags
+
+- tty and not `--no-onboard` → interactive prompts.
+- non-tty (CI) OR `--no-onboard` → template profile with empty values, `ns.default` still updated.
+- `--force` → overwrite even if `profile.md` exists.
+
+## Components touched
+
+| File | Change |
+|---|---|
+| `src/lorekeep/onboard.py` | new — pure helpers + orchestrator |
+| `src/lorekeep/cli.py` | `init`: add `--no-onboard`/`--force`, call `run_onboarding` |
+| `tests/test_onboard.py` | new — unit tests for helpers + orchestrator (injected prompt) |
+| `tests/test_init_cli.py` | extend — `init` writes `me` profile (non-tty template path) |
+| `docs/guides/getting-started.md` | update step 2 to mention the prompt + `me` namespace |
+| `AGENTS.md` | update `init` row description |
+
+## Testing
+
+TDD. `run_onboarding`'s `prompt` callable is injected, so interactive logic is
+tested without a real tty. Cases:
+- `profile_markdown` — exact string for given inputs.
+- `write_profile` — file exists at `raw/me/profile.md`, parents created.
+- `update_ns_default` — rewritten `config.yaml` has `ns.default: [me, public]`,
+  other fields preserved.
+- `run_onboarding` interactive — injected fake prompt → profile + ns.default written.
+- `run_onboarding` non-interactive — template with empty values written.
+- Idempotent — existing profile → returns `False`, no write; `force=True` → overwrites.
+- `init` CLI (non-tty, `LOREKEEP_HOME` tmp) — `profile.md` created, `ns.default` updated.
+
+## Risks
+
+- **Config comment loss** on `update_ns_default` for hand-edited configs —
+  accepted (see Decisions); documented in the command's output hint.
+- **Non-tty still writes a profile** — intentional (so installs/CI get the
+  namespace scaffold), but the profile is empty; user fills it later.
+- **`profile_markdown` with empty strings** (non-tty) still produces valid
+  markdown the extractor can handle; no crash on empty fields.

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 
 import typer
@@ -297,12 +298,20 @@ def doctor() -> None:
 
 
 @app.command()
-def init() -> None:
-    """Bootstrap the data home: config + schema + raw/graph dirs."""
+def init(
+    no_onboard: bool = typer.Option(
+        False, "--no-onboard", help="skip the me-namespace onboarding prompt"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="overwrite an existing raw/me/profile.md"
+    ),
+) -> None:
+    """Bootstrap the data home: config + schema + raw/graph dirs + me profile."""
     p = resolve_paths()
     created = []
+    config_fresh = not p["config"].exists()
     p["config"].parent.mkdir(parents=True, exist_ok=True)
-    if not p["config"].exists():
+    if config_fresh:
         p["config"].write_text(DEFAULT_CONFIG_YAML)
         created.append(str(p["config"]))
     p["schema"].parent.mkdir(parents=True, exist_ok=True)
@@ -311,12 +320,24 @@ def init() -> None:
         created.append(str(p["schema"]))
     p["raw"].mkdir(parents=True, exist_ok=True)
     p["out"].mkdir(parents=True, exist_ok=True)
+
+    from lorekeep.onboard import run_onboarding
+    interactive = sys.stdin.isatty()
+    ran = False
+    # Onboard only on a freshly-created config; leave an existing config
+    # (which may carry a partial layout or a different ns.default) untouched.
+    if not no_onboard and config_fresh:
+        ran = run_onboarding(p["home"], p["config"], interactive=interactive, force=force)
+
     typer.echo(f"home ready: config={p['config']}")
     typer.echo(f"  schema={p['schema']}  raw={p['raw']}  graph={p['out']}")
     if created:
         typer.echo(f"  wrote defaults: {created}")
     else:
         typer.echo("  (existing config/schema preserved)")
+    if ran:
+        typer.echo("  wrote raw/me/profile.md; ns.default=[me, public]")
+        typer.echo("  next: `lorekeep compile`, then `lorekeep mcp add --ns me`")
 
 
 @app.command()

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -324,10 +324,15 @@ def init(
     from lorekeep.onboard import run_onboarding
     interactive = sys.stdin.isatty()
     ran = False
-    # Onboard only on a freshly-created config; leave an existing config
-    # (which may carry a partial layout or a different ns.default) untouched.
-    if not no_onboard and config_fresh:
-        ran = run_onboarding(p["home"], p["config"], interactive=interactive, force=force)
+    # Fresh config: full onboarding (profile + ns.default); `force` controls
+    # profile overwrite as today.  Existing config + --force: re-onboard the
+    # profile only, leaving a user-customized ns.default untouched (idempotent).
+    # Existing config without --force: onboarding skipped.
+    if not no_onboard:
+        if config_fresh:
+            ran = run_onboarding(p["home"], p["config"], interactive=interactive, force=force)
+        elif force:
+            ran = run_onboarding(p["home"], p["config"], interactive=interactive, force=True, update_ns=False)
 
     typer.echo(f"home ready: config={p['config']}")
     typer.echo(f"  schema={p['schema']}  raw={p['raw']}  graph={p['out']}")

--- a/src/lorekeep/onboard.py
+++ b/src/lorekeep/onboard.py
@@ -51,6 +51,7 @@ def run_onboarding(
     interactive: bool,
     prompt: Callable[[str], str] | None = None,
     force: bool = False,
+    update_ns: bool = True,
 ) -> bool:
     profile = home / "raw" / PROFILE_NS / "profile.md"
     if profile.exists() and not force:
@@ -66,5 +67,9 @@ def run_onboarding(
         name = role = what = tz = ""
 
     write_profile(home / "raw", profile_markdown(name, role, what, tz))
-    update_ns_default(config_path, [PROFILE_NS, "public"])
+    # Only update ns.default on a fresh config (update_ns=True). When re-onboarding
+    # the profile on an existing config (--force), leave a user-customized
+    # ns.default untouched.
+    if update_ns:
+        update_ns_default(config_path, [PROFILE_NS, "public"])
     return True

--- a/src/lorekeep/onboard.py
+++ b/src/lorekeep/onboard.py
@@ -1,0 +1,70 @@
+"""First-run onboarding: create a personal `me` namespace + profile.
+
+Called from `cli.init`. Interactive prompts run only on a tty; non-tty / CI
+gets a template profile with empty values. `ns.default` is updated to
+`[me, public]` so an agent scoped to the default sees the user's profile.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import yaml
+
+PROFILE_NS = "me"
+
+
+def profile_markdown(name: str, role: str, what: str, tz: str) -> str:
+    return (
+        f"# {name}\n\n"
+        f"- **Role**: {role}\n"
+        f"- **What I do**: {what}\n"
+        f"- **Timezone**: {tz}\n"
+        "\n"
+        "Personal namespace — facts about me live here (`raw/me/`).\n"
+    )
+
+
+def write_profile(raw_root: Path, md: str) -> Path:
+    ns_dir = raw_root / PROFILE_NS
+    ns_dir.mkdir(parents=True, exist_ok=True)
+    path = ns_dir / "profile.md"
+    path.write_text(md, encoding="utf-8")
+    return path
+
+
+def update_ns_default(config_path: Path, ns_list: list[str]) -> None:
+    from lorekeep.config import load_config
+
+    cfg = load_config(config_path)
+    cfg.ns.default = list(ns_list)
+    config_path.write_text(
+        yaml.safe_dump(cfg.model_dump(), sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def run_onboarding(
+    home: Path,
+    config_path: Path,
+    *,
+    interactive: bool,
+    prompt: Callable[[str], str] | None = None,
+    force: bool = False,
+) -> bool:
+    profile = home / "raw" / PROFILE_NS / "profile.md"
+    if profile.exists() and not force:
+        return False
+
+    if interactive:
+        p = prompt or input
+        name = p("Your name: ")
+        role = p("Your role/title: ")
+        what = p("What do you work on? ")
+        tz = p("Your timezone (e.g. Asia/Ho_Chi_Minh): ")
+    else:
+        name = role = what = tz = ""
+
+    write_profile(home / "raw", profile_markdown(name, role, what, tz))
+    update_ns_default(config_path, [PROFILE_NS, "public"])
+    return True

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -48,3 +48,23 @@ def test_init_no_onboard_skips_profile(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["init", "--no-onboard"])
     assert result.exit_code == 0, result.stdout
     assert not (home / "raw" / "me" / "profile.md").exists()
+
+
+def test_init_force_reonboards_profile_on_existing_config(tmp_path: Path, monkeypatch):
+    """--force rewrites the profile on an existing config; ns.default preserved."""
+    import yaml
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "raw" / "me").mkdir(parents=True)
+    # Seed an existing config + profile ("old"). CliRunner is non-tty, so the
+    # rewritten profile is the empty template — assert content changed AND
+    # ns.default (seeded non-default) is preserved.
+    (home / "raw" / "me" / "profile.md").write_text("old", encoding="utf-8")
+    (home / "config.yaml").write_text("ns:\n  default: [public]\n", encoding="utf-8")
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    result = runner.invoke(app, ["init", "--force"])
+    assert result.exit_code == 0, result.stdout
+    md = (home / "raw" / "me" / "profile.md").read_text(encoding="utf-8")
+    assert md != "old"  # profile rewritten
+    data = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+    assert data["ns"]["default"] == ["public"]  # preserved, not clobbered to [me, public]

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -29,3 +29,22 @@ def test_init_preserves_existing_config(tmp_path: Path, monkeypatch):
     assert (home / "config.yaml").read_text() == "install_source: local\n"
     assert (home / "schema.json").exists()
     assert (home / "raw").is_dir()
+
+
+def test_init_writes_me_profile_non_tty(tmp_path: Path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0, result.stdout
+    assert (home / "raw" / "me" / "profile.md").exists()
+    import yaml
+    data = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+    assert data["ns"]["default"] == ["me", "public"]
+
+
+def test_init_no_onboard_skips_profile(tmp_path: Path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    result = runner.invoke(app, ["init", "--no-onboard"])
+    assert result.exit_code == 0, result.stdout
+    assert not (home / "raw" / "me" / "profile.md").exists()

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -97,3 +97,23 @@ def test_run_onboarding_force_overwrites(tmp_path: Path):
     )
     assert ran is True
     assert "Alice" in (home / "raw" / "me" / "profile.md").read_text(encoding="utf-8")
+
+
+def test_run_onboarding_update_ns_false_preserves_ns(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "raw" / "me").mkdir(parents=True)
+    (home / "raw" / "me" / "profile.md").write_text("old", encoding="utf-8")
+    # A user-customized ns.default that must NOT be clobbered.
+    cfg = home / "config.yaml"
+    cfg.write_text("ns:\n  default: [custom]\n", encoding="utf-8")
+    answers = iter(["Alice", "Eng", "Backend", "UTC"])
+    ran = run_onboarding(
+        home, cfg, interactive=True, prompt=lambda _: next(answers),
+        force=True, update_ns=False,
+    )
+    assert ran is True
+    # Profile was rewritten.
+    assert "Alice" in (home / "raw" / "me" / "profile.md").read_text(encoding="utf-8")
+    # ns.default left untouched.
+    assert yaml.safe_load(cfg.read_text(encoding="utf-8"))["ns"]["default"] == ["custom"]

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+
+import yaml
+
+from lorekeep.onboard import (
+    PROFILE_NS,
+    profile_markdown,
+    write_profile,
+    update_ns_default,
+    run_onboarding,
+)
+
+
+def test_profile_markdown_exact():
+    md = profile_markdown("Alice", "Eng", "Backend", "UTC")
+    assert md == (
+        "# Alice\n\n"
+        "- **Role**: Eng\n"
+        "- **What I do**: Backend\n"
+        "- **Timezone**: UTC\n"
+        "\n"
+        "Personal namespace — facts about me live here (`raw/me/`).\n"
+    )
+
+
+def test_write_profile_creates_file(tmp_path: Path):
+    raw = tmp_path / "raw"
+    p = write_profile(raw, "# Alice\n")
+    assert p == raw / PROFILE_NS / "profile.md"
+    assert p.read_text(encoding="utf-8") == "# Alice\n"
+
+
+def test_update_ns_default_preserves_rest(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "provider:\n"
+        "  model: openai/gpt-4o-mini\n"
+        "  backend: openai\n"
+        "ns:\n"
+        "  default: [public]\n"
+        "install_source: pypi\n",
+        encoding="utf-8",
+    )
+    update_ns_default(cfg, [PROFILE_NS, "public"])
+    data = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+    assert data["ns"]["default"] == ["me", "public"]
+    assert data["provider"]["model"] == "openai/gpt-4o-mini"
+    assert data["install_source"] == "pypi"
+
+
+def test_run_onboarding_interactive_writes_profile_and_ns(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    cfg = home / "config.yaml"
+    cfg.write_text("ns:\n  default: [public]\n", encoding="utf-8")
+    answers = iter(["Alice", "Eng", "Backend", "UTC"])
+    ran = run_onboarding(home, cfg, interactive=True, prompt=lambda _: next(answers))
+    assert ran is True
+    assert (home / "raw" / "me" / "profile.md").exists()
+    assert yaml.safe_load(cfg.read_text(encoding="utf-8"))["ns"]["default"] == ["me", "public"]
+
+
+def test_run_onboarding_non_interactive_template(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    cfg = home / "config.yaml"
+    cfg.write_text("ns:\n  default: [public]\n", encoding="utf-8")
+    ran = run_onboarding(home, cfg, interactive=False)
+    assert ran is True
+    md = (home / "raw" / "me" / "profile.md").read_text(encoding="utf-8")
+    assert "**Role**: \n" in md  # empty value preserved
+
+
+def test_run_onboarding_idempotent_skip(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "raw" / "me").mkdir(parents=True)
+    (home / "raw" / "me" / "profile.md").write_text("existing", encoding="utf-8")
+    cfg = home / "config.yaml"
+    cfg.write_text("ns:\n  default: [public]\n", encoding="utf-8")
+    # prompt must NOT be called when skipping
+    ran = run_onboarding(home, cfg, interactive=True, prompt=lambda _: (_ for _ in ()).throw(AssertionError("prompt called")))
+    assert ran is False
+    assert (home / "raw" / "me" / "profile.md").read_text(encoding="utf-8") == "existing"
+
+
+def test_run_onboarding_force_overwrites(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "raw" / "me").mkdir(parents=True)
+    (home / "raw" / "me" / "profile.md").write_text("old", encoding="utf-8")
+    cfg = home / "config.yaml"
+    cfg.write_text("ns:\n  default: [public]\n", encoding="utf-8")
+    answers = iter(["Alice", "Eng", "Backend", "UTC"])
+    ran = run_onboarding(
+        home, cfg, interactive=True, prompt=lambda _: next(answers), force=True
+    )
+    assert ran is True
+    assert "Alice" in (home / "raw" / "me" / "profile.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Stacked on #39. Makes `lorekeep init` immediately personal: on a fresh data home it creates a `me` namespace, asks a few questions, and writes a structured profile (`raw/me/profile.md`) so the compiled graph starts with facts about the user — instead of an empty `raw/` the user must seed with an irrelevant example namespace.

- **`src/lorekeep/onboard.py`** (new) — pure helpers (`profile_markdown`, `write_profile`, `update_ns_default`) + `run_onboarding(home, config_path, *, interactive, prompt=None, force=False, update_ns=True)`. The injected `prompt` callable makes interactive logic testable without a tty.
- **`cli.py init`** — gains `--no-onboard` / `--force`. On a fresh config + tty it prompts (name / role / "what you work on" / timezone), writes `raw/me/profile.md`, sets `ns.default=[me, public]`. Non-tty writes a template. `--force` re-onboards the profile on an existing config without touching `ns.default` (profile-only).
- **Docs** — `getting-started.md` step-2 note + `AGENTS.md` `init` row.

## Behavior

| State | Result |
|---|---|
| fresh config + tty | prompts → `raw/me/profile.md` + `ns.default=[me, public]` |
| fresh config + non-tty (CI) | template profile (empty values) + `ns.default=[me, public]` |
| fresh config + `--no-onboard` | skip onboarding entirely (no profile, no ns change) |
| existing config + `--force` | re-onboard profile only; `ns.default` untouched |
| existing config, no flags | idempotent — onboarding skipped |

`update_ns_default` rewrites `config.yaml` via `yaml.safe_dump(model_dump())`, so onboarding only runs against a just-created default config (the `config_fresh` gate) — a hand-edited config with a real key is never rewritten.

## Design

- Spec: `docs/superpowers/specs/2026-06-26-onboard-me-namespace-design.md`
- Plan: `docs/superpowers/plans/2026-06-26-onboard-me-namespace.md`

## Test plan

- New `tests/test_onboard.py` (8): markdown exact string, write_profile, update_ns_default preserves other fields, interactive + non-interactive, idempotent skip, force overwrite, `update_ns=False` leaves ns.default.
- Extended `tests/test_init_cli.py` (3): non-tty writes profile, `--no-onboard` skips, `--force` re-onboards on existing config.
- Full suite: **185 passed**. 1 failure = `test_watch_boots_and_shuts_down_cleanly`, a pre-existing macOS flake (no GNU `timeout` binary) — fails identically on the parent branch, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)