### PR TITLE
refactor: remove fake provider from production code, test-only injection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ uv run lorekeep <command>                    # run the CLI in dev mode
 | `backup [--init <remote-url>]` | Commit + push `.lorekeep/` to your private backup git repo |
 | `version` | Print version |
 
-**Offline / no-LLM mode:** set `LOREKEEP_PROVIDER=fake` to make `compile` and `import` use `FakeProvider` with canned responses. **All CLI/compile/import tests use this** — no API key or real model required.
+**Offline / no-LLM mode:** tests inject `FakeProvider` via monkeypatch (`patch_make_provider` / `patch_make_import_provider` fixtures in `conftest.py`). **All CLI/compile/import tests use this** — no API key or real model required.
 
 ## Architecture: two strictly separated phases
 
@@ -83,7 +83,7 @@ Pure (no I/O), 4-tier precedence high→low: explicit `LOREKEEP_RAW/OUT/CACHE/SC
 
 ## Tests
 
-`~140` tests, no network. Gold corpus in `tests/fixtures/gold/`, raw fixtures in `tests/fixtures/raw/`. Compile/serve/import tests set `LOREKEEP_*` env vars and `LOREKEEP_PROVIDER=fake` to pin paths and avoid the LLM — follow this pattern for any new CLI test rather than hitting a real provider.
+`~140` tests, no network. Gold corpus in `tests/fixtures/gold/`, raw fixtures in `tests/fixtures/raw/`. Compile/serve/import tests inject `FakeProvider` via `patch_make_provider` / `patch_make_import_provider` conftest fixtures to pin paths and avoid the LLM — follow this pattern for any new CLI test rather than hitting a real provider.
 
 ## Cursor Cloud specific instructions
 
@@ -91,7 +91,7 @@ The startup update script already runs `uv sync`; the toolchain (Python 3.11+ vi
 
 Non-obvious caveats for running/testing here:
 
-- **No API key needed for any dev work.** Export `LOREKEEP_PROVIDER=fake` to run `compile`/`import` and the full end-to-end flow offline with `FakeProvider` (canned facts). To avoid polluting the repo's `.lorekeep/` data home, run demos against a throwaway data home: `LOREKEEP_HOME=/tmp/lk uv run lorekeep <cmd>`.
+- **No API key needed for tests.** Tests inject `FakeProvider` via `patch_make_provider` / `patch_make_import_provider` conftest fixtures. For manual smoke testing, configure a real provider in `config.yaml`. To avoid polluting the repo's `.lorekeep/` data home, run demos against a throwaway data home: `LOREKEEP_HOME=/tmp/lk uv run lorekeep <cmd>`.
 - **End-to-end smoke flow** (offline): `init` → drop a markdown file under `.lorekeep/raw/<ns>/` → `compile` → `check`/`doctor`. Then query the graph by calling the `mcp_server.py` tools directly after `ms.configure(graph_dir=..., allowed_ns=[...], schema_path=...)` — the read tools (`search`, `get_node`, `neighbors`, `at_time`, `history`, `list_namespaces`) are plain functions, no MCP transport required. `search` returns a list of node-id strings; `get_node` returns a dict; `neighbors`/`at_time`/`changes` return `{"nodes": [...], "edges": [...]}`.
 - **`lorekeep serve` blocks on stdio** waiting for an MCP client — it won't return on its own. To just confirm it boots, run it under `timeout` with stdin closed (`timeout 3 uv run lorekeep serve --transport stdio </dev/null`); a clean timeout with no error output means success.
 - **`tests/test_mcp_reload.py::test_lazy_reload_on_facts_change` is timing-flaky** — lazy-reload triggers off `facts.jsonl` mtime, and the test can rewrite the file within one mtime tick on fast filesystems, so it intermittently fails then passes on re-run. Treat an isolated failure of just this test as a flake, not a regression.

--- a/docs/architecture/evaluation.md
+++ b/docs/architecture/evaluation.md
@@ -13,7 +13,7 @@
 - **Golden tests:** snapshot `facts.jsonl` for a fixture corpus; diffs catch regressions.
 - Compile-only ⇒ no concurrency to test.
 
-All compile/serve/import tests set `LOREKEEP_PROVIDER=fake` to avoid a real LLM — no API key required.
+All compile/serve/import tests inject `FakeProvider` via monkeypatch to avoid a real LLM — no API key required.
 
 ## Evaluation
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -108,8 +108,9 @@ provider:
 Prefer an env var instead? Set `api_key_env: DEEPSEEK_API_KEY` (and
 `api_key: null`), then `export DEEPSEEK_API_KEY=sk-...`. Both work.
 
-> **Offline / no key?** `export LOREKEEP_PROVIDER=fake` makes `compile` use a
-> canned response — enough to try the rest of the flow with zero API cost.
+> **No provider yet?** `init` wires agents and imports memory files
+> regardless. Compile is skipped until you add an API key — the graph
+> will be empty but the MCP tools are wired and ready.
 
 ## 5. Compile
 
@@ -188,8 +189,7 @@ recovery — is in [Backing up the data home](backup.md).
 - **`lorekeep serve` hangs** — it blocks on stdio waiting for an MCP client.
   To just confirm it boots, run it under a timeout with stdin closed:
   `timeout 3 uvx lorekeep serve --transport stdio </dev/null`.
-- **Compile gave 0 nodes** — the provider wasn't reached. Either
-  `export LOREKEEP_PROVIDER=fake` for an offline test, or check
+- **Compile gave 0 nodes** — the provider wasn't reached. Check
   `api_key_env` / `api_base` in `config.yaml`. If you switched provider or
   model after a first compile, delete `<data-home>/cache.json` (the cache key
   doesn't include the model) and recompile.

--- a/docs/guides/serve.md
+++ b/docs/guides/serve.md
@@ -5,9 +5,9 @@ Path resolution (env > `LOREKEEP_HOME` > dev mode > XDG) is covered in [data-hom
 ## Installed use (recommended)
 
 ```bash
-uvx lorekeep init                     # bootstrap ~/.config/lorekeep + ~/.local/share/lorekeep
+uvx lorekeep init                     # bootstrap + wire agents + compile + start daemon
 # add your docs under ~/.local/share/lorekeep/raw/<ns>/
-LOREKEEP_PROVIDER=fake uvx lorekeep compile  # (or set a real provider in config)
+uvx lorekeep compile                  # requires a real provider in config.yaml
 uvx lorekeep mcp add --agent claude --ns <ns>
 uvx lorekeep doctor
 

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import typer
 
 from lorekeep import __version__
-from lorekeep.compile.providers import FakeProvider, LiteLLMProvider
+from lorekeep.compile.providers import LiteLLMProvider
 from lorekeep.config import Config, load_config
 from lorekeep.pipeline import compile_graph
 from lorekeep.paths import resolve_paths
@@ -39,32 +39,22 @@ def _build_provider(config: Config) -> LiteLLMProvider:
     )
 
 
-_FAKE_CANNED = json.dumps({
-    "nodes": [
-        {"id": "svc:payments-api", "type": "service", "name": "payments-api",
-         "props": {"lang": "go"}, "valid_from": "2024-01-15"},
-        {"id": "svc:auth", "type": "service", "name": "auth"},
-        {"id": "team:backend", "type": "team", "name": "team-backend"},
-        {"id": "dec:adr-007", "type": "decision",
-         "props": {"title": "payments-api adopts internal signing"}},
-    ],
-    "edges": [
-        {"type": "depends_on", "from": "svc:payments-api", "to": "svc:auth",
-         "valid_from": "2024-01-15", "valid_to": "2025-03-01"},
-        {"type": "decided_by", "from": "dec:adr-007", "to": "team:backend"},
-    ],
-    "aliases": {},
-})
-
-
-def _make_provider(config: Config) -> FakeProvider | LiteLLMProvider:
-    """Create provider honoring LOREKEEP_PROVIDER=fake for offline/test use.
-
-    Shared by standalone compile, daemon auto-compile, and import.
-    """
-    if os.environ.get("LOREKEEP_PROVIDER") == "fake":
-        return FakeProvider(responses=[_FAKE_CANNED])
+def _make_provider(config: Config) -> LiteLLMProvider:
+    """Create provider for compile.  Tests monkeypatch this to inject FakeProvider."""
     return _build_provider(config)
+
+
+def _make_import_provider(config: Config) -> LiteLLMProvider:
+    """Create provider for import deep mode.  Tests monkeypatch this."""
+    return _build_provider(config)
+
+
+def _has_provider(config: Config) -> bool:
+    """Check if a provider API key is available.  Tests monkeypatch this."""
+    return bool(
+        (config.provider.api_key_env and os.environ.get(config.provider.api_key_env))
+        or config.provider.api_key
+    )
 
 
 @app.command()
@@ -512,11 +502,7 @@ def _auto_import_and_compile(p: dict) -> None:
     schema = load_schema(p["schema"])
     config = load_config(p["config"])
 
-    has_key = (
-        os.environ.get("LOREKEEP_PROVIDER") == "fake"
-        or (config.provider.api_key_env and os.environ.get(config.provider.api_key_env))
-        or config.provider.api_key
-    )
+    has_key = _has_provider(config)
 
     if not has_key:
         if imported:
@@ -640,15 +626,6 @@ def import_cmd(
     p = resolve_paths()
     config = load_config(p["config"])
 
-    def _build_import_provider():
-        """Deep-mode provider (fake under LOREKEEP_PROVIDER=fake, else config)."""
-        if os.environ.get("LOREKEEP_PROVIDER") == "fake":
-            from lorekeep.compile.providers import FakeProvider
-            # Provide enough canned responses for deep mode batches
-            canned = "# Knowledge Summary\n\n## Decisions\n- No real session data imported (fake provider).\n"
-            return FakeProvider(responses=[canned] * 50)
-        return _build_provider(config)
-
     # --- Cursor: global composer conversations, deep-only ------------------
     if from_source == "cursor":
         if quick:
@@ -673,7 +650,7 @@ def import_cmd(
         ns = session_ns or "cursor-session"
         result = import_cursor(
             raw_root=p["raw"], db_path=db, namespace=ns,
-            provider=_build_import_provider(), dry_run=dry_run,
+            provider=_make_import_provider(config), dry_run=dry_run,
         )
         ses_count = len(result.get("session", []))
         if dry_run:
@@ -697,7 +674,7 @@ def import_cmd(
                        "Run Claude Code in this project first.")
             raise typer.Exit(code=1)
 
-    provider = None if quick else _build_import_provider()
+    provider = None if quick else _make_import_provider(config)
 
     from lorekeep.importer.claude import import_claude
     result = import_claude(

--- a/src/lorekeep/defaults.py
+++ b/src/lorekeep/defaults.py
@@ -73,7 +73,7 @@ PROVIDER_PRESETS: dict[str, dict] = {
         "api_key_env": None,
     },
     "5": {
-        "label": "Skip — offline/fake mode (set LOREKEEP_PROVIDER=fake to compile)",
+        "label": "Skip — configure provider later (edit config.yaml)",
         "backend": "openai",
         "model": "openai/gpt-4o-mini",
         "api_base": None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,57 @@
 from pathlib import Path
+import json
 import pytest
+
+from lorekeep.compile.providers import FakeProvider
 
 
 @pytest.fixture
 def fixtures() -> Path:
     return Path(__file__).parent / "fixtures"
+
+
+CANNED_EXTRACTION = json.dumps({
+    "nodes": [
+        {"id": "svc:payments-api", "type": "service", "name": "payments-api",
+         "props": {"lang": "go"}, "valid_from": "2024-01-15"},
+        {"id": "svc:auth", "type": "service", "name": "auth"},
+        {"id": "team:backend", "type": "team", "name": "team-backend"},
+        {"id": "dec:adr-007", "type": "decision",
+         "props": {"title": "payments-api adopts internal signing"}},
+    ],
+    "edges": [
+        {"type": "depends_on", "from": "svc:payments-api", "to": "svc:auth",
+         "valid_from": "2024-01-15", "valid_to": "2025-03-01"},
+        {"type": "decided_by", "from": "dec:adr-007", "to": "team:backend"},
+    ],
+    "aliases": {},
+})
+
+
+@pytest.fixture
+def fake_provider():
+    """FakeProvider with canned extraction responses for compile/ingest tests."""
+    return FakeProvider(responses=[CANNED_EXTRACTION] * 50)
+
+
+@pytest.fixture
+def fake_extraction():
+    """Canned extraction JSON string for tests that build their own FakeProvider."""
+    return CANNED_EXTRACTION
+
+
+@pytest.fixture
+def patch_make_provider(monkeypatch, fake_provider):
+    """Monkeypatch cli._make_provider + _has_provider to return a FakeProvider."""
+    monkeypatch.setattr("lorekeep.cli._make_provider", lambda config: fake_provider)
+    monkeypatch.setattr("lorekeep.cli._has_provider", lambda config: True)
+
+
+@pytest.fixture
+def patch_make_import_provider(monkeypatch):
+    """Monkeypatch cli._make_import_provider to return a FakeProvider for import deep mode."""
+    canned = "# Knowledge Summary\n\n## Decisions\n- Test import summary.\n"
+    monkeypatch.setattr(
+        "lorekeep.cli._make_import_provider",
+        lambda config: FakeProvider(responses=[canned] * 50),
+    )

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -6,14 +6,13 @@ from lorekeep.cli import app
 runner = CliRunner()
 
 
-def test_agent_ingest_yes_flag(monkeypatch, tmp_path: Path, fixtures: Path):
+def test_agent_ingest_yes_flag(patch_make_provider, monkeypatch, tmp_path: Path, fixtures: Path):
     """agent ingest --yes: approve all facts, journal is created."""
     monkeypatch.setenv("LOREKEEP_RAW", str(tmp_path / "raw"))
     monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "graph"))
     monkeypatch.setenv("LOREKEEP_CACHE", str(tmp_path / "cache.json"))
     monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
     monkeypatch.setenv("LOREKEEP_PENDING", str(tmp_path / "pending"))
-    monkeypatch.setenv("LOREKEEP_PROVIDER", "fake")
 
     raw_file = tmp_path / "raw" / "backend" / "payments.md"
     raw_file.parent.mkdir(parents=True)
@@ -35,14 +34,13 @@ def test_agent_ingest_yes_flag(monkeypatch, tmp_path: Path, fixtures: Path):
         assert entry["status"] == "pending"
 
 
-def test_agent_ingest_interactive_approve_all(monkeypatch, tmp_path: Path, fixtures: Path):
+def test_agent_ingest_interactive_approve_all(patch_make_provider, monkeypatch, tmp_path: Path, fixtures: Path):
     """agent ingest: interactive mode, approve all nodes and edges."""
     monkeypatch.setenv("LOREKEEP_RAW", str(tmp_path / "raw"))
     monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "graph"))
     monkeypatch.setenv("LOREKEEP_CACHE", str(tmp_path / "cache.json"))
     monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
     monkeypatch.setenv("LOREKEEP_PENDING", str(tmp_path / "pending"))
-    monkeypatch.setenv("LOREKEEP_PROVIDER", "fake")
 
     raw_file = tmp_path / "raw" / "backend" / "payments.md"
     raw_file.parent.mkdir(parents=True)
@@ -61,14 +59,13 @@ def test_agent_ingest_interactive_approve_all(monkeypatch, tmp_path: Path, fixtu
     assert len(lines) == 6  # 4 nodes + 2 edges
 
 
-def test_agent_ingest_interactive_reject_all(monkeypatch, tmp_path: Path, fixtures: Path):
+def test_agent_ingest_interactive_reject_all(patch_make_provider, monkeypatch, tmp_path: Path, fixtures: Path):
     """agent ingest: interactive mode, reject all → no journal entries."""
     monkeypatch.setenv("LOREKEEP_RAW", str(tmp_path / "raw"))
     monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "graph"))
     monkeypatch.setenv("LOREKEEP_CACHE", str(tmp_path / "cache.json"))
     monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
     monkeypatch.setenv("LOREKEEP_PENDING", str(tmp_path / "pending"))
-    monkeypatch.setenv("LOREKEEP_PROVIDER", "fake")
 
     raw_file = tmp_path / "raw" / "backend" / "payments.md"
     raw_file.parent.mkdir(parents=True)
@@ -82,14 +79,13 @@ def test_agent_ingest_interactive_reject_all(monkeypatch, tmp_path: Path, fixtur
     assert "nothing approved" in result.stdout
 
 
-def test_agent_ingest_interactive_review_individual(monkeypatch, tmp_path: Path, fixtures: Path):
+def test_agent_ingest_interactive_review_individual(patch_make_provider, monkeypatch, tmp_path: Path, fixtures: Path):
     """agent ingest: interactive mode, reject all-at-once but approve individually."""
     monkeypatch.setenv("LOREKEEP_RAW", str(tmp_path / "raw"))
     monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "graph"))
     monkeypatch.setenv("LOREKEEP_CACHE", str(tmp_path / "cache.json"))
     monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
     monkeypatch.setenv("LOREKEEP_PENDING", str(tmp_path / "pending"))
-    monkeypatch.setenv("LOREKEEP_PROVIDER", "fake")
 
     raw_file = tmp_path / "raw" / "backend" / "payments.md"
     raw_file.parent.mkdir(parents=True)
@@ -111,12 +107,11 @@ def test_agent_ingest_interactive_review_individual(monkeypatch, tmp_path: Path,
     assert len(lines) == 4  # 4 nodes approved, 0 edges
 
 
-def test_agent_ingest_missing_source(monkeypatch, tmp_path: Path, fixtures: Path):
+def test_agent_ingest_missing_source(patch_make_provider, monkeypatch, tmp_path: Path, fixtures: Path):
     """agent ingest: missing source file errors out."""
     monkeypatch.setenv("LOREKEEP_RAW", str(tmp_path / "raw"))
     monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
     monkeypatch.setenv("LOREKEEP_PENDING", str(tmp_path / "pending"))
-    monkeypatch.setenv("LOREKEEP_PROVIDER", "fake")
 
     raw_root = tmp_path / "raw"
     raw_root.mkdir(parents=True)
@@ -126,12 +121,11 @@ def test_agent_ingest_missing_source(monkeypatch, tmp_path: Path, fixtures: Path
     assert "not found" in result.stdout
 
 
-def test_agent_ingest_source_outside_raw(monkeypatch, tmp_path: Path, fixtures: Path):
+def test_agent_ingest_source_outside_raw(patch_make_provider, monkeypatch, tmp_path: Path, fixtures: Path):
     """agent ingest: source outside raw/ errors out."""
     monkeypatch.setenv("LOREKEEP_RAW", str(tmp_path / "raw"))
     monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
     monkeypatch.setenv("LOREKEEP_PENDING", str(tmp_path / "pending"))
-    monkeypatch.setenv("LOREKEEP_PROVIDER", "fake")
 
     raw_root = tmp_path / "raw"
     raw_root.mkdir(parents=True)

--- a/tests/test_compile_cli.py
+++ b/tests/test_compile_cli.py
@@ -6,13 +6,12 @@ from lorekeep.cli import app
 runner = CliRunner()
 
 
-def test_compile_command_uses_config_provider(monkeypatch, tmp_path: Path, fixtures: Path):
+def test_compile_command_uses_config_provider(patch_make_provider, monkeypatch, tmp_path: Path, fixtures: Path):
     # point the CLI at temp dirs via env
     monkeypatch.setenv("LOREKEEP_RAW", str(tmp_path / "raw"))
     monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "graph"))
     monkeypatch.setenv("LOREKEEP_CACHE", str(tmp_path / "cache.json"))
     monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
-    monkeypatch.setenv("LOREKEEP_PROVIDER", "fake")
 
     raw = tmp_path / "raw/backend/payments.md"
     raw.parent.mkdir(parents=True)

--- a/tests/test_import_cursor.py
+++ b/tests/test_import_cursor.py
@@ -191,11 +191,10 @@ def test_import_cursor_missing_db_errors(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_cli_import_cursor_runs(monkeypatch, tmp_path: Path, state_db: Path):
+def test_cli_import_cursor_runs(patch_make_import_provider, monkeypatch, tmp_path: Path, state_db: Path):
     monkeypatch.setenv("LOREKEEP_RAW", str(tmp_path / "raw"))
     monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "graph"))
     monkeypatch.setenv("LOREKEEP_CACHE", str(tmp_path / "cache.json"))
-    monkeypatch.setenv("LOREKEEP_PROVIDER", "fake")
     monkeypatch.setenv("CURSOR_STATE_DB", str(state_db))
 
     result = runner.invoke(app, ["import", "--from", "cursor"])
@@ -205,7 +204,6 @@ def test_cli_import_cursor_runs(monkeypatch, tmp_path: Path, state_db: Path):
 
 def test_cli_import_cursor_rejects_quick(monkeypatch, tmp_path: Path, state_db: Path):
     monkeypatch.setenv("CURSOR_STATE_DB", str(state_db))
-    monkeypatch.setenv("LOREKEEP_PROVIDER", "fake")
     result = runner.invoke(app, ["import", "--from", "cursor", "--quick"])
     assert result.exit_code == 1
     assert "deep-only" in result.stdout

--- a/tests/test_init_chain.py
+++ b/tests/test_init_chain.py
@@ -10,7 +10,7 @@ from lorekeep.cli import app
 runner = CliRunner()
 
 
-def _setup_env(tmp_path: Path, monkeypatch, fake_provider=True):
+def _setup_env(tmp_path: Path, monkeypatch):
     home = tmp_path / "home"
     project = tmp_path / "project"
     fake_home = tmp_path / "fakehome"
@@ -24,16 +24,14 @@ def _setup_env(tmp_path: Path, monkeypatch, fake_provider=True):
     monkeypatch.setattr("lorekeep.integrations.detect.shutil.which", lambda _: None)
     monkeypatch.delenv("OPENCODE", raising=False)
     monkeypatch.delenv("CLAUDECODE", raising=False)
-    if fake_provider:
-        monkeypatch.setenv("LOREKEEP_PROVIDER", "fake")
     return home, project
 
 
 # ── Init chains into compile ──────────────────────────────────────────────
 
 
-def test_init_compiles_with_fake_provider(tmp_path: Path, monkeypatch):
-    """init --yes with LOREKEEP_PROVIDER=fake should auto-compile facts.jsonl."""
+def test_init_compiles_with_provider(patch_make_provider, tmp_path: Path, monkeypatch):
+    """init --yes with patched provider should auto-compile facts.jsonl."""
     home, project = _setup_env(tmp_path, monkeypatch)
 
     result = runner.invoke(app, ["init", "--yes", "--no-watch"])
@@ -47,7 +45,7 @@ def test_init_compiles_with_fake_provider(tmp_path: Path, monkeypatch):
 
 def test_init_skips_compile_without_api_key(tmp_path: Path, monkeypatch):
     """init --yes without provider key should skip compile gracefully."""
-    home, project = _setup_env(tmp_path, monkeypatch, fake_provider=False)
+    home, project = _setup_env(tmp_path, monkeypatch)
 
     result = runner.invoke(app, ["init", "--yes", "--no-watch"])
     assert result.exit_code == 0, result.stdout

--- a/tests/test_watch_e2e.py
+++ b/tests/test_watch_e2e.py
@@ -26,7 +26,6 @@ def _bootstrap_home(tmp_path: Path):
 def _set_env(home: Path):
     return {
         "LOREKEEP_HOME": str(home),
-        "LOREKEEP_PROVIDER": "fake",
         "LOREKEEP_DEV": "0",
     }
 
@@ -34,7 +33,7 @@ def _set_env(home: Path):
 # ── Compile → MCP visibility ──────────────────────────────────────────────
 
 
-def test_raw_change_compiled_then_visible_in_mcp(tmp_path: Path, fixtures: Path, monkeypatch):
+def test_raw_change_compiled_then_visible_in_mcp(patch_make_provider, tmp_path: Path, fixtures: Path, monkeypatch):
     """Write markdown to raw/ → compile (fake) → facts.jsonl → MCP search finds new nodes."""
     home = _bootstrap_home(tmp_path)
     shutil.copy(fixtures / "schema.json", home / "schema.json")
@@ -105,7 +104,7 @@ def test_pending_journal_resolved_then_visible_in_mcp(tmp_path: Path, fixtures: 
 # ── Standalone compile preserves pending journals (PR1 fix) ───────────────
 
 
-def test_standalone_compile_preserves_pending_journals(tmp_path: Path, fixtures: Path, monkeypatch):
+def test_standalone_compile_preserves_pending_journals(patch_make_provider, tmp_path: Path, fixtures: Path, monkeypatch):
     """lorekeep compile re-merges pending journals after regenerating facts.jsonl."""
     home = _bootstrap_home(tmp_path)
     shutil.copy(fixtures / "schema.json", home / "schema.json")
@@ -150,7 +149,7 @@ def test_standalone_compile_preserves_pending_journals(tmp_path: Path, fixtures:
 # ── Full loop: raw write + journal → compile + resolve → MCP ──────────────
 
 
-def test_full_loop_compile_and_resolve_visible_in_mcp(tmp_path: Path, fixtures: Path, monkeypatch):
+def test_full_loop_compile_and_resolve_visible_in_mcp(patch_make_provider, tmp_path: Path, fixtures: Path, monkeypatch):
     """Raw markdown + pending journal → compile → both visible through MCP search."""
     home = _bootstrap_home(tmp_path)
     shutil.copy(fixtures / "schema.json", home / "schema.json")

--- a/tests/test_watch_sessions.py
+++ b/tests/test_watch_sessions.py
@@ -130,7 +130,6 @@ def test_watch_boots_and_shuts_down_cleanly(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "graph"))
     monkeypatch.setenv("LOREKEEP_CACHE", str(tmp_path / "cache.json"))
     monkeypatch.setenv("LOREKEEP_PENDING", str(tmp_path / "pending"))
-    monkeypatch.setenv("LOREKEEP_PROVIDER", "fake")
     monkeypatch.setenv("LOREKEEP_DEV", "1")
 
     (tmp_path / "raw").mkdir()
@@ -150,7 +149,6 @@ def test_watch_boots_and_shuts_down_cleanly(monkeypatch, tmp_path: Path):
              "LOREKEEP_OUT": str(tmp_path / "graph"),
              "LOREKEEP_CACHE": str(tmp_path / "cache.json"),
              "LOREKEEP_PENDING": str(tmp_path / "pending"),
-             "LOREKEEP_PROVIDER": "fake",
              "LOREKEEP_DEV": "1",
              "PYTHONPATH": str(Path(__file__).parent.parent / "src"),
              },


### PR DESCRIPTION
## Summary

`LOREKEEP_PROVIDER=fake` no longer works in production. FakeProvider is now injected via monkeypatch in tests only.

### Why

The fake provider env var was a silent fallback that could accidentally be set in production, producing canned data that looks real. Tests should own their fakes, not the runtime.

### Changes

**Production code (`cli.py`):**
- Removed `_FAKE_CANNED` constant
- `_make_provider()` always delegates to `_build_provider()` (no env-var branch)
- New `_has_provider(config)` seam for API key detection (testable)
- Refactored nested `_build_import_provider` closure → module-level `_make_import_provider(config)`
- Removed `FakeProvider` from top-level import

**Tests (`conftest.py` + 6 files):**
- New shared fixtures: `fake_provider`, `fake_extraction`, `patch_make_provider` (patches `_make_provider` + `_has_provider`), `patch_make_import_provider`
- All 6 test files migrated from `LOREKEEP_PROVIDER=fake` env var → fixture injection
- `test_watch_sessions.py` subprocess test: removed env var (daemon boot test doesn't need provider)

**Docs:**
- AGENTS.md: test pattern describes monkeypatch injection, not env var
- getting-started.md / serve.md: removed fake provider from user-facing guidance
- evaluation.md: updated test pattern
- defaults.py: provider preset 5 relabeled

**Before:**
```python
monkeypatch.setenv("LOREKEEP_PROVIDER", "fake")
result = runner.invoke(app, ["compile"])
```

**After:**
```python
def test_compile(patch_make_provider, monkeypatch, tmp_path, fixtures):
    ...
    result = runner.invoke(app, ["compile"])
```

235 tests pass, zero `LOREKEEP_PROVIDER` references in production code or user-facing docs.