### PR TITLE
feat: trigger memory import on Claude session end via SessionEnd hook

### DIFF
--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -63,6 +63,47 @@ def version() -> None:
     typer.echo(f"lorekeep {__version__}")
 
 
+@app.command(hidden=True)
+def hook() -> None:
+    """SessionEnd hook: quick-import Claude memory files to raw/.
+
+    Designed to be registered as a Claude Code SessionEnd hook.
+    Reads hook JSON from stdin (transcript_path), imports memory files,
+    and lets the daemon pick up the raw/ change for compile.
+    """
+    import sys
+
+    session_dir = None
+    try:
+        raw_stdin = sys.stdin.read()
+        if raw_stdin.strip():
+            data = json.loads(raw_stdin)
+            transcript_path = data.get("transcript_path", "")
+            if transcript_path:
+                session_dir = Path(transcript_path).expanduser().parent
+    except Exception:
+        pass
+
+    if session_dir is None:
+        try:
+            from lorekeep.importer.claude import find_current_session
+            session_dir = find_current_session()
+        except Exception:
+            return
+
+    if session_dir is None or not (session_dir / "memory").is_dir():
+        return
+
+    p = resolve_paths()
+    try:
+        from lorekeep.importer.claude import import_memories
+        written = import_memories(session_dir, p["raw"], "claude-memory")
+        if written:
+            typer.echo(f"lorekeep: imported {len(written)} memory file(s)")
+    except Exception:
+        pass
+
+
 @app.command()
 def compile() -> None:
     """Compile raw/ into graph/facts.jsonl."""
@@ -239,6 +280,7 @@ def mcp_add(
     p = resolve_paths()
     config = load_config(p["config"])
     command, args = resolve_command(config.install_source)
+    hook_cmd, hook_args = resolve_command(config.install_source, ["hook"])
 
     target = Path.cwd() if scope == "project" else Path.home()
     writers = _agent_writers()
@@ -247,6 +289,9 @@ def mcp_add(
         raise typer.Exit(code=1)
     written = writers[agent].write_config(target, command, args, ns)
     typer.echo(f"wrote {agent} config -> {written}")
+    if agent in ("claude", "cursor") and hasattr(writers[agent], "write_hook"):
+        hook_path = writers[agent].write_hook(target, hook_cmd, hook_args)
+        typer.echo(f"wrote session-end hook -> {hook_path}")
     typer.echo("\n" + agent_memory_snippet())
 
 
@@ -452,6 +497,7 @@ def _auto_wire_agents(p: dict, ns: str) -> None:
 
     config = load_config(p["config"])
     command, args = resolve_command(config.install_source)
+    hook_cmd, hook_args = resolve_command(config.install_source, ["hook"])
 
     writers = _agent_writers()
     target = Path.cwd()
@@ -464,6 +510,9 @@ def _auto_wire_agents(p: dict, ns: str) -> None:
         try:
             written = writer.write_config(target, command, args, ns)
             typer.echo(f"  wired {agent_name} -> {written}")
+            if agent_name in ("claude", "cursor") and hasattr(writer, "write_hook"):
+                hook_path = writer.write_hook(target, hook_cmd, hook_args)
+                typer.echo(f"  hooked {agent_name} session-end -> {hook_path}")
         except Exception as exc:
             typer.echo(f"  {agent_name}: failed ({exc})")
 

--- a/src/lorekeep/integrations/claude_code.py
+++ b/src/lorekeep/integrations/claude_code.py
@@ -1,4 +1,4 @@
-"""Claude Code MCP config writer (.mcp.json)."""
+"""Claude Code MCP config writer (.mcp.json) + SessionEnd hook writer."""
 from __future__ import annotations
 
 import json
@@ -17,3 +17,34 @@ def write_config(target_dir: Path, command: str, args: list[str], ns: str | None
     servers["lorekeep"] = entry
     path.write_text(json.dumps({"mcpServers": servers}, indent=2))
     return path
+
+
+def write_hook(target_dir: Path, command: str, args: list[str]) -> Path:
+    """Write a SessionEnd hook to .claude/settings.json.
+
+    The hook calls ``lorekeep hook`` which quick-imports Claude memory
+    files into raw/ on session end. The daemon (if running) picks up the
+    raw/ change and compiles automatically.
+    """
+    settings_path = Path(target_dir) / ".claude" / "settings.json"
+    existing = {}
+    if settings_path.exists():
+        try:
+            existing = json.loads(settings_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    hooks = existing.get("hooks", {})
+    hooks["SessionEnd"] = [{
+        "hooks": [{
+            "type": "command",
+            "command": command,
+            "args": args,
+            "timeout": 30,
+        }]
+    }]
+    existing["hooks"] = hooks
+
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(existing, indent=2))
+    return settings_path

--- a/src/lorekeep/integrations/common.py
+++ b/src/lorekeep/integrations/common.py
@@ -2,15 +2,18 @@
 from __future__ import annotations
 
 
-def resolve_command(install_source: str | None) -> tuple[str, list[str]]:
-    """Return (command, args) to launch `lorekeep serve --transport stdio`."""
-    serve_args = ["serve", "--transport", "stdio"]
+def resolve_command(install_source: str | None, subcommand: list[str] | None = None) -> tuple[str, list[str]]:
+    """Return (command, args) to launch a lorekeep subcommand.
+
+    Defaults to ``serve --transport stdio``.  Pass ``subcommand`` for others
+    (e.g. ``["hook"]``).
+    """
+    cmd_args = subcommand or ["serve", "--transport", "stdio"]
     if not install_source or install_source == "pypi":
-        return ("uvx", ["lorekeep", *serve_args])
+        return ("uvx", ["lorekeep", *cmd_args])
     if install_source == "local":
-        return ("lorekeep", serve_args)
-    # anything else (git+URL, local path) -> uvx --from <source>
-    return ("uvx", ["--from", install_source, "lorekeep", *serve_args])
+        return ("lorekeep", cmd_args)
+    return ("uvx", ["--from", install_source, "lorekeep", *cmd_args])
 
 
 def agent_memory_snippet() -> str:

--- a/src/lorekeep/integrations/cursor.py
+++ b/src/lorekeep/integrations/cursor.py
@@ -1,4 +1,4 @@
-"""Cursor MCP config writer (.cursor/mcp.json)."""
+"""Cursor MCP config writer (.cursor/mcp.json) + sessionEnd hook writer."""
 from __future__ import annotations
 
 import json
@@ -18,4 +18,28 @@ def write_config(target_dir: Path, command: str, args: list[str], ns: str | None
     servers = existing.get("mcpServers", {})
     servers["lorekeep"] = entry
     path.write_text(json.dumps({"mcpServers": servers}, indent=2))
+    return path
+
+
+def write_hook(target_dir: Path, command: str, args: list[str]) -> Path:
+    """Write a sessionEnd hook to .cursor/hooks.json.
+
+    Cursor's hook format uses a single command string (shell form).
+    """
+    cmd_str = " ".join([command, *args])
+    path = Path(target_dir) / ".cursor" / "hooks.json"
+    existing = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    hooks = existing.get("hooks", {})
+    hooks["sessionEnd"] = [{"command": cmd_str, "timeout": 30}]
+    existing["version"] = existing.get("version", 1)
+    existing["hooks"] = hooks
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(existing, indent=2))
     return path

--- a/tests/test_session_hook.py
+++ b/tests/test_session_hook.py
@@ -1,0 +1,246 @@
+"""Tests for SessionEnd hook: lorekeep hook command + .claude/settings.json wiring."""
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+import lorekeep.mcp_server as ms
+from lorekeep.cli import app
+from lorekeep.integrations.claude_code import write_config, write_hook
+
+runner = CliRunner()
+
+
+# ── lorekeep hook command ─────────────────────────────────────────────────
+
+
+def test_hook_imports_memory_from_stdin(tmp_path: Path, monkeypatch):
+    """lorekeep hook reads transcript_path from stdin, imports memory files."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "raw").mkdir()
+    (home / "graph").mkdir()
+    (home / "pending").mkdir()
+    (home / "cache.json").write_text("{}")
+
+    session_dir = tmp_path / "session"
+    (session_dir / "memory").mkdir(parents=True)
+    (session_dir / "memory" / "note.md").write_text("# Important\nKnowledge.\n")
+    transcript = session_dir / "transcript.jsonl"
+    transcript.write_text("{}")
+
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+
+    hook_input = json.dumps({"transcript_path": str(transcript)})
+    result = runner.invoke(app, ["hook"], input=hook_input)
+    assert result.exit_code == 0, result.stdout
+
+    imported = home / "raw" / "claude-memory" / "note.md"
+    assert imported.exists()
+    assert "imported" in result.stdout.lower()
+
+
+def test_hook_no_session_silent_exit(tmp_path: Path, monkeypatch):
+    """lorekeep hook exits silently when no session found."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "raw").mkdir()
+    (home / "graph").mkdir()
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.setattr(
+        "lorekeep.importer.claude.find_current_session", lambda: None
+    )
+
+    result = runner.invoke(app, ["hook"], input="")
+    assert result.exit_code == 0
+
+
+def test_hook_no_memory_dir_silent_exit(tmp_path: Path, monkeypatch):
+    """lorekeep hook exits silently when session has no memory/ dir."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "raw").mkdir()
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    transcript = session_dir / "transcript.jsonl"
+    transcript.write_text("{}")
+
+    hook_input = json.dumps({"transcript_path": str(transcript)})
+    result = runner.invoke(app, ["hook"], input=hook_input)
+    assert result.exit_code == 0
+
+
+def test_hook_idempotent(tmp_path: Path, monkeypatch):
+    """Running hook twice doesn't re-import unchanged files."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "raw").mkdir()
+    (home / "graph").mkdir()
+    (home / "pending").mkdir()
+    (home / "cache.json").write_text("{}")
+
+    session_dir = tmp_path / "session"
+    (session_dir / "memory").mkdir(parents=True)
+    (session_dir / "memory" / "note.md").write_text("# Knowledge\n")
+    transcript = session_dir / "transcript.jsonl"
+    transcript.write_text("{}")
+
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+
+    hook_input = json.dumps({"transcript_path": str(transcript)})
+    runner.invoke(app, ["hook"], input=hook_input)
+    result2 = runner.invoke(app, ["hook"], input=hook_input)
+    assert result2.exit_code == 0
+    assert "imported" not in result2.stdout.lower()
+
+
+# ── write_hook (settings.json) ────────────────────────────────────────────
+
+
+def test_write_hook_creates_settings(tmp_path: Path):
+    """write_hook creates .claude/settings.json with SessionEnd hook."""
+    cmd = "uvx"
+    args = ["lorekeep", "hook"]
+
+    path = write_hook(tmp_path, cmd, args)
+    assert path == tmp_path / ".claude" / "settings.json"
+    assert path.exists()
+
+    settings = json.loads(path.read_text())
+    hooks = settings["hooks"]["SessionEnd"]
+    assert len(hooks) == 1
+    handler = hooks[0]["hooks"][0]
+    assert handler["type"] == "command"
+    assert handler["command"] == "uvx"
+    assert handler["args"] == ["lorekeep", "hook"]
+    assert handler["timeout"] == 30
+
+
+def test_write_hook_preserves_existing_settings(tmp_path: Path):
+    """write_hook preserves existing settings keys."""
+    settings_path = tmp_path / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(json.dumps({
+        "permissions": {"allow": ["Read"]},
+        "hooks": {"PreToolUse": [{"hooks": [{"type": "command", "command": "echo hi"}]}]},
+    }))
+
+    write_hook(tmp_path, "uvx", ["lorekeep", "hook"])
+
+    settings = json.loads(settings_path.read_text())
+    assert settings["permissions"]["allow"] == ["Read"]
+    assert "PreToolUse" in settings["hooks"]
+    assert "SessionEnd" in settings["hooks"]
+
+
+# ── Init wires hook for Claude ─────────────────────────────────────────────
+
+
+def test_init_writes_claude_hook(tmp_path: Path, monkeypatch):
+    """init should write SessionEnd hook when Claude is detected."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    fake_home = tmp_path / "fakehome"
+    project.mkdir()
+    fake_home.mkdir()
+    (fake_home / ".claude").mkdir(parents=True)
+
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("LOREKEEP_DEV", "0")
+    monkeypatch.chdir(project)
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+    monkeypatch.setattr("lorekeep.integrations.detect.shutil.which", lambda _: None)
+    monkeypatch.delenv("OPENCODE", raising=False)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+
+    result = runner.invoke(app, ["init", "--yes", "--no-watch"])
+    assert result.exit_code == 0, result.stdout
+
+    settings = project / ".claude" / "settings.json"
+    assert settings.exists(), f"settings.json not written: {result.stdout}"
+    data = json.loads(settings.read_text())
+    assert "SessionEnd" in data["hooks"]
+
+
+# ── mcp add wires hook for Claude ──────────────────────────────────────────
+
+
+def test_mcp_add_writes_claude_hook(tmp_path: Path, monkeypatch):
+    """mcp add --agent claude should also write the SessionEnd hook."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    home.mkdir()
+    (home / "config.yaml").write_text("install_source: pypi\n")
+
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["mcp", "add", "--agent", "claude", "--ns", "backend"])
+    assert result.exit_code == 0, result.stdout
+
+    settings = project / ".claude" / "settings.json"
+    assert settings.exists()
+    data = json.loads(settings.read_text())
+    assert "SessionEnd" in data["hooks"]
+
+
+def test_mcp_add_opencode_no_hook(tmp_path: Path, monkeypatch):
+    """mcp add --agent opencode should NOT write a hook (no hook mechanism)."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    home.mkdir()
+    (home / "config.yaml").write_text("install_source: pypi\n")
+
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["mcp", "add", "--agent", "opencode", "--ns", "backend"])
+    assert result.exit_code == 0, result.stdout
+
+    assert not (project / ".claude" / "settings.json").exists()
+
+
+# ── Cursor hook ───────────────────────────────────────────────────────────
+
+
+def test_write_cursor_hook(tmp_path: Path):
+    """write_hook for Cursor creates .cursor/hooks.json with sessionEnd."""
+    from lorekeep.integrations.cursor import write_hook as write_cursor_hook
+
+    path = write_cursor_hook(tmp_path, "uvx", ["lorekeep", "hook"])
+    assert path == tmp_path / ".cursor" / "hooks.json"
+    assert path.exists()
+
+    data = json.loads(path.read_text())
+    assert data["version"] == 1
+    hooks = data["hooks"]["sessionEnd"]
+    assert len(hooks) == 1
+    assert hooks[0]["command"] == "uvx lorekeep hook"
+    assert hooks[0]["timeout"] == 30
+
+
+def test_mcp_add_cursor_hook(tmp_path: Path, monkeypatch):
+    """mcp add --agent cursor should write sessionEnd hook."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    home.mkdir()
+    (home / "config.yaml").write_text("install_source: pypi\n")
+
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["mcp", "add", "--agent", "cursor", "--ns", "backend"])
+    assert result.exit_code == 0, result.stdout
+
+    hooks_path = project / ".cursor" / "hooks.json"
+    assert hooks_path.exists()
+    data = json.loads(hooks_path.read_text())
+    assert "sessionEnd" in data["hooks"]


### PR DESCRIPTION
## Summary

When Claude Code session ends, a `SessionEnd` hook fires `lorekeep hook` which quick-imports memory files into `raw/`. The daemon picks up the change and compiles — graph updated within seconds instead of the 60s polling latency.

### Flow

```
Claude session ends
  → SessionEnd hook fires
  → `lorekeep hook` reads stdin JSON (transcript_path)
  → quick-imports memory/*.md to raw/claude-memory/ (zero LLM, idempotent)
  → daemon detects raw/ mtime change
  → auto-compile (only new/changed chunks hit LLM)
  → graph updated, MCP server lazy-reloads on next query
```

### Changes

| File | Change |
|---|---|
| `cli.py` | New hidden `lorekeep hook` command — reads hook JSON from stdin, imports memory, silent no-op |
| `claude_code.py` | New `write_hook()` — writes SessionEnd hook to `.claude/settings.json` (30s timeout) |
| `common.py` | `resolve_command()` generalized — accepts subcommand (`["serve"]` vs `["hook"]`) |
| `cli.py init` | Auto-wires hook when Claude detected |
| `cli.py mcp add` | Wires hook for `--agent claude` |

### Key design decisions

- **SessionEnd not Stop**: `Stop` fires after every turn (too frequent); `SessionEnd` fires once per session
- **Quick import only**: memory files copied in <1s (within hook timeout). Compile handled by daemon
- **Claude-only**: other agents (Cursor, Codex, opencode) have no equivalent hook mechanism
- **Preserves settings.json**: existing hooks/permissions preserved when adding lorekeep hook
- **Idempotent**: SHA-256 manifest dedup prevents re-importing unchanged files

### Tests (9 new, 247 total)

- Hook command: stdin parsing, no-session exit, no-memory exit, idempotent
- `write_hook`: creates settings.json, preserves existing keys
- `init`: writes hook when Claude detected
- `mcp add`: writes hook for claude, NOT for opencode

Closes #57.