### PR TITLE
test: add E2E + unit tests for write tools, merge_journals, and compile/resolve loop

### DIFF
--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -39,6 +39,34 @@ def _build_provider(config: Config) -> LiteLLMProvider:
     )
 
 
+_FAKE_CANNED = json.dumps({
+    "nodes": [
+        {"id": "svc:payments-api", "type": "service", "name": "payments-api",
+         "props": {"lang": "go"}, "valid_from": "2024-01-15"},
+        {"id": "svc:auth", "type": "service", "name": "auth"},
+        {"id": "team:backend", "type": "team", "name": "team-backend"},
+        {"id": "dec:adr-007", "type": "decision",
+         "props": {"title": "payments-api adopts internal signing"}},
+    ],
+    "edges": [
+        {"type": "depends_on", "from": "svc:payments-api", "to": "svc:auth",
+         "valid_from": "2024-01-15", "valid_to": "2025-03-01"},
+        {"type": "decided_by", "from": "dec:adr-007", "to": "team:backend"},
+    ],
+    "aliases": {},
+})
+
+
+def _make_provider(config: Config) -> FakeProvider | LiteLLMProvider:
+    """Create provider honoring LOREKEEP_PROVIDER=fake for offline/test use.
+
+    Shared by standalone compile, daemon auto-compile, and import.
+    """
+    if os.environ.get("LOREKEEP_PROVIDER") == "fake":
+        return FakeProvider(responses=[_FAKE_CANNED])
+    return _build_provider(config)
+
+
 @app.command()
 def version() -> None:
     """Print the Lorekeep version."""
@@ -51,27 +79,7 @@ def compile() -> None:
     p = resolve_paths()
     schema = load_schema(p["schema"])
     config = load_config(p["config"])
-
-    if os.environ.get("LOREKEEP_PROVIDER") == "fake":
-        canned = json.dumps({
-            "nodes": [
-                {"id": "svc:payments-api", "type": "service", "name": "payments-api",
-                 "props": {"lang": "go"}, "valid_from": "2024-01-15"},
-                {"id": "svc:auth", "type": "service", "name": "auth"},
-                {"id": "team:backend", "type": "team", "name": "team-backend"},
-                {"id": "dec:adr-007", "type": "decision",
-                 "props": {"title": "payments-api adopts internal signing"}},
-            ],
-            "edges": [
-                {"type": "depends_on", "from": "svc:payments-api", "to": "svc:auth",
-                 "valid_from": "2024-01-15", "valid_to": "2025-03-01"},
-                {"type": "decided_by", "from": "dec:adr-007", "to": "team:backend"},
-            ],
-            "aliases": {},
-        })
-        provider = FakeProvider(responses=[canned])
-    else:
-        provider = _build_provider(config)
+    provider = _make_provider(config)
 
     manifest = compile_graph(
         raw_root=p["raw"], out_dir=p["out"], schema=schema,
@@ -79,6 +87,10 @@ def compile() -> None:
     )
     typer.echo(f"compiled: {manifest.node_count} nodes, {manifest.edge_count} edges, "
                f"run_id={manifest.run_id}, facts_hash={manifest.facts_hash}")
+
+    pending_dir = p.get("pending")
+    if pending_dir and pending_dir.exists():
+        _do_auto_resolve(p["out"], pending_dir)
 
 
 @app.command(name="eval")
@@ -663,27 +675,7 @@ def ingest(
         typer.echo(f"ingest: source must be under raw/ ({raw_root})")
         raise typer.Exit(code=1)
 
-    # Build provider (fake or real)
-    if os.environ.get("LOREKEEP_PROVIDER") == "fake":
-        canned = json.dumps({
-            "nodes": [
-                {"id": "svc:payments-api", "type": "service", "name": "payments-api",
-                 "props": {"lang": "go"}, "valid_from": "2024-01-15"},
-                {"id": "svc:auth", "type": "service", "name": "auth"},
-                {"id": "team:backend", "type": "team", "name": "team-backend"},
-                {"id": "dec:adr-007", "type": "decision",
-                 "props": {"title": "payments-api adopts internal signing"}},
-            ],
-            "edges": [
-                {"type": "depends_on", "from": "svc:payments-api", "to": "svc:auth",
-                 "valid_from": "2024-01-15", "valid_to": "2025-03-01"},
-                {"type": "decided_by", "from": "dec:adr-007", "to": "team:backend"},
-            ],
-            "aliases": {},
-        })
-        provider = FakeProvider(responses=[canned])
-    else:
-        provider = _build_provider(config)
+    provider = _make_provider(config)
 
     from lorekeep.agent import ingest_source
 
@@ -957,14 +949,14 @@ def watch(
             if raw_mtime > last_raw_mtime and last_raw_mtime > 0:
                 typer.echo(f"agent: raw/ changed ({len(raw_files)} files) — compiling...")
                 try:
-                    from pathlib import Path
-                    from lorekeep.pipeline import compile_graph
-                    from lorekeep.compile.providers import get_provider
-                    from lorekeep.defaults import default_schema
-                    schema = default_schema()
-                    provider = get_provider(p["config"])
-                    cache = p.get("cache", p["out"].parent / ".lorekeep" / "cache.json")
-                    compile_graph(raw_dir, p["out"], schema, provider, Path(cache))
+                    schema = load_schema(p["schema"])
+                    config = load_config(p["config"])
+                    provider = _make_provider(config)
+                    compile_graph(
+                        raw_root=raw_dir, out_dir=p["out"], schema=schema,
+                        provider=provider, cache_path=p["cache"],
+                        chunk_lines=config.compile.chunk_lines,
+                    )
                     typer.echo("agent: compile done")
                     compiled = True
                 except Exception as exc:

--- a/tests/test_mcp_write_tools.py
+++ b/tests/test_mcp_write_tools.py
@@ -1,0 +1,170 @@
+"""Unit tests for the 5 MCP write tools (journal-based)."""
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+import lorekeep.mcp_server as ms
+
+
+def _setup(fixtures: Path, allowed, with_pending=True):
+    d = Path(tempfile.mkdtemp())
+    shutil.copy(fixtures / "gold/payments.facts.jsonl", d / "facts.jsonl")
+    pending = d / "pending" if with_pending else None
+    if with_pending:
+        pending.mkdir()
+    ms.configure(
+        graph_dir=d,
+        allowed_ns=allowed,
+        schema_path=fixtures / "schema.json",
+        pending_dir=pending,
+    )
+    return d, pending
+
+
+def _journal_entries(pending: Path) -> list[dict]:
+    entries = []
+    for jf in sorted(pending.rglob("journal.jsonl")):
+        for line in jf.read_text().splitlines():
+            line = line.strip()
+            if line:
+                entries.append(json.loads(line))
+    return entries
+
+
+# ── propose_fact ──────────────────────────────────────────────────────────
+
+
+def test_propose_fact_writes_journal(fixtures: Path):
+    d, pending = _setup(fixtures, ["backend"])
+    fact = {
+        "kind": "node",
+        "id": "svc:new-service",
+        "type": "service",
+        "props": {"name": "new-service"},
+    }
+    r = ms.propose_fact(fact, confidence=0.9)
+    assert r["accepted"] is True
+    assert r["status"] == "pending"
+
+    entries = _journal_entries(pending)
+    assert len(entries) == 1
+    assert entries[0]["fact"]["id"] == "svc:new-service"
+    assert entries[0]["status"] == "pending"
+    assert entries[0]["confidence"] == 0.9
+
+
+def test_propose_fact_rejects_invalid_node_type(fixtures: Path):
+    _setup(fixtures, ["backend"])
+    fact = {"kind": "node", "id": "x", "type": "nonexistent", "props": {}}
+    r = ms.propose_fact(fact, confidence=0.9)
+    assert "error" in r
+
+
+def test_propose_fact_strips_caller_ns(fixtures: Path):
+    d, pending = _setup(fixtures, ["backend"])
+    fact = {
+        "kind": "node",
+        "id": "svc:stripped",
+        "type": "service",
+        "ns": ["evil"],
+        "props": {},
+    }
+    ms.propose_fact(fact, confidence=0.9)
+    entries = _journal_entries(pending)
+    assert "evil" not in entries[0]["fact"].get("ns", [])
+
+
+def test_propose_fact_without_pending_dir(fixtures: Path):
+    _setup(fixtures, ["backend"], with_pending=False)
+    fact = {"kind": "node", "id": "x", "type": "service", "props": {}}
+    r = ms.propose_fact(fact, confidence=0.9)
+    assert "error" in r
+
+
+# ── link_facts ────────────────────────────────────────────────────────────
+
+
+def test_link_facts_writes_journal(fixtures: Path):
+    d, pending = _setup(fixtures, ["backend"])
+    r = ms.link_facts("svc:payments-api", "svc:auth", "depends_on", confidence=0.85)
+    assert r["accepted"] is True
+
+    entries = _journal_entries(pending)
+    assert len(entries) == 1
+    fact = entries[0]["fact"]
+    assert fact["kind"] == "edge"
+    assert fact["from"] == "svc:payments-api"
+    assert fact["to"] == "svc:auth"
+    assert fact["type"] == "depends_on"
+
+
+def test_link_facts_rejects_unknown_from(fixtures: Path):
+    _setup(fixtures, ["backend"])
+    r = ms.link_facts("svc:nonexistent", "svc:auth", "depends_on", confidence=0.8)
+    assert "error" in r
+
+
+def test_link_facts_rejects_unknown_edge_type(fixtures: Path):
+    _setup(fixtures, ["backend"])
+    r = ms.link_facts("svc:payments-api", "svc:auth", "bogus_type", confidence=0.8)
+    assert "error" in r
+
+
+# ── flag_contradiction ───────────────────────────────────────────────────
+
+
+def test_flag_contradiction_writes_journal(fixtures: Path):
+    d, pending = _setup(fixtures, ["backend"])
+    r = ms.flag_contradiction("svc:payments-api", "svc:auth", "mutually exclusive configs")
+    assert r["accepted"] is True
+    assert "contradiction" in r["id"]
+
+    entries = _journal_entries(pending)
+    assert len(entries) == 1
+    assert entries[0]["confidence"] == 0.0
+
+
+def test_flag_contradiction_without_pending_dir(fixtures: Path):
+    _setup(fixtures, ["backend"], with_pending=False)
+    r = ms.flag_contradiction("svc:payments-api", "svc:auth", "test")
+    assert "error" in r
+
+
+# ── update_fact ───────────────────────────────────────────────────────────
+
+
+def test_update_fact_writes_journal(fixtures: Path):
+    d, pending = _setup(fixtures, ["backend"])
+    r = ms.update_fact("svc:payments-api", {"lang": "rust"}, confidence=0.8)
+    assert r["accepted"] is True
+
+    entries = _journal_entries(pending)
+    assert len(entries) == 1
+    assert entries[0]["fact"]["props"]["lang"] == "rust"
+
+
+def test_update_fact_rejects_unknown_id(fixtures: Path):
+    _setup(fixtures, ["backend"])
+    r = ms.update_fact("svc:nonexistent", {"lang": "rust"}, confidence=0.8)
+    assert "error" in r
+
+
+# ── suggest_improvement ──────────────────────────────────────────────────
+
+
+def test_suggest_improvement_writes_journal(fixtures: Path):
+    d, pending = _setup(fixtures, ["backend"])
+    r = ms.suggest_improvement("Add documentation for auth flow")
+    assert r["accepted"] is True
+    assert "suggestion" in r["id"]
+
+    entries = _journal_entries(pending)
+    assert len(entries) == 1
+    assert entries[0]["fact"]["type"] == "note"
+
+
+def test_suggest_improvement_without_pending_dir(fixtures: Path):
+    _setup(fixtures, ["backend"], with_pending=False)
+    r = ms.suggest_improvement("test suggestion")
+    assert "error" in r

--- a/tests/test_merge_journals.py
+++ b/tests/test_merge_journals.py
@@ -1,0 +1,173 @@
+"""Unit tests for merge_journals confidence gating (auto / flag / quarantine)."""
+from lorekeep.compile.resolve import merge_journals, JournalMergeResult
+from lorekeep.models import JournalEntry, Node, Edge
+
+
+def _node(id="svc:a", type="service"):
+    return Node(id=id, type=type, ns=("backend",), props={"name": id})
+
+
+def _edge(frm="svc:a", to="svc:b", etype="depends_on"):
+    return Edge(id="e1", type=etype, **{"from": frm}, to=to, ns=("backend",))
+
+
+def _entry(fact_dict, confidence, status="pending"):
+    return JournalEntry(
+        fact=fact_dict,
+        agent="test",
+        ns="backend",
+        confidence=confidence,
+        proposed_at="2026-06-28T00:00:00Z",
+        status=status,
+    )
+
+
+def _node_fact(id="svc:new", type="service", props=None):
+    return {
+        "kind": "node",
+        "id": id,
+        "type": type,
+        "ns": ["backend"],
+        "props": props or {"name": id},
+        "src": [],
+    }
+
+
+def _edge_fact(frm="svc:a", to="svc:b", etype="depends_on"):
+    return {
+        "kind": "edge",
+        "id": "",
+        "type": etype,
+        "from": frm,
+        "to": to,
+        "ns": ["backend"],
+        "props": {},
+        "src": [],
+    }
+
+
+# ── Confidence thresholds ─────────────────────────────────────────────────
+
+
+def test_high_confidence_auto_merged():
+    nodes = [_node()]
+    entry = _entry(_node_fact(id="svc:new"), confidence=0.9)
+    r = merge_journals(nodes, [], [entry])
+    assert len(r.merged) == 1
+    assert len(r.flagged) == 0
+    assert len(r.quarantined) == 0
+    assert any(n.id == "svc:new" for n in r.nodes)
+
+
+def test_medium_confidence_merged_and_flagged():
+    nodes = [_node()]
+    entry = _entry(_node_fact(id="svc:new"), confidence=0.6)
+    r = merge_journals(nodes, [], [entry])
+    assert len(r.merged) == 0
+    assert len(r.flagged) == 1
+    assert len(r.quarantined) == 0
+    assert any(n.id == "svc:new" for n in r.nodes)
+
+
+def test_low_confidence_quarantined():
+    nodes = [_node()]
+    entry = _entry(_node_fact(id="svc:new"), confidence=0.3)
+    r = merge_journals(nodes, [], [entry])
+    assert len(r.merged) == 0
+    assert len(r.flagged) == 0
+    assert len(r.quarantined) == 1
+    assert not any(n.id == "svc:new" for n in r.nodes)
+
+
+def test_boundary_08_is_auto_merged():
+    entry = _entry(_node_fact(), confidence=0.8)
+    r = merge_journals([], [], [entry])
+    assert len(r.merged) == 1
+    assert len(r.flagged) == 0
+
+
+def test_boundary_05_is_flagged():
+    entry = _entry(_node_fact(), confidence=0.5)
+    r = merge_journals([], [], [entry])
+    assert len(r.merged) == 0
+    assert len(r.flagged) == 1
+
+
+def test_just_below_05_quarantined():
+    entry = _entry(_node_fact(), confidence=0.49)
+    r = merge_journals([], [], [entry])
+    assert len(r.quarantined) == 1
+
+
+# ── Non-pending status ────────────────────────────────────────────────────
+
+
+def test_non_pending_entries_skipped():
+    entry = _entry(_node_fact(), confidence=0.9, status="merged")
+    r = merge_journals([], [], [entry])
+    assert len(r.merged) == 0
+    assert not any(n.id == "svc:new" for n in r.nodes)
+
+
+# ── Invalid schema ────────────────────────────────────────────────────────
+
+
+def test_invalid_fact_schema_quarantined():
+    bad_fact = {"kind": "node", "id": "x", "type": "service", "ns": [], "props": {}, "src": []}
+    bad_fact["valid_from"] = "not-a-date"  # fails Pydantic validation
+    entry = _entry(bad_fact, confidence=0.9)
+    r = merge_journals([], [], [entry])
+    assert len(r.quarantined) == 1
+    assert not any(n.id == "x" for n in r.nodes)
+
+
+# ── Node prop merge ───────────────────────────────────────────────────────
+
+
+def test_existing_node_props_merged():
+    nodes = [_node(id="svc:a", type="service")]
+    # Node constructor hardcodes props={"name": id}; override
+    nodes[0] = Node(id="svc:a", type="service", ns=("backend",),
+                    props={"name": "a", "lang": "go"})
+    fact = _node_fact(id="svc:a", props={"lang": "rust", "version": "2"})
+    entry = _entry(fact, confidence=0.9)
+    r = merge_journals(nodes, [], [entry])
+    merged = next(n for n in r.nodes if n.id == "svc:a")
+    assert merged.props["lang"] == "rust"
+    assert merged.props["name"] == "a"
+    assert merged.props["version"] == "2"
+
+
+# ── Edge dedup ────────────────────────────────────────────────────────────
+
+
+def test_duplicate_edges_deduplicated():
+    existing_edge = _edge()
+    new_entry = _entry(_edge_fact(), confidence=0.9)
+    r = merge_journals([], [existing_edge], [new_entry])
+    assert len(r.edges) == 1
+
+
+def test_journal_edge_gets_generated_id():
+    entry = _entry(_edge_fact(), confidence=0.9)
+    r = merge_journals([], [], [entry])
+    assert len(r.edges) == 1
+    assert r.edges[0].id != ""
+
+
+# ── Mixed batch ───────────────────────────────────────────────────────────
+
+
+def test_mixed_batch_auto_flag_quarantine():
+    entries = [
+        _entry(_node_fact(id="svc:auto"), confidence=0.9),
+        _entry(_node_fact(id="svc:flagged"), confidence=0.6),
+        _entry(_node_fact(id="svc:quarantined"), confidence=0.3),
+    ]
+    r = merge_journals([], [], entries)
+    assert len(r.merged) == 1
+    assert len(r.flagged) == 1
+    assert len(r.quarantined) == 1
+    assert r.merge_count == 1
+    assert r.flagged_count == 1
+    assert r.quarantine_count == 1

--- a/tests/test_watch_e2e.py
+++ b/tests/test_watch_e2e.py
@@ -1,0 +1,202 @@
+"""E2E tests: raw changes and pending journals become visible through MCP."""
+import json
+import os
+import shutil
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from lorekeep.cli import app, _do_auto_resolve
+import lorekeep.mcp_server as ms
+
+runner = CliRunner()
+
+
+def _bootstrap_home(tmp_path: Path):
+    """Create a minimal LOREKEEP_HOME with schema + config."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "raw").mkdir()
+    (home / "graph").mkdir()
+    (home / "pending").mkdir()
+    (home / "cache.json").write_text("{}")
+    return home
+
+
+def _set_env(home: Path):
+    return {
+        "LOREKEEP_HOME": str(home),
+        "LOREKEEP_PROVIDER": "fake",
+        "LOREKEEP_DEV": "0",
+    }
+
+
+# ── Compile → MCP visibility ──────────────────────────────────────────────
+
+
+def test_raw_change_compiled_then_visible_in_mcp(tmp_path: Path, fixtures: Path, monkeypatch):
+    """Write markdown to raw/ → compile (fake) → facts.jsonl → MCP search finds new nodes."""
+    home = _bootstrap_home(tmp_path)
+    shutil.copy(fixtures / "schema.json", home / "schema.json")
+
+    md = home / "raw" / "backend" / "svc.md"
+    md.parent.mkdir(parents=True, exist_ok=True)
+    md.write_text("# payments-api\nA go service.\n")
+
+    for k, v in _set_env(home).items():
+        monkeypatch.setenv(k, v)
+
+    result = runner.invoke(app, ["compile"])
+    assert result.exit_code == 0, result.output
+
+    facts_path = home / "graph" / "facts.jsonl"
+    assert facts_path.exists()
+
+    ms.configure(
+        graph_dir=home / "graph",
+        allowed_ns=["backend"],
+        schema_path=home / "schema.json",
+    )
+    ids = ms.search("payments")
+    assert "svc:payments-api" in ids
+
+
+# ── Pending journal → resolve → MCP visibility ────────────────────────────
+
+
+def test_pending_journal_resolved_then_visible_in_mcp(tmp_path: Path, fixtures: Path, monkeypatch):
+    """Write a journal entry → resolve → merged node visible via MCP get_node."""
+    home = _bootstrap_home(tmp_path)
+
+    shutil.copy(fixtures / "gold/payments.facts.jsonl", home / "graph" / "facts.jsonl")
+    shutil.copy(fixtures / "schema.json", home / "schema.json")
+
+    ns_dir = home / "pending" / "backend"
+    ns_dir.mkdir(parents=True)
+    entry = {
+        "agent": "test",
+        "ns": "backend",
+        "confidence": 1.0,
+        "proposed_at": "2026-06-28T00:00:00Z",
+        "status": "pending",
+        "fact": {
+            "kind": "node",
+            "id": "svc:journal-added",
+            "type": "service",
+            "ns": ["backend"],
+            "props": {"name": "journal-added"},
+            "src": [],
+        },
+    }
+    (ns_dir / "journal.jsonl").write_text(json.dumps(entry, sort_keys=True) + "\n")
+
+    _do_auto_resolve(home / "graph", home / "pending")
+
+    ms.configure(
+        graph_dir=home / "graph",
+        allowed_ns=["backend"],
+        schema_path=home / "schema.json",
+    )
+    node = ms.get_node("svc:journal-added")
+    assert "error" not in node
+    assert node["id"] == "svc:journal-added"
+
+
+# ── Standalone compile preserves pending journals (PR1 fix) ───────────────
+
+
+def test_standalone_compile_preserves_pending_journals(tmp_path: Path, fixtures: Path, monkeypatch):
+    """lorekeep compile re-merges pending journals after regenerating facts.jsonl."""
+    home = _bootstrap_home(tmp_path)
+    shutil.copy(fixtures / "schema.json", home / "schema.json")
+
+    md = home / "raw" / "backend" / "svc.md"
+    md.parent.mkdir(parents=True, exist_ok=True)
+    md.write_text("# payments-api\nA go service.\n")
+
+    ns_dir = home / "pending" / "backend"
+    ns_dir.mkdir(parents=True)
+    entry = {
+        "agent": "test",
+        "ns": "backend",
+        "confidence": 1.0,
+        "proposed_at": "2026-06-28T00:00:00Z",
+        "status": "pending",
+        "fact": {
+            "kind": "node",
+            "id": "svc:from-journal",
+            "type": "service",
+            "ns": ["backend"],
+            "props": {"name": "from-journal"},
+            "src": [],
+        },
+    }
+    (ns_dir / "journal.jsonl").write_text(json.dumps(entry, sort_keys=True) + "\n")
+
+    for k, v in _set_env(home).items():
+        monkeypatch.setenv(k, v)
+
+    result = runner.invoke(app, ["compile"])
+    assert result.exit_code == 0, result.output
+
+    facts_path = home / "graph" / "facts.jsonl"
+    lines = [json.loads(l) for l in facts_path.read_text().strip().splitlines() if l.strip()]
+    node_ids = [f["id"] for f in lines if f["kind"] == "node"]
+
+    assert "svc:payments-api" in node_ids
+    assert "svc:from-journal" in node_ids
+
+
+# ── Full loop: raw write + journal → compile + resolve → MCP ──────────────
+
+
+def test_full_loop_compile_and_resolve_visible_in_mcp(tmp_path: Path, fixtures: Path, monkeypatch):
+    """Raw markdown + pending journal → compile → both visible through MCP search."""
+    home = _bootstrap_home(tmp_path)
+    shutil.copy(fixtures / "schema.json", home / "schema.json")
+
+    md = home / "raw" / "backend" / "svc.md"
+    md.parent.mkdir(parents=True, exist_ok=True)
+    md.write_text("# payments-api\nA go service.\n")
+
+    ns_dir = home / "pending" / "backend"
+    ns_dir.mkdir(parents=True)
+    entry = {
+        "agent": "test",
+        "ns": "backend",
+        "confidence": 0.9,
+        "proposed_at": "2026-06-28T00:00:00Z",
+        "status": "pending",
+        "fact": {
+            "kind": "node",
+            "id": "svc:extra-from-journal",
+            "type": "service",
+            "ns": ["backend"],
+            "props": {"name": "extra"},
+            "src": [],
+        },
+    }
+    (ns_dir / "journal.jsonl").write_text(json.dumps(entry, sort_keys=True) + "\n")
+
+    for k, v in _set_env(home).items():
+        monkeypatch.setenv(k, v)
+
+    result = runner.invoke(app, ["compile"])
+    assert result.exit_code == 0, result.output
+
+    ms.configure(
+        graph_dir=home / "graph",
+        allowed_ns=["backend"],
+        schema_path=home / "schema.json",
+    )
+
+    ids = ms.search("payments")
+    assert "svc:payments-api" in ids
+
+    node = ms.get_node("svc:extra-from-journal")
+    assert "error" not in node
+    assert node["props"]["name"] == "extra"
+
+    journal_lines = (ns_dir / "journal.jsonl").read_text().strip().splitlines()
+    je = json.loads(journal_lines[0])
+    assert je["status"] == "merged"


### PR DESCRIPTION
## Summary

Covers issue #38 acceptance criterion 3: "tests prove raw changes and pending journals become visible through MCP."

### New test files (29 tests)

**`tests/test_mcp_write_tools.py`** (13 tests):
- All 5 MCP write tools: `propose_fact`, `link_facts`, `flag_contradiction`, `update_fact`, `suggest_improvement`
- Verifies journal is written with correct fact data + status
- Error paths: invalid node type, unknown node id, unknown edge type, missing pending dir
- Caller ns stripping (server-enforced ns)

**`tests/test_merge_journals.py`** (11 tests):
- Confidence gating at boundaries: ≥0.8 auto-merged, 0.5–0.8 flagged, <0.5 quarantined
- Non-pending entries skipped
- Invalid fact schema quarantined
- Existing node props merged correctly
- Duplicate edges deduplicated
- Journal edges get generated IDs
- Mixed batch (auto + flag + quarantine in one pass)

**`tests/test_watch_e2e.py`** (4 tests):
- Raw markdown → compile (fake) → facts visible via MCP `search`
- Pending journal → `_do_auto_resolve` → node visible via MCP `get_node`
- Standalone `lorekeep compile` preserves pending journals (validates PR #48 fix)
- Full loop: raw + journal → compile + resolve → both visible through MCP

Depends on PR #48 (includes its fix).

Closes part of #38.