### PR TITLE
ci: add workflow_dispatch for manual PyPI republish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,12 @@ name: release-please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag to publish (e.g. v0.1.13)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -21,6 +27,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     outputs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
@@ -32,7 +39,7 @@ jobs:
 
   publish:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: always() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -41,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ github.event.inputs.tag_name || needs.release-please.outputs.tag_name }}
 
       - uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
Adds `workflow_dispatch` trigger to re-publish a specific tag to PyPI without re-running release-please. Needed to retry the failed v0.1.13 publish after PyPI trusted publisher fix.