### PR TITLE
docs: align docs with shipped write tools, journals, resolve, and daemon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-Lorekeep compiles a team's raw markdown docs into a **temporal knowledge graph** (`facts.jsonl`) and exposes it **read-only** to coding agents (Claude Code, Cursor, Codex) over MCP, with per-namespace permission. The defining constraint: **there is no runtime write path.** A curator compiles offline; agents only read. Knowledge is processed once at compile time, not re-RAG'd per query.
+Lorekeep compiles a team's raw markdown docs into a **temporal knowledge graph** (`facts.jsonl`) and exposes it to coding agents (Claude Code, Cursor, Codex, opencode) over MCP, with per-namespace permission. Agents read facts through 8 read tools and propose new facts through 5 journal-based write tools (confidence-gated, merged on resolve). Knowledge is processed once at compile time, not re-RAG'd per query.
 
 ## Commands
 
@@ -28,8 +28,8 @@ uv run lorekeep <command>                    # run the CLI in dev mode
 | `compile` | `raw/*.md` → `graph/facts.jsonl` + `manifest.json` (runs the LLM pipeline) |
 | `check` | Validate compiled graph loads, no dangling edges (exit 1 on failure) |
 | `eval` | Tier-1 construction P/R/F1 vs gold corpus + structure metrics |
-| `serve [--transport stdio\|http]` | Run the read-only MCP server |
-| `mcp add --agent claude\|cursor\|codex --ns NS` | Write agent MCP config (`.mcp.json`) |
+| `serve [--transport stdio\|http]` | Run the MCP server (8 read + 5 write tools) |
+| `mcp add --agent claude\|cursor\|codex\|opencode --ns NS` | Write agent MCP config |
 | `import --from claude\|cursor` | Import agent sessions into `raw/` (claude: quick+deep; cursor: deep-only) |
 | `doctor` | Verify install: graph loads, schema valid, a tool responds |
 | `backup [--init <remote-url>]` | Commit + push `.lorekeep/` to your private backup git repo |
@@ -44,7 +44,7 @@ COMPILE (offline, curator):  raw/<ns>/*.md → ingest → extract(LLM) → resol
 SERVE   (runtime, per device): facts.jsonl → GraphStore → ScopedGraph(ns) → MCP → agent
 ```
 
-These never overlap. `compile` mutates `facts.jsonl`; `serve` reads it and lazily reloads on mtime change — there is no live write API.
+`compile` mutates `facts.jsonl`; `serve` reads it and lazily reloads on mtime change. Write tools (propose_fact, link_facts, etc.) append to `pending/` journals; resolve merges them into the graph.
 
 ### Compile pipeline (`src/lorekeep/compile/`, orchestrated by `pipeline.py`)
 `ingest` chunks markdown with `path:line` provenance → `extract` calls the LLM provider for schema-constrained nodes/edges/aliases (per-chunk SHA-256 hash cache → unchanged chunks return cached output, giving byte-stable recompiles) → `resolve` collapses alias variants to canonical entities and quarantines invalid facts → `writer` emits **sorted** `facts.jsonl` + `manifest.json`. Failures are skip-and-log (partial compile is valid); errors/quarantine land in the manifest.
@@ -57,7 +57,7 @@ Pydantic, all `frozen=True`, `extra="forbid"`. `Node` / `Edge` are the two `kind
 - **`perm/ns.py` `ScopedGraph`** — the **single permission chokepoint**. Wraps a `GraphStore` and filters *every* query. Deny-by-default: `effective_ns = allowed ∪ {public}`; a node is visible iff `ns ∩ effective_ns ≠ ∅`; an edge iff **both** endpoints visible **and** `edge.ns ∩ effective_ns ≠ ∅` (an edge never leaks a neighbor the caller can't see). **Any new query path must go through `ScopedGraph`, not `GraphStore` directly.**
 
 ### Serve (`mcp_server.py`)
-`FastMCP` with 8 read-only tools (`search`, `get_node`, `neighbors`, `at_time`, `history`, `changes`, `list_namespaces`, `schema`). Module-global `ScopedGraph` is set by `configure()`; `_require()` lazy-reloads when `facts.jsonl` mtime changes (so `compile` is visible without reconnecting). Tools are plain functions registered with `@mcp.tool()` but stay directly callable — **tests invoke them directly, no MCP transport**. The writer uses atomic `os.replace` so lazy-reload never reads a half-written file.
+`FastMCP` with 8 read tools (`search`, `get_node`, `neighbors`, `at_time`, `history`, `changes`, `list_namespaces`, `schema`) and 5 write tools (`propose_fact`, `link_facts`, `flag_contradiction`, `update_fact`, `suggest_improvement`). Module-global `ScopedGraph` is set by `configure()`; `_require()` lazy-reloads when `facts.jsonl` mtime changes (so `compile` is visible without reconnecting). Tools are plain functions registered with `@mcp.tool()` but stay directly callable — **tests invoke them directly, no MCP transport**. The writer uses atomic `os.replace` so lazy-reload never reads a half-written file.
 
 ### Path resolution (`paths.py`)
 Pure (no I/O), 4-tier precedence high→low: explicit `LOREKEEP_RAW/OUT/CACHE/SCHEMA/CONFIG` env → `LOREKEEP_HOME` → **dev mode** (`.lorekeep/` present in CWD, or `LOREKEEP_DEV=1`; auto-detected in a source checkout) — all data lives under `cwd/.lorekeep/` (`config.yaml`, `schema.json`, `raw/`, `graph/`, `cache.json`), mirroring the `LOREKEEP_HOME` layout → XDG (`platformdirs`). Running `uv run lorekeep …` from the repo uses the repo's own `.lorekeep/` data home with zero migration.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center"><img src="cover.jpeg" alt="Lorekeep" /></p>
 
-**A temporal knowledge graph for AI agents, over MCP — agents read at query time, contribute at compile time (runtime write planned for phase 2).**
+**A temporal knowledge graph for AI agents, over MCP — agents read at query time and propose facts at runtime through journal-based write tools.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
@@ -37,7 +37,7 @@ knowledge.
 - **Append-and-resolve** — three write paths (raw/ compile, agent ingest,
   import sessions) converge into one resolve step. Journals are append-only;
   resolve is pure logic, zero LLM cost.
-- **Agent-driven knowledge** [planned] — agents propose facts at runtime via MCP write
+- **Agent-driven knowledge** — agents propose facts at runtime via MCP write
   tools at **zero marginal LLM cost**. Confidence-gated: high-confidence
   auto-merge, low-confidence quarantine.
 - **File-sovereign** — `facts.jsonl` (one fact per line, sorted) is the single
@@ -47,8 +47,8 @@ knowledge.
 - **Namespace permission** — facts are tagged `ns` from the directory tree
   (`raw/<ns>/`); agents scoped to namespaces; cross-namespace edges
   hidden unless both endpoints are visible. Deny-by-default.
-- **MCP, stdio-first** — `lorekeep serve` exposes 8 read tools (5 write tools planned);
-  `lorekeep mcp add` wires Claude Code / Cursor / Codex.
+- **MCP, stdio-first** — `lorekeep serve` exposes 8 read + 5 write tools;
+  `lorekeep mcp add` wires Claude Code / Cursor / Codex / opencode.
 - **Autonomous agent daemon** — `lorekeep agent watch` keeps the graph current:
   auto-compile on raw/ change, auto-resolve pending journals, delta import of
   agent session memory. Runs in the background; MCP server lazy-reloads.
@@ -90,7 +90,7 @@ uvx lorekeep mcp add --agent claude --ns backend
 uvx lorekeep doctor
 ```
 
-Restart Claude Code → 8 Lorekeep read tools are available, scoped to your namespace.
+Restart Claude Code → 13 Lorekeep tools are available (8 read + 5 write), scoped to your namespace.
 
 ## Lifecycle
 
@@ -118,7 +118,7 @@ The full journey from install to continuous use — see the
 | 3. Compile | `lorekeep compile` | LLM-extract facts → `facts.jsonl` (cached, deterministic) |
 | 4. Wire agent | `lorekeep mcp add --agent claude --ns <ns>` | Write `.mcp.json`, scoped to namespace |
 | 5. Verify | `lorekeep doctor` | Graph loads, schema valid, tool responds |
-| 6. Serve | `lorekeep serve` | MCP server (read-only, 8 tools, lazy-reload) |
+| 6. Serve | `lorekeep serve` | MCP server (8 read + 5 write tools, lazy-reload) |
 | 7. Keep current | `lorekeep agent watch &` | Daemon: auto-compile, auto-resolve, delta-import sessions |
 | 8. Back up | `lorekeep backup` | Push data home to private git repo (raw/ + schema.json) |
 
@@ -132,7 +132,7 @@ updates. Step 8 syncs across machines.
                ════════════════
 raw/<ns>/*.md ──► ingest ──► extract(LLM) ──┐
                                             │
-agent propose ──► MCP write tools ──► ──────┤  [planned phase 2]
+agent propose ──► MCP write tools ──► ──────┤
   (ZERO LLM cost, journal append)           │
                                             ├──► resolve ──► writer ──► facts.jsonl
 import ──► raw/ ──► compile ────────────────┘    (pure logic,          │
@@ -143,7 +143,7 @@ import ──► raw/ ──► compile ─────────────�
 facts.jsonl ──load──► GraphStore ──► ScopedGraph(ns) ──► MCP ──► agent
                          ▲              ▲                      │
                          │              │         ◄── read queries
-                          │              └────────── write proposals (journal) [planned]
+                           │              └────────── write proposals (journal)
                          └── lazy-reload on mtime change
 
                AUTONOMOUS AGENT DAEMON
@@ -153,12 +153,12 @@ facts.jsonl ──load──► GraphStore ──► ScopedGraph(ns) ──► M
                  └── watch Claude memory/ → delta import → raw/
 ```
 
-**Three write paths → one resolve**: markdown is compiled by an LLM (chunked + cached); agents will propose facts at runtime through MCP write tools at **zero marginal LLM cost** (the agent already ran the LLM for the conversation) — **planned for phase 2**; agent sessions are imported into raw/. All converge at `resolve` — pure Python logic that merges, deduplicates, validates, and writes byte-stable `facts.jsonl`.
+**Three write paths → one resolve**: markdown is compiled by an LLM (chunked + cached); agents propose facts at runtime through MCP write tools at **zero marginal LLM cost** (the agent already ran the LLM for the conversation); agent sessions are imported into raw/. All converge at `resolve` — pure Python logic that merges, deduplicates, validates, and writes byte-stable `facts.jsonl`.
 
 **Serve**: `GraphStore` loads `facts.jsonl` into a networkx graph with temporal
 queries. `ScopedGraph` is the single permission chokepoint — every query is
-filtered through strict visibility rules. The FastMCP server exposes 8 read tools
-(5 write tools planned for phase 2) over `ScopedGraph`. It lazy-reloads when
+filtered through strict visibility rules. The FastMCP server exposes 8 read
++ 5 write tools over `ScopedGraph`. It lazy-reloads when
 `facts.jsonl` changes, so `compile` is instantly visible without reconnecting.
 
 ## Concepts
@@ -181,17 +181,17 @@ neighbor the caller can't see.
 `[from,to)`), `history(id)` (versions of an entity), `changes(t1,t2)` (edges
 that began/ended in the window).
 
-**Agent-driven knowledge** [planned] — agents will propose facts at runtime through MCP write tools (zero LLM cost). Facts land in `pending/<ns>/journal.jsonl` with agent id, confidence score, and timestamp. Resolve merges them into the graph: high-confidence (≥0.8) auto-merge, medium (0.5-0.8) merge + flag, low (<0.5) quarantine.
+**Agent-driven knowledge** — agents propose facts at runtime through MCP write tools (zero LLM cost). Facts land in `pending/<ns>/journal.jsonl` with agent id, confidence score, and timestamp. Resolve merges them into the graph: high-confidence (≥0.8) auto-merge, medium (0.5-0.8) merge + flag, low (<0.5) quarantine.
 
 **Autonomous agent daemon** — `lorekeep agent watch` keeps the graph current: watches `raw/` for changes → auto-compile; monitors `pending/` → auto-resolve; delta-imports Claude session memory into `raw/`. Scheduled lint and weekly suggestions are planned. See [docs/architecture/agent.md](docs/architecture/agent.md).
 
-## MCP tools (8 read, scoped; 5 write planned)
+## MCP tools (8 read + 5 write, scoped)
 
 **Read:** `search` · `get_node` · `neighbors` · `at_time` · `history` · `changes` · `list_namespaces` · `schema`.
 
-**Write** (journal-based, zero LLM cost, planned phase 2): `propose_fact` · `link_facts` · `flag_contradiction` · `update_fact` · `suggest_improvement`.
+**Write** (journal-based, zero LLM cost): `propose_fact` · `link_facts` · `flag_contradiction` · `update_fact` · `suggest_improvement`.
 
-Every result is filtered to the caller's namespace. Write tools will append to `pending/` journals; facts enter the graph on the next resolve pass.
+Every result is filtered to the caller's namespace. Write tools append to `pending/` journals; facts enter the graph on the next resolve pass.
 
 ## Configuration
 
@@ -246,7 +246,7 @@ src/lorekeep/
   agent.py             autonomous agent: ingest, lint, suggest, status, watch
   store/{graph,fts}.py                          GraphStore + optional FTS cache
   perm/ns.py                                    ScopedGraph permission chokepoint
-  mcp_server.py                                 FastMCP + 8 read tools (5 write planned)
+  mcp_server.py                                 FastMCP + 8 read + 5 write tools
   integrations/{claude_code,cursor,codex,common}.py
   pipeline.py, cli.py
   eval/{gold,construction,retrieval}.py
@@ -258,7 +258,7 @@ docs/                  README.md index, architecture/, guides/
 
 **v1 (implemented)** — compile pipeline + serve (store/permission/MCP read/integrations) + import + agent daemon (watch/ingest/lint/suggest/status) + journal + resolve + data-home + dev mode + lazy-reload + backup + eval. Published to PyPI as `lorekeep`.
 
-**Phase 2 (planned)** — MCP write tools (runtime fact proposals via `propose_fact`, `link_facts`, etc.) + `wiki.md` views (Obsidian-compatible markdown output), streamable-HTTP team server, OIDC/SSO, embeddings/hybrid search, scheduled nightly lint/suggest in daemon, schema evolve, full Tier-2 benchmark datasets (HotpotQA/CronQuestions) and the bespoke Tier-3 Lorekeep-Reason eval.
+**Phase 2 (planned)** — `wiki.md` views (Obsidian-compatible markdown output), streamable-HTTP team server, OIDC/SSO, embeddings/hybrid search, scheduled nightly lint/suggest in daemon, schema evolve, full Tier-2 benchmark datasets (HotpotQA/CronQuestions) and the bespoke Tier-3 Lorekeep-Reason eval.
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,16 @@
 # Security policy — Lorekeep
 
 Lorekeep compiles team documents into a temporal knowledge graph and serves it
-read-only to AI coding agents over MCP. This document describes the threat
+to AI coding agents over MCP. This document describes the threat
 model and the configuration decisions that keep a deployment safe.
 
 ## Trust model
 
-- **Compile-only, single writer.** The graph (`graph/facts.jsonl`) is produced by
-  `lorekeep compile` and never mutated by the server. Agents read via MCP; there is
-  no write API. No concurrency control is needed because readers are read-only.
+- **Compile + journal-based writes.** The graph (`graph/facts.jsonl`) is produced by
+  `lorekeep compile` and never mutated directly by the server. Agents read via MCP
+  and propose facts through journal-based write tools that append to `pending/` —
+  facts enter the graph only after a resolve pass (confidence-gated). No concurrency
+  control is needed on the read path because `facts.jsonl` is replaced atomically.
 - **Per-process namespace scope.** An MCP server's visible data is fixed at startup
   by `LOREKEEP_NS` (comma-separated namespaces). Visibility is enforced by a single
   chokepoint, `ScopedGraph` (`src/lorekeep/perm/ns.py`), applied to **every** query.

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -13,7 +13,7 @@ lorekeep/
 │   ├── facts.jsonl             # THE store: nodes + edges + temporal + ns, 1 fact/line
 │   ├── manifest.json           # provenance: raw→fact map, chunk hashes, run id, errors, quarantine
 │   └── schema.json             # node/edge type definitions
-├── pending/                    # agent-proposed facts (planned phase 2)
+├── pending/                    # agent-proposed facts (journals)
 │   ├── <ns>/journal.jsonl      # per-namespace append-only journal
 │   └── <agent>/journal.jsonl   # per-agent append-only journal
 ├── .lorekeep/                  # LOCAL only (gitignored)
@@ -23,8 +23,8 @@ lorekeep/
     ├── compile/{ingest,extract,resolve,writer}.py
     ├── store/{graph,fts}.py
     ├── perm/ns.py
-    ├── journal.py              # journal append + load [planned phase 2]
-    ├── agent.py                # autonomous agent CLI [planned phase 2]
+    ├── journal.py              # journal append + load
+    ├── agent.py                # autonomous agent CLI
     ├── integrations/{claude_code,cursor,codex}.py
     ├── mcp_server.py
     └── cli.py
@@ -96,8 +96,8 @@ Each component has one responsibility, a clear input/output interface, and is te
 | `compile/extract` | chunk + schema | candidate facts | **The compiler.** LLM-driven, provider-pluggable. Constrained to `schema.json`. Idempotent per chunk via hash cache. |
 | `compile/resolve` | candidate facts + journals | clean facts | Entity dedup (alias → canonical id), validate edge endpoints exist, enforce ns-consistency, quarantine malformed facts. Merges from three sources (raw/ > import > agent-propose). |
 | `compile/writer` | clean facts | `facts.jsonl` + `manifest.json` | **Deterministic emit**: facts sorted by `(kind, type, id)`, sorted JSON keys, stable formatting ⇒ byte-identical output for unchanged input ⇒ clean git diffs. |
-| `journal` [planned] | fact + agent + confidence | append to `pending/` journal | Append-only JSONL writer. Agent-proposed facts land here before resolve. |
-| `agent` [planned] | — | — | Daemon: watch raw/ → auto-compile, periodic resolve, nightly lint, auto-import, suggest. CLI: `agent lint`, `agent ingest`, `agent evolve`. |
+| `journal` | fact + agent + confidence | append to `pending/` journal | Append-only JSONL writer. Agent-proposed facts land here before resolve. |
+| `agent` | — | — | Daemon: watch raw/ → auto-compile, periodic resolve, nightly lint, auto-import, suggest. CLI: `agent lint`, `agent ingest`, `agent evolve`. |
 | `store/graph` | `facts.jsonl` | networkx `MultiDiGraph` (temporal) | Load + query API: `get_node`, `neighbors`, `snapshot`, `history`, `changes`. Pure functions; no I/O after load. |
 | `perm/ns` | `allowed_ns` (set) | filter / guard | **Single permission chokepoint.** Every store query passes through here. |
 | `store/fts` (optional) | `facts.jsonl` | FTS cache | FTS5 over node text/props for text search. Local, gitignored, rebuilt from `facts.jsonl`. Falls back to in-memory scan if absent. |

--- a/docs/architecture/journal.md
+++ b/docs/architecture/journal.md
@@ -1,7 +1,5 @@
 # Journal: agent-driven knowledge accumulation
 
-> **Status: planned (phase 2).** The journal system, MCP write tools, and periodic resolve described here are target architecture. Current v1 is compile-only with 8 read-only MCP tools. Implementation tracked in [#15](https://github.com/manhhailua/lorekeep/issues/15).
-
 The journal is the mechanism by which coding agents contribute knowledge to Lorekeep **at runtime, at zero marginal LLM cost**. Agents propose facts during conversation; the journal captures them as append-only JSONL; a periodic resolve pass merges validated facts into `facts.jsonl`.
 
 ## Why journals?

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -8,7 +8,7 @@ Lorekeep builds a **living temporal knowledge graph** that coding agents both **
 2. **Strictly file-based storage** (`facts.jsonl` + `pending/` journals), for privacy and portability.
 3. **Namespace-scoped permission**, for team-level use rather than a single local user.
 
-The system is **compile-only in v1, append-and-resolve in phase 2**: raw docs are compiled offline; agents will propose facts at runtime through a journal; a periodic resolve pass merges all sources into `facts.jsonl` without additional LLM calls. This keeps the graph continuously up-to-date while strictly controlling API cost. The target architecture is described in this document; v1 status is noted throughout.
+The system has two phases: **compile** (offline, curator-side) and **serve** (runtime, per device). Raw docs are compiled offline; agents propose facts at runtime through journal-based write tools; a periodic resolve pass merges all sources into `facts.jsonl` without additional LLM calls. This keeps the graph continuously up-to-date while strictly controlling API cost.
 
 ## North star
 
@@ -57,7 +57,7 @@ Lorekeep exists to let an agent reason about a domain **systematically and with 
     │            ◄── MCP write tools (journal)    │
     └───────────────────────────────────────────┘
 
-                    AUTONOMOUS AGENT (daemon) [planned phase 2]
+                    AUTONOMOUS AGENT (daemon)
                     ═════════════════════════════════════════
 
     lorekeep agent watch:

--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -42,11 +42,9 @@ raw/<ns>/*.md ──► ingest ──► extract(LLM) ──► candidate facts 
 
 `raw/` is populated by hand or by `lorekeep import`, which converts a coding agent's sessions (Claude Code, Cursor) into markdown; see the [import guide](../guides/import.md).
 
-## Path 2: agent propose (runtime, zero LLM cost) [planned]
+## Path 2: agent propose (runtime, zero LLM cost)
 
-> **Status: planned (phase 2).** MCP write tools and journal-based agent proposals are target architecture. Current v1 has no runtime write path. See [#15](https://github.com/manhhailua/lorekeep/issues/15).
-
-Coding agents will propose facts during conversation through MCP write tools. Each proposal is appended to `pending/<ns>/journal.jsonl` as a journal entry.
+Coding agents propose facts during conversation through MCP write tools. Each proposal is appended to `pending/<ns>/journal.jsonl` as a journal entry.
 
 ```python
 # Agent-side (Claude Code): agent discovers checkout service during conversation

--- a/docs/architecture/serve-mcp.md
+++ b/docs/architecture/serve-mcp.md
@@ -27,11 +27,9 @@ The serve chain loads `facts.jsonl` once and exposes it to coding agents over MC
 
 Every read tool is auto-scoped by `allowed_ns`. See [permission](permission.md) and [temporal](temporal.md) for the filtering these tools apply.
 
-## Write tools (5 tools, journal-based) [planned]
+## Write tools (5 tools, journal-based)
 
-> **Status: planned (phase 2).** These 5 write tools are target architecture. Current v1 exposes only the 8 read tools above. Implementation tracked in [#15](https://github.com/manhhailua/lorekeep/issues/15).
-
-Write tools **will not mutate** `facts.jsonl` directly. They will append to `pending/<ns>/journal.jsonl`. Facts become visible after the next resolve pass (see [pipeline](pipeline.md)).
+Write tools **do not mutate** `facts.jsonl` directly. They append to `pending/<ns>/journal.jsonl`. Facts become visible after the next resolve pass (see [pipeline](pipeline.md)).
 
 | Tool | Purpose | Confidence |
 |---|---|---|
@@ -86,7 +84,7 @@ MCP server lazy-reloads on next query → fact is now searchable
 
 ## Coding-agent integration
 
-`lorekeep mcp add --agent {claude|cursor|codex} [--scope project|user] [--ns <ns>]` writes the correct config and prints an agent-memory snippet to paste into `CLAUDE.md` / `.cursorrules` / `AGENTS.md`.
+`lorekeep mcp add --agent {claude|cursor|codex|opencode} [--scope project|user] [--ns <ns>]` writes the correct config and prints an agent-memory snippet to paste into `CLAUDE.md` / `.cursorrules` / `AGENTS.md`.
 
 > **Install source.** The snippets use `uvx lorekeep`, which assumes the package is on PyPI. `mcp add` detects `install_source` from `.lorekeep/config.yaml` so the emitted config matches the deployment (PyPI `uvx`, `git+https`, or a local `uv tool install .`).
 

--- a/docs/guides/compile.md
+++ b/docs/guides/compile.md
@@ -42,9 +42,7 @@ unchanged input yields a byte-identical file (extraction is cached under
 **What compile does not do:** compile processes only `raw/`. Agent-proposed
 facts in `pending/` journals are merged by `resolve` (see step 5).
 
-## 4. Resolve pending facts (manual) [planned]
-
-> **Planned for phase 2.** Resolve and daemon commands are not yet available. See [#15](https://github.com/manhhailua/lorekeep/issues/15).
+## 4. Resolve pending facts (manual)
 
 ```bash
 uv run lorekeep resolve
@@ -57,7 +55,7 @@ with review flag, low (<0.5) quarantine.
 Resolve also runs automatically: the daemon (`lorekeep agent watch`) resolves
 every 5 minutes or after 50 pending entries.
 
-## 5. Full pipeline (compile + resolve) [planned]
+## 5. Full pipeline (compile + resolve)
 
 ```bash
 uv run lorekeep compile && uv run lorekeep resolve
@@ -66,7 +64,7 @@ uv run lorekeep compile && uv run lorekeep resolve
 Or let the daemon handle it:
 
 ```bash
-uv run lorekeep agent watch    # watches raw/ + pending/ → auto-compile + resolve [planned]
+uv run lorekeep agent watch    # watches raw/ + pending/ → auto-compile + resolve
 ```
 
 ## 6. Evaluate construction quality
@@ -88,12 +86,12 @@ uv run lorekeep check
 
 Exits non-zero if the graph has dangling edges.
 
-## How agents contribute knowledge [planned]
+## How agents contribute knowledge
 
-Agents will propose facts at runtime through MCP write tools (see [serve.md](serve.md)).
+Agents propose facts at runtime through MCP write tools (see [serve.md](serve.md)).
 These are appended to `pending/<ns>/journal.jsonl` at **zero LLM cost** — the
 agent already ran the LLM for the conversation. Facts become searchable after
-the next resolve. **Write tools and resolve are planned for phase 2.**
+the next resolve.
 
 ## Next: serve to agents
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -132,8 +132,10 @@ uvx lorekeep mcp add --agent opencode --ns backend
 
 Supported agents: `claude`, `cursor`, `codex`, `opencode`.
 
-Restart the agent → the 8 read-only Lorekeep tools (`search`, `get_node`,
-`neighbors`, `at_time`, `history`, `changes`, `list_namespaces`, `schema`) are
+Restart the agent → the 13 Lorekeep tools (8 read: `search`, `get_node`,
+`neighbors`, `at_time`, `history`, `changes`, `list_namespaces`, `schema`;
+5 write: `propose_fact`, `link_facts`, `flag_contradiction`, `update_fact`,
+`suggest_improvement`) are
 available, scoped to `backend` (+ `public`). See
 [Serving the graph](serve.md).
 

--- a/docs/guides/serve.md
+++ b/docs/guides/serve.md
@@ -48,12 +48,10 @@ LOREKEEP_HOME=~/kb-work uvx lorekeep compile
 `list_namespaces`, `schema`. Results are filtered to `LOREKEEP_NS`; cross-namespace
 edges are hidden unless both endpoints are visible.
 
-## Write tools (5 tools, journal-based) [planned]
+## Write tools (5 tools, journal-based)
 
-> **Planned for phase 2.** These write tools are not yet available. Current v1 exposes 8 read tools. See [#15](https://github.com/manhhailua/lorekeep/issues/15).
-
-When implemented, agents will contribute knowledge during conversation at **zero LLM cost**. Facts
-will be appended to `pending/` journals and merged into the graph on the next
+Agents contribute knowledge during conversation at **zero LLM cost**. Facts
+are appended to `pending/` journals and merged into the graph on the next
 resolve pass.
 
 | Tool | Purpose | Confidence |


### PR DESCRIPTION
## Summary

Covers issue #38 acceptance criterion 2: "Docs accurately describe MCP write tools, journals, resolve, and daemon status."

### What changed

Removed `[planned]` / `[planned phase 2]` markers from features that are **already shipped**:

- **5 MCP write tools** (`propose_fact`, `link_facts`, `flag_contradiction`, `update_fact`, `suggest_improvement`) — live in `mcp_server.py`
- **Journal system** (`journal.py`) — append-only writer + loader
- **Resolve pass** (`compile/resolve.py:merge_journals`) — confidence-gated merge
- **Autonomous agent daemon** (`lorekeep agent watch`) — auto-compile, auto-resolve, session import

### Files updated (11)

| File | Changes |
|---|---|
| `README.md` | Tool counts (8 read-only → 8 read + 5 write), removed "planned for phase 2" from features, status section, project layout |
| `AGENTS.md` | "read-only" → "8 read + 5 write", removed "no runtime write path" claim, added opencode to agents list, serve section |
| `SECURITY.md` | Trust model: "compile-only, single writer" → "compile + journal-based writes" |
| `docs/architecture/serve-mcp.md` | Removed `[planned]` status block from write tools section |
| `docs/architecture/journal.md` | Removed `[planned]` status banner |
| `docs/architecture/pipeline.md` | Removed `[planned]` from Path 2 heading + status block |
| `docs/architecture/overview.md` | Removed `[planned phase 2]` from daemon diagram, updated phase description |
| `docs/architecture/data-model.md` | Removed `[planned]` from journal.py, agent.py, and component table |
| `docs/guides/compile.md` | Removed `[planned]` from resolve, full pipeline, and agent-contributed sections |
| `docs/guides/serve.md` | Removed `[planned]` from write tools section |
| `docs/guides/getting-started.md` | "8 read-only tools" → "13 tools (8 read + 5 write)" |

Genuinely unimplemented features remain marked as planned: `agent evolve`, `--auto-fix`, scheduled nightly lint/suggest, retry-queue.

Closes part of #38.