### PR TITLE
feat: auto-detect coding agents during init and wire MCP automatically

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -9,7 +9,7 @@ graph — including the backup setup. For the terse 5-step version, see the
 - A **data home** (`.lorekeep/` in a source checkout, or an XDG dir for an
   installed copy) holding your config, schema, raw docs, and compiled graph.
 - A compiled `facts.jsonl` graph built from your markdown.
-- A coding agent (Claude Code / Cursor / Codex) reading the graph over MCP,
+- A coding agent (Claude Code / Cursor / Codex / opencode) reading the graph over MCP,
   scoped to a namespace.
 - A private git backup of the data home, so the graph syncs to your other
   machines.
@@ -49,7 +49,16 @@ uvx lorekeep init
    `raw/<ns>/about.md`, so the compiled graph starts with a fact about you.
 
 It then writes `config.yaml` + `schema.json`, creates `raw/` + `graph/` dirs,
-and writes `raw/<ns>/about.md`.
+writes `raw/<ns>/about.md`, and **auto-detects coding agents** to wire:
+
+- If you're running `init` **inside** a coding agent (e.g. from opencode's or
+  Claude Code's shell), it wires only that agent.
+- If you're in a **plain shell**, it scans for all installed agents
+  (`~/.claude`, `~/.cursor`, `~/.codex`, `~/.config/opencode`) and wires each.
+
+Each detected agent gets its MCP config written automatically (`.mcp.json`,
+`.cursor/mcp.json`, `config.toml`, or `opencode.json` — depending on the agent).
+Restart the agent to pick up the new tools.
 
 Non-interactive (CI, scripts): `uvx lorekeep init --yes`. From a source
 checkout it uses the repo's own `.lorekeep/`; for an installed copy it uses
@@ -113,13 +122,15 @@ Recompiling unchanged input is **byte-identical** (determinism is a hard
 requirement) — unchanged chunks return cached LLM output, so only edited docs
 cost tokens on recompile.
 
-## 6. Wire a coding agent
+## 6. Wire additional coding agents
 
-Write a portable `.mcp.json` scoped to a namespace:
+`init` already wired agents it detected. To add more, or to re-scope one:
 
 ```bash
-uvx lorekeep mcp add --agent claude --ns backend
+uvx lorekeep mcp add --agent opencode --ns backend
 ```
+
+Supported agents: `claude`, `cursor`, `codex`, `opencode`.
 
 Restart the agent → the 8 read-only Lorekeep tools (`search`, `get_node`,
 `neighbors`, `at_time`, `history`, `changes`, `list_namespaces`, `schema`) are

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -227,12 +227,11 @@ app.add_typer(mcp_app, name="mcp")
 
 @mcp_app.command("add")
 def mcp_add(
-    agent: str = typer.Option(..., "--agent", help="claude | cursor | codex"),
+    agent: str = typer.Option(..., "--agent", help="claude | cursor | codex | opencode"),
     scope: str = typer.Option("project", "--scope", help="project | user"),
     ns: str = typer.Option(None, "--ns", help="namespace to scope the agent to"),
 ) -> None:
     """Write the agent's MCP config + print an agent-memory snippet."""
-    from lorekeep.integrations import claude_code, codex, cursor
     from lorekeep.integrations.common import agent_memory_snippet, resolve_command
 
     p = resolve_paths()
@@ -240,9 +239,9 @@ def mcp_add(
     command, args = resolve_command(config.install_source)
 
     target = Path.cwd() if scope == "project" else Path.home()
-    writers = {"claude": claude_code, "cursor": cursor, "codex": codex}
+    writers = _agent_writers()
     if agent not in writers:
-        typer.echo(f"unknown agent: {agent} (choose claude|cursor|codex)")
+        typer.echo(f"unknown agent: {agent} (choose claude|cursor|codex|opencode)")
         raise typer.Exit(code=1)
     written = writers[agent].write_config(target, command, args, ns)
     typer.echo(f"wrote {agent} config -> {written}")
@@ -357,10 +356,12 @@ def init(
         (ns_dir / "about.md").write_text(about_md)
         typer.echo(f"  wrote: {ns_dir / 'about.md'}")
 
+    # Auto-detect and wire coding agents (active session or installed).
     if not config_existed:
+        _auto_wire_agents(p, ns)
         typer.echo("\nNext steps:")
         typer.echo("  1. Compile:           uvx lorekeep compile   (or LOREKEEP_PROVIDER=fake)")
-        typer.echo(f"  2. Wire an agent:     uvx lorekeep mcp add --agent claude --ns {ns}")
+        typer.echo("  2. More agents:       uvx lorekeep mcp add --agent <claude|cursor|codex|opencode>")
 
 
 def _interactive_init(p: dict) -> tuple[str, str, str]:
@@ -418,6 +419,51 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
     }
     p["config"].write_text(yaml.dump(config, default_flow_style=False, sort_keys=False))
     return ns, name, bio
+
+
+def _auto_wire_agents(p: dict, ns: str) -> None:
+    """Detect coding agents and write their MCP configs automatically.
+
+    If running inside a coding agent (env var set), wires only that agent.
+    Otherwise scans the filesystem for all installed agents and wires each.
+    """
+    from lorekeep.integrations.detect import detect_agents
+    from lorekeep.integrations.common import agent_memory_snippet, resolve_command
+
+    detected = detect_agents()
+    if not detected:
+        typer.echo("\n  No coding agents detected — run `lorekeep mcp add --agent <name>` after install.")
+        return
+
+    config = load_config(p["config"])
+    command, args = resolve_command(config.install_source)
+
+    writers = _agent_writers()
+    target = Path.cwd()
+
+    typer.echo(f"\n  Detected agents: {', '.join(detected)}")
+    for agent_name in detected:
+        writer = writers.get(agent_name)
+        if not writer:
+            continue
+        try:
+            written = writer.write_config(target, command, args, ns)
+            typer.echo(f"  wired {agent_name} -> {written}")
+        except Exception as exc:
+            typer.echo(f"  {agent_name}: failed ({exc})")
+
+    typer.echo("\n  " + agent_memory_snippet().replace("\n", "\n  ").strip())
+
+
+def _agent_writers() -> dict:
+    """Return the agent-name → writer-module mapping (lazy import)."""
+    from lorekeep.integrations import claude_code, codex, cursor, opencode
+    return {
+        "claude": claude_code,
+        "cursor": cursor,
+        "codex": codex,
+        "opencode": opencode,
+    }
 
 
 @app.command()

--- a/src/lorekeep/integrations/detect.py
+++ b/src/lorekeep/integrations/detect.py
@@ -1,0 +1,82 @@
+"""Detect coding agents: active session (env vars) + installed (filesystem markers).
+
+Two-layer detection:
+  1. ``detect_active_agent`` — which agent shell are we running inside right now?
+     Uses well-known env vars.  Returns at most one agent name (or ``None``).
+  2. ``detect_installed_agents`` — which agents are installed on this machine?
+     Checks for config directories / binaries.  Returns a list (may be empty).
+
+``detect_agents`` combines both: if an active session is detected, return just
+that agent.  Otherwise, return all installed agents found on the filesystem.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+# Env var that each agent sets when it launches a subprocess shell.
+# The value is checked for truthiness (any non-empty string counts).
+_ACTIVE_ENV: dict[str, list[str]] = {
+    "claude": ["CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT"],
+    "opencode": ["OPENCODE"],
+    "cursor": ["CURSOR_DEBUG"],
+}
+
+# Filesystem markers that indicate an agent has been installed / used.
+# Each entry is a list of candidate paths (``~`` expanded relative to home).
+_INSTALLED_MARKERS: dict[str, list[str]] = {
+    "claude": ["~/.claude"],
+    "cursor": ["~/.cursor"],
+    "codex": ["~/.codex"],
+    "opencode": ["~/.config/opencode", "~/.opencode"],
+}
+
+# Binary names to look for in PATH (fallback when dir markers are missing).
+_BINARIES: dict[str, list[str]] = {
+    "claude": ["claude"],
+    "cursor": ["cursor"],
+    "codex": ["codex"],
+    "opencode": ["opencode"],
+}
+
+SUPPORTED_AGENTS = sorted(_ACTIVE_ENV.keys() | _INSTALLED_MARKERS.keys())
+
+
+def _env_truthy(name: str) -> bool:
+    val = os.environ.get(name, "")
+    return val not in ("", "0", "false", "False")
+
+
+def detect_active_agent() -> str | None:
+    """Return the agent whose shell we are running inside, or ``None``."""
+    for agent, env_vars in _ACTIVE_ENV.items():
+        if any(_env_truthy(v) for v in env_vars):
+            return agent
+    return None
+
+
+def detect_installed_agents() -> list[str]:
+    """Return all agents detected on this machine (filesystem + PATH)."""
+    found: list[str] = []
+    home = Path.home()
+    for agent, markers in _INSTALLED_MARKERS.items():
+        if any(Path(m).expanduser().exists() for m in markers):
+            found.append(agent)
+            continue
+        if any(shutil.which(b) for b in _BINARIES.get(agent, [])):
+            found.append(agent)
+    return found
+
+
+def detect_agents() -> list[str]:
+    """Detect agents to wire during ``init``.
+
+    - If running inside a coding agent, return **only** that agent (the user
+      is already in it; wiring others is noise).
+    - Otherwise, return all installed agents found on the filesystem.
+    """
+    active = detect_active_agent()
+    if active:
+        return [active]
+    return detect_installed_agents()

--- a/src/lorekeep/integrations/opencode.py
+++ b/src/lorekeep/integrations/opencode.py
@@ -1,0 +1,43 @@
+"""opencode MCP config writer (opencode.json ``mcp`` section).
+
+opencode uses a different MCP schema than Claude/Cursor:
+  - Config file: ``opencode.json`` (project root) or ``~/.config/opencode/opencode.json`` (global)
+  - Key: ``mcp`` (not ``mcpServers``)
+  - Entry shape: ``{"type": "local", "command": [cmd, ...args], "enabled": true, "environment": {...}}``
+  - ``command`` is a single array (command + args combined)
+
+Idempotent: re-running merges into the existing ``mcp`` section, replacing only
+the ``lorekeep`` entry.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def write_config(target_dir: Path, command: str, args: list[str], ns: str | None) -> Path:
+    target_dir = Path(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    path = target_dir / "opencode.json"
+
+    existing: dict = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text())
+        except (json.JSONDecodeError, ValueError):
+            existing = {}
+
+    entry: dict = {
+        "type": "local",
+        "command": [command, *args],
+        "enabled": True,
+    }
+    if ns:
+        entry["environment"] = {"LOREKEEP_NS": ns}
+
+    mcp = existing.get("mcp", {})
+    mcp["lorekeep"] = entry
+    existing["mcp"] = mcp
+
+    path.write_text(json.dumps(existing, indent=2) + "\n")
+    return path

--- a/tests/test_agent_detect.py
+++ b/tests/test_agent_detect.py
@@ -1,0 +1,71 @@
+"""Tests for agent auto-detection (env vars + filesystem markers)."""
+from pathlib import Path
+from lorekeep.integrations.detect import detect_active_agent, detect_installed_agents, detect_agents
+
+
+def _isolate(monkeypatch, tmp_path):
+    """Block all real env vars + filesystem markers + PATH lookups."""
+    for v in ("CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "OPENCODE", "CURSOR_DEBUG"):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr("lorekeep.integrations.detect.shutil.which", lambda _: None)
+
+
+def test_detect_active_opencode(monkeypatch):
+    _isolate(monkeypatch, Path("/tmp"))
+    monkeypatch.setenv("OPENCODE", "1")
+    assert detect_active_agent() == "opencode"
+
+
+def test_detect_active_claude(monkeypatch):
+    _isolate(monkeypatch, Path("/tmp"))
+    monkeypatch.setenv("CLAUDECODE", "1")
+    assert detect_active_agent() == "claude"
+
+
+def test_detect_active_none(monkeypatch, tmp_path):
+    _isolate(monkeypatch, tmp_path)
+    assert detect_active_agent() is None
+
+
+def test_detect_active_falsy_env_ignored(monkeypatch, tmp_path):
+    _isolate(monkeypatch, tmp_path)
+    monkeypatch.setenv("OPENCODE", "0")
+    assert detect_active_agent() is None
+
+
+def test_detect_installed_finds_markers(monkeypatch, tmp_path):
+    _isolate(monkeypatch, tmp_path)
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".config" / "opencode").mkdir(parents=True)
+    found = detect_installed_agents()
+    assert "claude" in found
+    assert "opencode" in found
+    assert "codex" not in found
+
+
+def test_detect_installed_empty(monkeypatch, tmp_path):
+    _isolate(monkeypatch, tmp_path)
+    assert detect_installed_agents() == []
+
+
+def test_detect_agents_active_overrides_installed(monkeypatch, tmp_path):
+    """When inside an agent session, return only that agent."""
+    _isolate(monkeypatch, tmp_path)
+    monkeypatch.setenv("OPENCODE", "1")
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".config" / "opencode").mkdir(parents=True)
+    result = detect_agents()
+    assert result == ["opencode"]
+
+
+def test_detect_agents_no_active_returns_all_installed(monkeypatch, tmp_path):
+    _isolate(monkeypatch, tmp_path)
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".cursor").mkdir()
+    result = detect_agents()
+    assert set(result) == {"claude", "cursor"}
+
+
+from pathlib import Path

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -117,3 +117,67 @@ def test_init_no_about_when_raw_has_files(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["init"])
     assert result.exit_code == 0, result.stdout
     assert not (home / "raw" / "public" / "about.md").exists()
+
+
+def test_init_auto_wires_detected_agent(tmp_path: Path, monkeypatch):
+    """init detects active agent from env and writes its MCP config."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("OPENCODE", "1")
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+    monkeypatch.setattr("lorekeep.integrations.detect.shutil.which", lambda _: None)
+    result = runner.invoke(app, ["init", "--yes"])
+    assert result.exit_code == 0, result.stdout
+    import json
+    mcp_path = project / "opencode.json"
+    assert mcp_path.exists(), f"opencode.json not written: {result.stdout}"
+    data = json.loads(mcp_path.read_text())
+    assert data["mcp"]["lorekeep"]["type"] == "local"
+
+
+def test_init_auto_wires_installed_agents(tmp_path: Path, monkeypatch):
+    """init in shell mode scans filesystem and wires all installed agents."""
+    home = tmp_path / "home"
+    fake_home = tmp_path / "fakehome"
+    project = tmp_path / "project"
+    project.mkdir()
+    (fake_home / ".claude").mkdir(parents=True)
+    (fake_home / ".config" / "opencode").mkdir(parents=True)
+
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.chdir(project)
+    monkeypatch.delenv("OPENCODE", raising=False)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+    monkeypatch.setattr("lorekeep.integrations.detect.shutil.which", lambda _: None)
+
+    result = runner.invoke(app, ["init", "--yes"])
+    assert result.exit_code == 0, result.stdout
+    assert (project / ".mcp.json").exists()
+    assert (project / "opencode.json").exists()
+
+
+def test_init_no_agents_detected_message(tmp_path: Path, monkeypatch):
+    """init reports when no agents are detected."""
+    home = tmp_path / "home"
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("OPENCODE", raising=False)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+    monkeypatch.setattr("lorekeep.integrations.detect.shutil.which", lambda _: None)
+
+    result = runner.invoke(app, ["init", "--yes"])
+    assert result.exit_code == 0, result.stdout
+    assert "no coding agents detected" in result.stdout.lower()

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 from lorekeep.integrations.common import resolve_command, agent_memory_snippet
-from lorekeep.integrations import claude_code, cursor, codex
+from lorekeep.integrations import claude_code, cursor, codex, opencode
 
 
 def test_resolve_command_pypi():
@@ -66,3 +66,39 @@ def test_codex_rejects_newline_in_ns(tmp_path: Path):
     import pytest
     with pytest.raises(ValueError):
         codex.write_config(tmp_path, "uvx", ["lorekeep"], ns="team\n[malicious]")
+
+
+def test_opencode_writes_json(tmp_path: Path):
+    opencode.write_config(tmp_path, "uvx", ["lorekeep", "serve", "--transport", "stdio"],
+                          ns="teams/backend")
+    data = json.loads((tmp_path / "opencode.json").read_text())
+    entry = data["mcp"]["lorekeep"]
+    assert entry["type"] == "local"
+    assert entry["command"] == ["uvx", "lorekeep", "serve", "--transport", "stdio"]
+    assert entry["enabled"] is True
+    assert entry["environment"]["LOREKEEP_NS"] == "teams/backend"
+
+
+def test_opencode_no_ns(tmp_path: Path):
+    opencode.write_config(tmp_path, "uvx", ["lorekeep", "serve", "--transport", "stdio"], ns=None)
+    data = json.loads((tmp_path / "opencode.json").read_text())
+    entry = data["mcp"]["lorekeep"]
+    assert "environment" not in entry
+
+
+def test_opencode_idempotent(tmp_path: Path):
+    opencode.write_config(tmp_path, "uvx", ["lorekeep"], ns="team/a")
+    opencode.write_config(tmp_path, "uvx", ["lorekeep"], ns="team/b")
+    data = json.loads((tmp_path / "opencode.json").read_text())
+    assert data["mcp"]["lorekeep"]["environment"]["LOREKEEP_NS"] == "team/b"
+
+
+def test_opencode_preserves_existing_keys(tmp_path: Path):
+    existing = {"$schema": "https://opencode.ai/config.json", "model": "anthropic/claude-sonnet-4-5", "mcp": {"other": {"type": "local", "command": ["foo"]}}}
+    (tmp_path / "opencode.json").write_text(json.dumps(existing))
+    opencode.write_config(tmp_path, "uvx", ["lorekeep", "serve", "--transport", "stdio"], ns=None)
+    data = json.loads((tmp_path / "opencode.json").read_text())
+    assert data["$schema"] == "https://opencode.ai/config.json"
+    assert data["model"] == "anthropic/claude-sonnet-4-5"
+    assert "other" in data["mcp"]
+    assert "lorekeep" in data["mcp"]

--- a/tests/test_mcp_add_cli.py
+++ b/tests/test_mcp_add_cli.py
@@ -26,3 +26,17 @@ def test_mcp_add_codex_user(tmp_path: Path, monkeypatch):
     assert result.exit_code == 0, result.stdout
     text = (tmp_path / "config.toml").read_text()
     assert "--from" in text and "git+https://github.com/x/lorekeep.git" in text
+
+
+def test_mcp_add_opencode_project(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LOREKEEP_CONFIG", str(tmp_path / "config.yaml"))
+    (tmp_path / "config.yaml").write_text("install_source: local\n")
+    result = runner.invoke(app, ["mcp", "add", "--agent", "opencode", "--ns", "teams/backend"])
+    assert result.exit_code == 0, result.stdout
+    import json
+    data = json.loads((tmp_path / "opencode.json").read_text())
+    entry = data["mcp"]["lorekeep"]
+    assert entry["type"] == "local"
+    assert entry["command"] == ["lorekeep", "serve", "--transport", "stdio"]
+    assert entry["environment"]["LOREKEEP_NS"] == "teams/backend"


### PR DESCRIPTION
## What

`lorekeep init` now auto-detects coding agents and writes their MCP configs automatically — no more manual `mcp add` step.

## Detection strategy

| Context | Behavior |
|---|---|
| Inside a coding agent (`OPENCODE=1`, `CLAUDECODE=1`) | Wire only that agent |
| Plain shell | Scan filesystem (`~/.claude`, `~/.cursor`, `~/.codex`, `~/.config/opencode`) + PATH → wire all detected |

## Changes

- **New `integrations/detect.py`** — two-layer detection: env vars (active session) + filesystem markers + PATH lookup (installed)
- **New `integrations/opencode.py`** — opencode MCP config writer (`opencode.json`, `mcp.lorekeep` schema with `type: local`, `command: []`, `environment: {}`)
- **`cli.py`** — `init` calls `_auto_wire_agents()` after data home setup; `mcp add` supports `opencode`; shared `_agent_writers()` helper
- **Docs** — getting-started.md updated: init auto-wires, section 6 is now "Wire additional agents"

## Supported agents

`claude` (`.mcp.json`), `cursor` (`.cursor/mcp.json`), `codex` (`config.toml`), `opencode` (`opencode.json`)

## Tests

198 pass (+16 new):
- 8 detection tests (env var, filesystem, PATH, active-overrides-installed)
- 4 opencode writer tests (write, no-ns, idempotent, preserves-existing-keys)
- 1 `mcp add --agent opencode` CLI test
- 3 init auto-wire CLI tests (active agent, installed scan, none-detected)