### PR TITLE
fix: add manifest dedup to deep-mode session import

### DIFF
--- a/src/lorekeep/importer/claude.py
+++ b/src/lorekeep/importer/claude.py
@@ -342,6 +342,17 @@ def import_session_deep(
 
     jsonl = transcripts[0]
     session_id = session_dir.name
+
+    # Dedup: skip if transcript content unchanged since last import
+    transcript_hash = hashlib.sha256(
+        jsonl.read_bytes()
+    ).hexdigest()
+    manifest = load_import_manifest(raw_root, namespace)
+    manifest_key = str(jsonl)
+
+    if not dry_run and manifest.get(manifest_key) == transcript_hash:
+        return []
+
     turns = parse_transcript(jsonl)
     if not turns:
         return []
@@ -373,6 +384,10 @@ def import_session_deep(
         dest.write_text(md, encoding="utf-8")
         previous_summary = md[:1000]   # carry short context forward
         written.append(dest)
+
+    if not dry_run and written:
+        manifest[manifest_key] = transcript_hash
+        save_import_manifest(raw_root, namespace, manifest)
 
     return written
 

--- a/tests/test_import_claude.py
+++ b/tests/test_import_claude.py
@@ -193,6 +193,61 @@ def test_import_session_deep_handles_empty_transcript(tmp_path: Path):
     assert result == []
 
 
+def test_import_session_deep_is_idempotent(tmp_path: Path, fixtures: Path):
+    """Re-importing the same transcript skips LLM summarization."""
+    session_dir = fixtures / "claude-session"
+    raw_root = tmp_path / "raw"
+    provider = FakeProvider(responses=["# Summary\n\n## Decisions\n- Use FastAPI\n"] * 50)
+
+    first = import_session_deep(session_dir, raw_root, namespace="test-session",
+                                provider=provider)
+    assert len(first) >= 1
+    assert len(provider.calls) >= 1
+
+    # Second call: same transcript, should skip entirely
+    call_before = len(provider.calls)
+    second = import_session_deep(session_dir, raw_root, namespace="test-session",
+                                 provider=provider)
+    assert second == []
+    assert len(provider.calls) == call_before  # no new LLM calls
+
+
+def test_import_session_deep_re_imports_on_change(tmp_path: Path):
+    """Transcript changed → re-import triggers LLM call."""
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    transcript = session_dir / "sess.jsonl"
+    transcript.write_text('{"role":"user","message":{"content":"what is FastAPI?"}}\n'
+                          '{"role":"assistant","message":{"content":[{"type":"text","text":"a web framework"}]}}\n')
+
+    raw_root = tmp_path / "raw"
+    provider = FakeProvider(responses=["# Summary\n\n## Decisions\n- Use FastAPI\n"] * 50)
+
+    first = import_session_deep(session_dir, raw_root, namespace="ns", provider=provider)
+    assert len(first) >= 1
+
+    # Modify transcript
+    transcript.write_text('{"role":"user","message":{"content":"what is Flask?"}}\n'
+                          '{"role":"assistant","message":{"content":[{"type":"text","text":"a web framework"}]}}\n')
+
+    call_before = len(provider.calls)
+    second = import_session_deep(session_dir, raw_root, namespace="ns", provider=provider)
+    assert len(second) >= 1
+    assert len(provider.calls) > call_before  # LLM called again
+
+
+def test_import_session_deep_dry_run_skips_manifest(tmp_path: Path, fixtures: Path):
+    """Dry run should not write manifest (so real import still processes)."""
+    session_dir = fixtures / "claude-session"
+    raw_root = tmp_path / "raw"
+    provider = FakeProvider(responses=["dummy"] * 50)
+
+    import_session_deep(session_dir, raw_root, namespace="ns",
+                        provider=provider, dry_run=True)
+    manifest_path = raw_root / "ns" / ".import-manifest.json"
+    assert not manifest_path.exists()
+
+
 # ---------------------------------------------------------------------------
 # orchestrator
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`import_session_deep` re-summarized the transcript via LLM on every call. The quick path (`import_memories`) was already idempotent via SHA-256 manifest, but the deep path was not.

### Fix

Compute SHA-256 of transcript content before processing. If hash matches the manifest, skip entirely (return `[]`, zero LLM calls). Manifest updated only after successful batch writes. Dry-run bypasses manifest.

Uses existing `load_import_manifest` / `save_import_manifest` infrastructure — same pattern as `import_memories`.

### Tests (3 new, 238 total)

- `test_import_session_deep_is_idempotent` — re-import same transcript → no LLM calls
- `test_import_session_deep_re_imports_on_change` — modify transcript → LLM called again
- `test_import_session_deep_dry_run_skips_manifest` — dry-run doesn't write manifest

Closes #58.