### PR TITLE
chore: sync uv.lock to v0.2.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "lorekeep"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
release-please bumps pyproject.toml version but doesn't run uv sync, so uv.lock was stale at 0.1.3. This caused every `uv run` to regenerate the lock, creating noise in diffs.