### PR TITLE
fix: enable minor bump for feat commits

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
     ".": {
       "release-type": "python",
       "include-v-in-tag": true,
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
Remove `bump-patch-for-minor-pre-major` which was overriding `bump-minor-pre-major`. Result: `feat:` commits now bump minor (0.x.0) instead of patch (0.0.x) as intended.