### PR TITLE
fix: resolve doc contradictions and false cadence claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ import ──► raw/ ──► compile ─────────────�
                SERVE + QUERY (runtime, per device)
 facts.jsonl ──load──► GraphStore ──► ScopedGraph(ns) ──► MCP ──► agent
                          ▲              ▲                      │
-                         │              │         ◄── read queries
-                           │              └────────── write proposals (journal)
+                          │              │         ◄── read queries
+                          │              └────────── write proposals (journal)
                          └── lazy-reload on mtime change
 
                AUTONOMOUS AGENT DAEMON

--- a/docs/guides/compile.md
+++ b/docs/guides/compile.md
@@ -52,8 +52,8 @@ Merges all pending agent-proposed facts from `pending/` journals into `facts.jso
 Facts are gated by confidence: high (≥0.8) auto-merge, medium (0.5-0.8) merge
 with review flag, low (<0.5) quarantine.
 
-Resolve also runs automatically: the daemon (`lorekeep agent watch`) resolves
-every 5 minutes or after 50 pending entries.
+Resolve also runs automatically: the daemon (`lorekeep agent watch`) detects
+new pending entries on every poll cycle (default 60s interval).
 
 ## 5. Full pipeline (compile + resolve)
 

--- a/docs/guides/serve.md
+++ b/docs/guides/serve.md
@@ -67,8 +67,9 @@ resolve pass.
 - 0.5-0.8: implied without explicit source. "Based on the architecture, X likely depends on Y."
 - < 0.5: speculation — these are quarantined, not merged.
 
-Facts become visible after the next resolve pass (every 5 min or 50 pending
-entries when daemon is running; or run `lorekeep resolve` manually). **Note: resolve and daemon are planned for phase 2.**
+Facts become visible after the next resolve pass (run `lorekeep resolve`
+manually; or automatically when `lorekeep agent watch` detects new pending
+entries, polling every 60s).
 
 ## Keeping the graph current
 


### PR DESCRIPTION
Follow-up to #50. Review caught 3 issues:

1. **[Medium] serve.md:70-71** — leftover 'planned for phase 2' note directly contradicted the shipped write tools section above it in the same file. Also claimed daemon resolves 'every 5 min or 50 entries' — actual behavior is event-driven (polls pending/ mtime every 60s default).

2. **[Low] compile.md:55-56** — same false cadence claim.

3. **[Low] README.md:146** — ASCII diagram misaligned by extra leading space introduced in #50.