### PR TITLE
feat: add import --from codex and --from opencode

### DIFF
--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -65,43 +65,34 @@ def version() -> None:
 
 @app.command(hidden=True)
 def hook() -> None:
-    """SessionEnd hook: quick-import Claude memory files to raw/.
+    """Session lifecycle hook: quick-import memories from all agents.
 
-    Designed to be registered as a Claude Code SessionEnd hook.
-    Reads hook JSON from stdin (transcript_path), imports memory files,
-    and lets the daemon pick up the raw/ change for compile.
+    Agent-agnostic — tries Claude and Codex memory imports (idempotent
+    via manifest). Each is a no-op if nothing changed. Daemon picks up
+    raw/ changes for compile.
     """
-    import sys
-
-    session_dir = None
-    try:
-        raw_stdin = sys.stdin.read()
-        if raw_stdin.strip():
-            data = json.loads(raw_stdin)
-            transcript_path = data.get("transcript_path", "")
-            if transcript_path:
-                session_dir = Path(transcript_path).expanduser().parent
-    except Exception:
-        pass
-
-    if session_dir is None:
-        try:
-            from lorekeep.importer.claude import find_current_session
-            session_dir = find_current_session()
-        except Exception:
-            return
-
-    if session_dir is None or not (session_dir / "memory").is_dir():
-        return
-
     p = resolve_paths()
+    total = 0
+
     try:
-        from lorekeep.importer.claude import import_memories
-        written = import_memories(session_dir, p["raw"], "claude-memory")
-        if written:
-            typer.echo(f"lorekeep: imported {len(written)} memory file(s)")
+        from lorekeep.importer.claude import find_current_session as find_claude
+        from lorekeep.importer.claude import import_memories as import_claude_mem
+        session_dir = find_claude()
+        if session_dir and (session_dir / "memory").is_dir():
+            written = import_claude_mem(session_dir, p["raw"], "claude-memory")
+            total += len(written)
     except Exception:
         pass
+
+    try:
+        from lorekeep.importer.codex import import_memories as import_codex_mem
+        written = import_codex_mem(p["raw"], "codex-memory")
+        total += len(written)
+    except Exception:
+        pass
+
+    if total:
+        typer.echo(f"lorekeep: imported {total} memory file(s)")
 
 
 @app.command()
@@ -289,7 +280,7 @@ def mcp_add(
         raise typer.Exit(code=1)
     written = writers[agent].write_config(target, command, args, ns)
     typer.echo(f"wrote {agent} config -> {written}")
-    if agent in ("claude", "cursor") and hasattr(writers[agent], "write_hook"):
+    if hasattr(writers[agent], "write_hook"):
         hook_path = writers[agent].write_hook(target, hook_cmd, hook_args)
         typer.echo(f"wrote session-end hook -> {hook_path}")
     typer.echo("\n" + agent_memory_snippet())
@@ -510,7 +501,7 @@ def _auto_wire_agents(p: dict, ns: str) -> None:
         try:
             written = writer.write_config(target, command, args, ns)
             typer.echo(f"  wired {agent_name} -> {written}")
-            if agent_name in ("claude", "cursor") and hasattr(writer, "write_hook"):
+            if hasattr(writer, "write_hook"):
                 hook_path = writer.write_hook(target, hook_cmd, hook_args)
                 typer.echo(f"  hooked {agent_name} session-end -> {hook_path}")
         except Exception as exc:
@@ -663,17 +654,79 @@ def import_cmd(
     """Import knowledge from an agent's sessions into raw/.
 
     Sources:
-      claude   Claude Code sessions. --quick copies memory/*.md only (no LLM);
-               default (deep) adds LLM-summarized transcript analysis.
-      cursor   Cursor composer conversations (GLOBAL state.vscdb). Deep-only --
-               --quick is rejected (Cursor has no curated memory files).
+      claude    Claude Code sessions. --quick copies memory/*.md only (no LLM);
+                default (deep) adds LLM-summarized transcript analysis.
+      cursor    Cursor composer conversations (GLOBAL state.vscdb). Deep-only.
+      codex     Codex CLI rollout transcripts ($CODEX_HOME/sessions/).
+                --quick copies memories/*.md only; default (deep) summarizes.
+      opencode  opencode sessions (SQLite DB). Deep-only — no memory dir.
     """
-    if from_source not in ("claude", "cursor"):
-        typer.echo(f"unknown source: {from_source} (claude | cursor)")
+    if from_source not in ("claude", "cursor", "codex", "opencode"):
+        typer.echo(f"unknown source: {from_source} (claude | cursor | codex | opencode)")
         raise typer.Exit(code=1)
 
     p = resolve_paths()
     config = load_config(p["config"])
+
+    # --- Codex: rollout JSONL transcripts, quick + deep --------------------
+    if from_source == "codex":
+        from lorekeep.importer.codex import find_current_session as find_codex, import_codex
+
+        rollout_path = Path(session_path).expanduser() if session_path else None
+        if rollout_path is None:
+            rollout_path = find_codex()
+        if rollout_path is None and not quick:
+            typer.echo("error: no Codex session found for this project. "
+                       "Run Codex CLI here first, or pass --session-path.")
+            raise typer.Exit(code=1)
+
+        result = import_codex(
+            raw_root=p["raw"],
+            rollout_path=rollout_path,
+            quick=quick,
+            memory_ns=memory_ns,
+            session_ns=session_ns or "codex-session",
+            provider=None if quick else _make_import_provider(config),
+            dry_run=dry_run,
+        )
+        mem_count = len(result.get("memory", []))
+        ses_count = len(result.get("session", []))
+        if dry_run:
+            typer.echo(f"dry-run: would import {mem_count} memories, {ses_count} session files")
+        else:
+            typer.echo(f"imported: {mem_count} memories -> raw/{memory_ns}/, "
+                       f"{ses_count} session files -> raw/{session_ns or 'codex-session'}/")
+        return
+
+    # --- opencode: SQLite DB, deep-only ------------------------------------
+    if from_source == "opencode":
+        if quick:
+            typer.echo("error: opencode import is deep-only (--quick not supported)")
+            raise typer.Exit(code=1)
+
+        from lorekeep.importer.opencode import find_current_session as find_oc, import_opencode
+
+        sid = session_path or find_oc()
+        if sid is None:
+            typer.echo("error: no opencode session found for this project. "
+                       "Run opencode here first, or pass --session-path <session-id>.")
+            raise typer.Exit(code=1)
+
+        ns = session_ns or "opencode-session"
+        result = import_opencode(
+            raw_root=p["raw"],
+            session_id=sid,
+            session_ns=ns,
+            provider=_make_import_provider(config),
+            dry_run=dry_run,
+        )
+        ses_count = len(result.get("session", []))
+        if dry_run:
+            typer.echo(f"dry-run: would import {ses_count} opencode session files")
+        else:
+            typer.echo(f"imported: {ses_count} session files -> raw/{ns}/")
+            typer.echo("next: lorekeep compile")
+        return
 
     # --- Cursor: global composer conversations, deep-only ------------------
     if from_source == "cursor":

--- a/src/lorekeep/importer/codex.py
+++ b/src/lorekeep/importer/codex.py
@@ -1,0 +1,287 @@
+"""Import knowledge from Codex CLI sessions into lorekeep raw/ tree.
+
+Codex stores sessions as JSONL rollout files at:
+  $CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
+
+Each line = {"timestamp": "...", "type": "...", "payload": {...}}
+The first line is always "session_meta" with cwd, session_id, model.
+Conversation turns are in "response_item" lines with payload.type == "message".
+
+Memory files live at $CODEX_HOME/memories/*.md (optional, may not exist).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+
+from lorekeep.compile.providers import LLMProvider
+from lorekeep.importer.claude import (
+    ConversationTurn,
+    chunk_turns,
+    summarize_batch,
+    load_import_manifest,
+    save_import_manifest,
+)
+
+_CODEX_PREFIX_RE = re.compile(r"^## My request for Codex:\n", re.DOTALL)
+
+
+def _codex_home() -> Path:
+    return Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+
+
+# ---------------------------------------------------------------------------
+# Session discovery
+# ---------------------------------------------------------------------------
+
+
+def find_current_session(cwd: Path | None = None) -> Path | None:
+    """Find the most recent Codex rollout file for the given cwd.
+
+    Codex shards sessions by date, not by project. The cwd is stored
+    inside the first line (session_meta) of each rollout file.
+    """
+    cwd = str((cwd or Path.cwd()).resolve())
+    sessions_dir = _codex_home() / "sessions"
+    if not sessions_dir.is_dir():
+        return None
+
+    rollouts = sorted(sessions_dir.rglob("rollout-*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True)
+    for rp in rollouts:
+        try:
+            first_line = rp.read_text(encoding="utf-8").splitlines()[0].strip()
+            if not first_line:
+                continue
+            rec = json.loads(first_line)
+            if rec.get("type") == "session_meta":
+                session_cwd = rec.get("payload", {}).get("cwd", "")
+                if session_cwd and Path(session_cwd).resolve() == Path(cwd):
+                    return rp
+        except (json.JSONDecodeError, IndexError, OSError):
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Transcript parsing
+# ---------------------------------------------------------------------------
+
+
+def _extract_message_text(content: list[dict] | str) -> str:
+    """Extract text from a Codex message content array."""
+    if isinstance(content, str):
+        return content
+    parts = []
+    for block in content:
+        if isinstance(block, dict):
+            text = block.get("text", "")
+            if text:
+                parts.append(text)
+    return "\n".join(parts)
+
+
+def _strip_codex_prefix(text: str) -> str:
+    """Strip Codex's '## My request for Codex:' prefix from user messages."""
+    return _CODEX_PREFIX_RE.sub("", text)
+
+
+def parse_rollout(rollout_path: Path) -> list[ConversationTurn]:
+    """Parse a Codex rollout JSONL file into structured conversation turns."""
+    turns: list[ConversationTurn] = []
+    current_user: str | None = None
+    current_assistant: list[str] = []
+    current_tools: list[str] = []
+
+    for line in rollout_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        if rec.get("type") != "response_item":
+            continue
+
+        payload = rec.get("payload", {})
+        ptype = payload.get("type", "")
+
+        if ptype == "message":
+            role = payload.get("role", "")
+            text = _extract_message_text(payload.get("content", []))
+
+            if role == "user":
+                if current_user is not None:
+                    turns.append(ConversationTurn(
+                        user_content=current_user,
+                        assistant_text="\n\n".join(current_assistant),
+                        tool_calls=list(current_tools),
+                    ))
+                current_user = _strip_codex_prefix(text)
+                current_assistant = []
+                current_tools = []
+            elif role == "assistant":
+                current_assistant.append(text)
+
+        elif ptype in ("function_call", "custom_tool_call"):
+            name = payload.get("name", "unknown")
+            if name not in current_tools:
+                current_tools.append(name)
+
+    if current_user is not None:
+        turns.append(ConversationTurn(
+            user_content=current_user,
+            assistant_text="\n\n".join(current_assistant),
+            tool_calls=list(current_tools),
+        ))
+
+    return turns
+
+
+# ---------------------------------------------------------------------------
+# Memory import (quick mode)
+# ---------------------------------------------------------------------------
+
+
+def import_memories(
+    raw_root: Path,
+    namespace: str = "codex-memory",
+    *,
+    dry_run: bool = False,
+) -> list[Path]:
+    """Copy memories/*.md files from $CODEX_HOME into raw/<namespace>/.
+
+    Returns list of written paths. Idempotent via SHA-256 manifest.
+    """
+    mem_dir = _codex_home() / "memories"
+    if not mem_dir.is_dir():
+        return []
+
+    dest_dir = raw_root / namespace
+    manifest = load_import_manifest(raw_root, namespace)
+    written: list[Path] = []
+
+    for src in sorted(mem_dir.glob("*.md")):
+        content = src.read_text(encoding="utf-8")
+        h = hashlib.sha256(content.encode()).hexdigest()
+        if manifest.get(str(src)) == h:
+            continue
+
+        if dry_run:
+            written.append(dest_dir / src.name)
+            continue
+
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / src.name
+        dest.write_text(content, encoding="utf-8")
+        manifest[str(src)] = h
+        written.append(dest)
+
+    if not dry_run and written:
+        save_import_manifest(raw_root, namespace, manifest)
+
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Deep session import
+# ---------------------------------------------------------------------------
+
+
+def import_session_deep(
+    rollout_path: Path,
+    raw_root: Path,
+    namespace: str = "codex-session",
+    provider: LLMProvider | None = None,
+    *,
+    batch_max_chars: int = 20_000,
+    dry_run: bool = False,
+) -> list[Path]:
+    """Deep-import a Codex session: parse, chunk, summarize each batch via LLM."""
+    session_id = rollout_path.stem
+
+    transcript_hash = hashlib.sha256(rollout_path.read_bytes()).hexdigest()
+    manifest = load_import_manifest(raw_root, namespace)
+    manifest_key = str(rollout_path)
+
+    if not dry_run and manifest.get(manifest_key) == transcript_hash:
+        return []
+
+    turns = parse_rollout(rollout_path)
+    if not turns:
+        return []
+
+    batches = chunk_turns(turns, max_chars=batch_max_chars)
+    dest_dir = raw_root / namespace
+    written: list[Path] = []
+
+    previous_summary = ""
+    for i, batch in enumerate(batches):
+        if dry_run:
+            dest = dest_dir / f"session-{session_id}-batch-{i + 1:02d}.md"
+            written.append(dest)
+            continue
+
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / f"session-{session_id}-batch-{i + 1:02d}.md"
+
+        try:
+            if provider is None:
+                raise RuntimeError("deep mode requires a provider")
+            md = summarize_batch(
+                batch, i, len(batches), namespace, session_id,
+                provider, previous_summary,
+            )
+        except Exception as exc:
+            md = f"# Error summarizing batch {i + 1}\n\nLLM call failed: {exc}\n"
+
+        dest.write_text(md, encoding="utf-8")
+        previous_summary = md[:1000]
+        written.append(dest)
+
+    if not dry_run and written:
+        manifest[manifest_key] = transcript_hash
+        save_import_manifest(raw_root, namespace, manifest)
+
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def import_codex(
+    raw_root: Path,
+    rollout_path: Path | None = None,
+    *,
+    quick: bool = False,
+    memory_ns: str = "codex-memory",
+    session_ns: str = "codex-session",
+    provider: LLMProvider | None = None,
+    batch_max_chars: int = 20_000,
+    dry_run: bool = False,
+) -> dict[str, list[Path]]:
+    """Import a Codex session into the lorekeep raw/ tree.
+
+    Returns ``{"memory": [...], "session": [...]}`` with written file paths.
+    """
+    result: dict[str, list[Path]] = {"memory": [], "session": []}
+
+    result["memory"] = import_memories(raw_root, namespace=memory_ns, dry_run=dry_run)
+
+    if not quick:
+        if rollout_path is None:
+            rollout_path = find_current_session()
+        if rollout_path is not None:
+            result["session"] = import_session_deep(
+                rollout_path, raw_root, namespace=session_ns,
+                provider=provider, batch_max_chars=batch_max_chars,
+                dry_run=dry_run,
+            )
+
+    return result

--- a/src/lorekeep/importer/opencode.py
+++ b/src/lorekeep/importer/opencode.py
@@ -1,0 +1,255 @@
+"""Import knowledge from opencode sessions into lorekeep raw/ tree.
+
+opencode stores all sessions in a single SQLite database:
+  ~/.local/share/opencode/opencode.db
+
+Schema: session -> message -> part (JSON in data columns).
+Sessions are linked to projects by worktree path (SHA-1 hashed as project_id).
+
+opencode has no memory/*.md directory — deep-only (like cursor).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+from lorekeep.compile.providers import LLMProvider
+from lorekeep.importer.claude import (
+    ConversationTurn,
+    chunk_turns,
+    summarize_batch,
+    load_import_manifest,
+    save_import_manifest,
+)
+
+
+def _opencode_data_dir() -> Path:
+    xdg = os.environ.get("XDG_DATA_HOME")
+    if xdg:
+        return Path(xdg) / "opencode"
+    return Path.home() / ".local" / "share" / "opencode"
+
+
+def _opencode_db() -> Path:
+    return _opencode_data_dir() / "opencode.db"
+
+
+# ---------------------------------------------------------------------------
+# Session discovery
+# ---------------------------------------------------------------------------
+
+
+def find_current_session(cwd: Path | None = None) -> str | None:
+    """Find the most recent opencode session ID for the given cwd.
+
+    Returns the session ID string, or None if no session found.
+    """
+    cwd = str((cwd or Path.cwd()).resolve())
+    db = _opencode_db()
+    if not db.is_file():
+        return None
+
+    try:
+        con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+        con.row_factory = sqlite3.Row
+        row = con.execute(
+            """SELECT s.id FROM session s
+               JOIN project p ON p.id = s.project_id
+               WHERE p.worktree = ?
+               ORDER BY s.time_created DESC LIMIT 1""",
+            (cwd,),
+        ).fetchone()
+        con.close()
+        return row["id"] if row else None
+    except sqlite3.Error:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Transcript parsing
+# ---------------------------------------------------------------------------
+
+
+def _extract_turns(con: sqlite3.Connection, session_id: str) -> list[ConversationTurn]:
+    """Extract conversation turns from opencode SQLite for a session."""
+    messages = con.execute(
+        "SELECT id, data FROM message WHERE session_id = ? ORDER BY time_created",
+        (session_id,),
+    ).fetchall()
+
+    turns: list[ConversationTurn] = []
+    current_user: str | None = None
+    current_assistant: list[str] = []
+    current_tools: list[str] = []
+
+    for msg in messages:
+        data = json.loads(msg["data"])
+        role = data.get("role", "")
+
+        parts = con.execute(
+            "SELECT data FROM part WHERE message_id = ? ORDER BY time_created",
+            (msg["id"],),
+        ).fetchall()
+
+        if role == "user":
+            if current_user is not None:
+                turns.append(ConversationTurn(
+                    user_content=current_user,
+                    assistant_text="\n\n".join(current_assistant),
+                    tool_calls=list(current_tools),
+                ))
+            current_user = ""
+            current_assistant = []
+            current_tools = []
+            for p in parts:
+                pdata = json.loads(p["data"])
+                if pdata.get("type") == "text":
+                    current_user = (current_user + "\n" + pdata.get("text", "")).strip()
+
+        elif role == "assistant":
+            for p in parts:
+                pdata = json.loads(p["data"])
+                ptype = pdata.get("type", "")
+                if ptype == "text":
+                    current_assistant.append(pdata.get("text", ""))
+                elif ptype == "tool":
+                    tool_name = pdata.get("tool", "unknown")
+                    if tool_name not in current_tools:
+                        current_tools.append(tool_name)
+
+    if current_user is not None:
+        turns.append(ConversationTurn(
+            user_content=current_user,
+            assistant_text="\n\n".join(current_assistant),
+            tool_calls=list(current_tools),
+        ))
+
+    return turns
+
+
+def parse_session(session_id: str, db_path: Path | None = None) -> list[ConversationTurn]:
+    """Parse an opencode session from SQLite into structured conversation turns."""
+    db = db_path or _opencode_db()
+    if not db.is_file():
+        return []
+
+    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    con.row_factory = sqlite3.Row
+    try:
+        return _extract_turns(con, session_id)
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# Deep session import
+# ---------------------------------------------------------------------------
+
+
+def import_session_deep(
+    session_id: str,
+    raw_root: Path,
+    namespace: str = "opencode-session",
+    provider: LLMProvider | None = None,
+    db_path: Path | None = None,
+    *,
+    batch_max_chars: int = 20_000,
+    dry_run: bool = False,
+) -> list[Path]:
+    """Deep-import an opencode session: parse, chunk, summarize each batch via LLM."""
+    db = db_path or _opencode_db()
+    if not db.is_file():
+        return []
+
+    manifest_key = f"opencode:{session_id}"
+
+    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute(
+            "SELECT time_updated FROM session WHERE id = ?", (session_id,)
+        ).fetchone()
+        if not row:
+            return []
+        content_hash = str(row["time_updated"])
+
+        manifest = load_import_manifest(raw_root, namespace)
+        if not dry_run and manifest.get(manifest_key) == content_hash:
+            return []
+
+        turns = _extract_turns(con, session_id)
+    finally:
+        con.close()
+
+    if not turns:
+        return []
+
+    batches = chunk_turns(turns, max_chars=batch_max_chars)
+    dest_dir = raw_root / namespace
+    written: list[Path] = []
+
+    previous_summary = ""
+    for i, batch in enumerate(batches):
+        if dry_run:
+            dest = dest_dir / f"session-{session_id}-batch-{i + 1:02d}.md"
+            written.append(dest)
+            continue
+
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / f"session-{session_id}-batch-{i + 1:02d}.md"
+
+        try:
+            if provider is None:
+                raise RuntimeError("deep mode requires a provider")
+            md = summarize_batch(
+                batch, i, len(batches), namespace, session_id,
+                provider, previous_summary,
+            )
+        except Exception as exc:
+            md = f"# Error summarizing batch {i + 1}\n\nLLM call failed: {exc}\n"
+
+        dest.write_text(md, encoding="utf-8")
+        previous_summary = md[:1000]
+        written.append(dest)
+
+    if not dry_run and written:
+        manifest[manifest_key] = content_hash
+        save_import_manifest(raw_root, namespace, manifest)
+
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def import_opencode(
+    raw_root: Path,
+    session_id: str | None = None,
+    *,
+    session_ns: str = "opencode-session",
+    provider: LLMProvider | None = None,
+    batch_max_chars: int = 20_000,
+    dry_run: bool = False,
+) -> dict[str, list[Path]]:
+    """Import an opencode session into the lorekeep raw/ tree.
+
+    Deep-only — opencode has no memory/*.md directory.
+    Returns ``{"memory": [], "session": [...]}``.
+    """
+    result: dict[str, list[Path]] = {"memory": [], "session": []}
+
+    if session_id is None:
+        session_id = find_current_session()
+    if session_id is not None:
+        result["session"] = import_session_deep(
+            session_id, raw_root, namespace=session_ns,
+            provider=provider, batch_max_chars=batch_max_chars,
+            dry_run=dry_run,
+        )
+
+    return result

--- a/src/lorekeep/integrations/codex.py
+++ b/src/lorekeep/integrations/codex.py
@@ -1,11 +1,7 @@
-"""Codex MCP config writer (config.toml [mcp_servers.lorekeep]).
-
-Idempotent: re-running replaces the existing [mcp_servers.lorekeep] block instead
-of appending a duplicate. Values are escaped so a stray quote/backslash in the
-namespace or command can't break the generated TOML.
-"""
+"""Codex MCP config writer (config.toml) + Stop hook writer (hooks.json)."""
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 _HEADER = "[mcp_servers.lorekeep]"
@@ -53,4 +49,34 @@ def write_config(target_dir: Path, command: str, args: list[str], ns: str | None
         new_text = "\n".join(rebuilt) + "\n"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(new_text)
+    return path
+
+
+def write_hook(target_dir: Path, command: str, args: list[str]) -> Path:
+    """Write a Stop hook to .codex/hooks.json.
+
+    Codex fires Stop after every turn. The lorekeep hook command is
+    idempotent (manifest dedup) — zero cost if memories unchanged.
+    """
+    cmd_str = " ".join([command, *args])
+    path = Path(target_dir) / ".codex" / "hooks.json"
+    existing = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    hooks = existing.get("hooks", {})
+    hooks["Stop"] = [{
+        "hooks": [{
+            "type": "command",
+            "command": cmd_str,
+            "timeout": 30,
+        }]
+    }]
+    existing["hooks"] = hooks
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(existing, indent=2))
     return path

--- a/src/lorekeep/integrations/opencode.py
+++ b/src/lorekeep/integrations/opencode.py
@@ -1,14 +1,4 @@
-"""opencode MCP config writer (opencode.json ``mcp`` section).
-
-opencode uses a different MCP schema than Claude/Cursor:
-  - Config file: ``opencode.json`` (project root) or ``~/.config/opencode/opencode.json`` (global)
-  - Key: ``mcp`` (not ``mcpServers``)
-  - Entry shape: ``{"type": "local", "command": [cmd, ...args], "enabled": true, "environment": {...}}``
-  - ``command`` is a single array (command + args combined)
-
-Idempotent: re-running merges into the existing ``mcp`` section, replacing only
-the ``lorekeep`` entry.
-"""
+"""opencode MCP config writer (opencode.json) + session.idle plugin writer."""
 from __future__ import annotations
 
 import json
@@ -40,4 +30,31 @@ def write_config(target_dir: Path, command: str, args: list[str], ns: str | None
     existing["mcp"] = mcp
 
     path.write_text(json.dumps(existing, indent=2) + "\n")
+    return path
+
+
+_PLUGIN_TS = """\
+import type {{ Plugin }} from "@opencode-ai/plugin"
+
+export default {{
+  event: async ({{ $, event }}) => {{
+    if (event.type === "session.idle") {{
+      await $`{cmd}`
+    }}
+  }},
+}} satisfies Plugin
+"""
+
+
+def write_hook(target_dir: Path, command: str, args: list[str]) -> Path:
+    """Write a session.idle plugin to .opencode/plugins/lorekeep.ts.
+
+    opencode has no declarative hooks — this TS plugin subscribes to
+    session.idle and runs the lorekeep hook command.
+    """
+    cmd = " ".join([command, *args])
+    plugin_dir = Path(target_dir) / ".opencode" / "plugins"
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    path = plugin_dir / "lorekeep.ts"
+    path.write_text(_PLUGIN_TS.format(cmd=cmd))
     return path

--- a/tests/test_import_codex.py
+++ b/tests/test_import_codex.py
@@ -1,0 +1,238 @@
+"""Tests for Codex CLI session importer."""
+import json
+from pathlib import Path
+
+import pytest
+
+from lorekeep.compile.providers import FakeProvider
+from lorekeep.importer.codex import (
+    _strip_codex_prefix,
+    find_current_session,
+    import_codex,
+    import_memories,
+    import_session_deep,
+    parse_rollout,
+)
+
+
+def _write_rollout(path: Path, cwd: str, turns: list[dict]) -> None:
+    """Write a synthetic Codex rollout JSONL file."""
+    lines = [json.dumps({
+        "timestamp": "2026-06-28T10:00:00.000Z",
+        "type": "session_meta",
+        "payload": {
+            "session_id": "test-session-001",
+            "cwd": cwd,
+            "originator": "codex-cli",
+            "model_provider": "openai",
+        },
+    })]
+    for turn in turns:
+        lines.append(json.dumps(turn))
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _user_msg(text: str) -> dict:
+    return {
+        "timestamp": "2026-06-28T10:00:01.000Z",
+        "type": "response_item",
+        "payload": {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": f"## My request for Codex:\n{text}"}],
+        },
+    }
+
+
+def _assistant_msg(text: str) -> dict:
+    return {
+        "timestamp": "2026-06-28T10:00:02.000Z",
+        "type": "response_item",
+        "payload": {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": text}],
+        },
+    }
+
+
+# ── parse_rollout ─────────────────────────────────────────────────────────
+
+
+def test_parse_rollout_extracts_turns(tmp_path: Path):
+    rollout = tmp_path / "rollout-test.jsonl"
+    _write_rollout(rollout, str(tmp_path), [
+        _user_msg("What is FastAPI?"),
+        _assistant_msg("FastAPI is a web framework."),
+    ])
+    turns = parse_rollout(rollout)
+    assert len(turns) == 1
+    assert turns[0].user_content == "What is FastAPI?"
+    assert "web framework" in turns[0].assistant_text
+
+
+def test_parse_rollout_strips_codex_prefix(tmp_path: Path):
+    rollout = tmp_path / "rollout-test.jsonl"
+    _write_rollout(rollout, str(tmp_path), [
+        _user_msg("Fix the bug"),
+        _assistant_msg("Done."),
+    ])
+    turns = parse_rollout(rollout)
+    assert "## My request for Codex:" not in turns[0].user_content
+
+
+def test_parse_rollout_empty_file(tmp_path: Path):
+    rollout = tmp_path / "rollout-empty.jsonl"
+    rollout.write_text("")
+    assert parse_rollout(rollout) == []
+
+
+def test_strip_codex_prefix():
+    assert _strip_codex_prefix("## My request for Codex:\nhello") == "hello"
+    assert _strip_codex_prefix("no prefix") == "no prefix"
+
+
+# ── find_current_session ─────────────────────────────────────────────────
+
+
+def test_find_current_session_matches_cwd(tmp_path: Path, monkeypatch):
+    codex_home = tmp_path / "codex"
+    sessions_dir = codex_home / "sessions" / "2026" / "06" / "28"
+    sessions_dir.mkdir(parents=True)
+
+    rollout = sessions_dir / "rollout-test.jsonl"
+    _write_rollout(rollout, str(tmp_path), [])
+
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    result = find_current_session(cwd=tmp_path)
+    assert result == rollout
+
+
+def test_find_current_session_no_match(tmp_path: Path, monkeypatch):
+    codex_home = tmp_path / "codex"
+    sessions_dir = codex_home / "sessions" / "2026" / "06" / "28"
+    sessions_dir.mkdir(parents=True)
+
+    rollout = sessions_dir / "rollout-test.jsonl"
+    _write_rollout(rollout, "/other/project", [])
+
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    assert find_current_session(cwd=tmp_path) is None
+
+
+def test_find_current_session_no_dir(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "noexist"))
+    assert find_current_session() is None
+
+
+# ── import_memories ──────────────────────────────────────────────────────
+
+
+def test_import_memories_copies_files(tmp_path: Path, monkeypatch):
+    codex_home = tmp_path / "codex"
+    (codex_home / "memories").mkdir(parents=True)
+    (codex_home / "memories" / "note.md").write_text("# Knowledge\nImportant fact.")
+
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    raw_root = tmp_path / "raw"
+
+    written = import_memories(raw_root)
+    assert len(written) == 1
+    assert (raw_root / "codex-memory" / "note.md").exists()
+
+
+def test_import_memories_idempotent(tmp_path: Path, monkeypatch):
+    codex_home = tmp_path / "codex"
+    (codex_home / "memories").mkdir(parents=True)
+    (codex_home / "memories" / "note.md").write_text("# Knowledge\n")
+
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    raw_root = tmp_path / "raw"
+
+    first = import_memories(raw_root)
+    second = import_memories(raw_root)
+    assert len(first) == 1
+    assert len(second) == 0
+
+
+def test_import_memories_no_dir(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "empty"))
+    assert import_memories(tmp_path / "raw") == []
+
+
+# ── import_session_deep ──────────────────────────────────────────────────
+
+
+def test_import_session_deep_writes_files(tmp_path: Path):
+    rollout = tmp_path / "rollout-test.jsonl"
+    _write_rollout(rollout, str(tmp_path), [
+        _user_msg("What is FastAPI?"),
+        _assistant_msg("A web framework for Python."),
+    ])
+    raw_root = tmp_path / "raw"
+    provider = FakeProvider(responses=["# Summary\n\n## Decisions\n- Use FastAPI\n"] * 50)
+
+    result = import_session_deep(rollout, raw_root, provider=provider)
+    assert len(result) >= 1
+    files = list((raw_root / "codex-session").glob("session-*.md"))
+    assert len(files) >= 1
+
+
+def test_import_session_deep_idempotent(tmp_path: Path):
+    rollout = tmp_path / "rollout-test.jsonl"
+    _write_rollout(rollout, str(tmp_path), [
+        _user_msg("Test"),
+        _assistant_msg("Response"),
+    ])
+    raw_root = tmp_path / "raw"
+    provider = FakeProvider(responses=["# Summary\n"] * 50)
+
+    first = import_session_deep(rollout, raw_root, provider=provider)
+    call_before = len(provider.calls)
+    second = import_session_deep(rollout, raw_root, provider=provider)
+    assert len(first) >= 1
+    assert second == []
+    assert len(provider.calls) == call_before
+
+
+# ── orchestrator ─────────────────────────────────────────────────────────
+
+
+def test_import_codex_deep(tmp_path: Path, monkeypatch):
+    codex_home = tmp_path / "codex"
+    sessions_dir = codex_home / "sessions" / "2026" / "06" / "28"
+    sessions_dir.mkdir(parents=True)
+    (codex_home / "memories").mkdir(parents=True)
+    (codex_home / "memories" / "fact.md").write_text("# Fact\n")
+
+    rollout = sessions_dir / "rollout-test.jsonl"
+    _write_rollout(rollout, str(tmp_path), [
+        _user_msg("Build an API"),
+        _assistant_msg("Use FastAPI."),
+    ])
+
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    raw_root = tmp_path / "raw"
+    provider = FakeProvider(responses=["# Summary\n\n## Architecture\n- FastAPI\n"] * 50)
+
+    result = import_codex(raw_root, rollout_path=rollout, provider=provider)
+    assert len(result["memory"]) == 1
+    assert len(result["session"]) >= 1
+
+
+def test_import_codex_quick_only(tmp_path: Path, monkeypatch):
+    codex_home = tmp_path / "codex"
+    (codex_home / "memories").mkdir(parents=True)
+    (codex_home / "memories" / "fact.md").write_text("# Fact\n")
+
+    rollout = codex_home / "sessions" / "2026" / "06" / "28" / "rollout-test.jsonl"
+    rollout.parent.mkdir(parents=True)
+    _write_rollout(rollout, str(tmp_path), [
+        _user_msg("Test"),
+        _assistant_msg("Response"),
+    ])
+
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    result = import_codex(tmp_path / "raw", rollout_path=rollout, quick=True)
+    assert len(result["memory"]) == 1
+    assert result["session"] == []

--- a/tests/test_import_opencode.py
+++ b/tests/test_import_opencode.py
@@ -1,0 +1,170 @@
+"""Tests for opencode session importer."""
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from lorekeep.compile.providers import FakeProvider
+from lorekeep.importer.opencode import (
+    find_current_session,
+    import_opencode,
+    import_session_deep,
+    parse_session,
+)
+
+
+def _build_db(db_path: Path, cwd: str, session_id: str = "ses_test001") -> str:
+    """Build a synthetic opencode SQLite DB with one session."""
+    con = sqlite3.connect(str(db_path))
+    con.executescript("""
+        CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT);
+        CREATE TABLE session (
+            id TEXT PRIMARY KEY, project_id TEXT,
+            time_created INTEGER, time_updated INTEGER, data TEXT
+        );
+        CREATE TABLE message (
+            id TEXT PRIMARY KEY, session_id TEXT,
+            time_created INTEGER, data TEXT
+        );
+        CREATE TABLE part (
+            id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+            time_created INTEGER, data TEXT
+        );
+    """)
+
+    project_id = "proj_test"
+    con.execute("INSERT INTO project VALUES (?, ?)", (project_id, cwd))
+    con.execute("INSERT INTO session VALUES (?, ?, ?, ?, ?)",
+                (session_id, project_id, 1000, 2000,
+                 json.dumps({"role": "system", "agent": "general"})))
+
+    # User message + parts
+    user_msg_id = "msg_user1"
+    con.execute("INSERT INTO message VALUES (?, ?, ?, ?)",
+                (user_msg_id, session_id, 1100,
+                 json.dumps({"role": "user"})))
+    con.execute("INSERT INTO part VALUES (?, ?, ?, ?, ?)",
+                ("part_u1", user_msg_id, session_id, 1100,
+                 json.dumps({"type": "text", "text": "What is the auth flow?"})))
+
+    # Assistant message + parts
+    asst_msg_id = "msg_asst1"
+    con.execute("INSERT INTO message VALUES (?, ?, ?, ?)",
+                (asst_msg_id, session_id, 1200,
+                 json.dumps({"role": "assistant", "finish": "stop"})))
+    con.execute("INSERT INTO part VALUES (?, ?, ?, ?, ?)",
+                ("part_a1", asst_msg_id, session_id, 1200,
+                 json.dumps({"type": "text", "text": "Auth uses JWT tokens."})))
+    con.execute("INSERT INTO part VALUES (?, ?, ?, ?, ?)",
+                ("part_a2", asst_msg_id, session_id, 1201,
+                 json.dumps({"type": "tool", "tool": "bash", "callID": "call_1",
+                             "state": {"status": "completed", "input": {"command": "ls"}}})))
+
+    con.commit()
+    con.close()
+    return session_id
+
+
+# ── find_current_session ─────────────────────────────────────────────────
+
+
+def test_find_current_session_matches_cwd(tmp_path: Path, monkeypatch):
+    db = tmp_path / "opencode.db"
+    _build_db(db, str(tmp_path))
+
+    monkeypatch.setattr("lorekeep.importer.opencode._opencode_db", lambda: db)
+    result = find_current_session(cwd=tmp_path)
+    assert result == "ses_test001"
+
+
+def test_find_current_session_no_match(tmp_path: Path, monkeypatch):
+    db = tmp_path / "opencode.db"
+    _build_db(db, "/other/project")
+
+    monkeypatch.setattr("lorekeep.importer.opencode._opencode_db", lambda: db)
+    assert find_current_session(cwd=tmp_path) is None
+
+
+def test_find_current_session_no_db(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("lorekeep.importer.opencode._opencode_db", lambda: tmp_path / "noexist.db")
+    assert find_current_session() is None
+
+
+# ── parse_session ────────────────────────────────────────────────────────
+
+
+def test_parse_session_extracts_turns(tmp_path: Path, monkeypatch):
+    db = tmp_path / "opencode.db"
+    sid = _build_db(db, str(tmp_path))
+
+    monkeypatch.setattr("lorekeep.importer.opencode._opencode_db", lambda: db)
+    turns = parse_session(sid, db_path=db)
+    assert len(turns) == 1
+    assert "auth flow" in turns[0].user_content.lower()
+    assert "JWT" in turns[0].assistant_text
+    assert "bash" in turns[0].tool_calls
+
+
+def test_parse_session_empty(tmp_path: Path):
+    db = tmp_path / "opencode.db"
+    _build_db(db, str(tmp_path))
+
+    turns = parse_session("nonexistent", db_path=db)
+    assert turns == []
+
+
+# ── import_session_deep ──────────────────────────────────────────────────
+
+
+def test_import_session_deep_writes_files(tmp_path: Path, monkeypatch):
+    db = tmp_path / "opencode.db"
+    sid = _build_db(db, str(tmp_path))
+
+    raw_root = tmp_path / "raw"
+    provider = FakeProvider(responses=["# Summary\n\n## Architecture\n- JWT auth\n"] * 50)
+
+    result = import_session_deep(sid, raw_root, provider=provider, db_path=db)
+    assert len(result) >= 1
+    files = list((raw_root / "opencode-session").glob("session-*.md"))
+    assert len(files) >= 1
+
+
+def test_import_session_deep_idempotent(tmp_path: Path):
+    db = tmp_path / "opencode.db"
+    sid = _build_db(db, str(tmp_path))
+
+    raw_root = tmp_path / "raw"
+    provider = FakeProvider(responses=["# Summary\n"] * 50)
+
+    first = import_session_deep(sid, raw_root, provider=provider, db_path=db)
+    call_before = len(provider.calls)
+    second = import_session_deep(sid, raw_root, provider=provider, db_path=db)
+    assert len(first) >= 1
+    assert second == []
+    assert len(provider.calls) == call_before
+
+
+# ── orchestrator ─────────────────────────────────────────────────────────
+
+
+def test_import_opencode_deep(tmp_path: Path, monkeypatch):
+    db = tmp_path / "opencode.db"
+    sid = _build_db(db, str(tmp_path))
+
+    monkeypatch.setattr("lorekeep.importer.opencode._opencode_db", lambda: db)
+    monkeypatch.setattr("lorekeep.importer.opencode.find_current_session", lambda cwd=None: sid)
+
+    raw_root = tmp_path / "raw"
+    provider = FakeProvider(responses=["# Summary\n\n## Decisions\n- JWT\n"] * 50)
+
+    result = import_opencode(raw_root, provider=provider)
+    assert result["memory"] == []
+    assert len(result["session"]) >= 1
+
+
+def test_import_opencode_no_session(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("lorekeep.importer.opencode._opencode_db", lambda: tmp_path / "noexist.db")
+    result = import_opencode(tmp_path / "raw")
+    assert result["memory"] == []
+    assert result["session"] == []

--- a/tests/test_session_hook.py
+++ b/tests/test_session_hook.py
@@ -16,8 +16,8 @@ runner = CliRunner()
 # ── lorekeep hook command ─────────────────────────────────────────────────
 
 
-def test_hook_imports_memory_from_stdin(tmp_path: Path, monkeypatch):
-    """lorekeep hook reads transcript_path from stdin, imports memory files."""
+def test_hook_imports_claude_memory(tmp_path: Path, monkeypatch):
+    """lorekeep hook auto-detects Claude session and imports memory files."""
     home = tmp_path / "home"
     home.mkdir()
     (home / "raw").mkdir()
@@ -28,13 +28,11 @@ def test_hook_imports_memory_from_stdin(tmp_path: Path, monkeypatch):
     session_dir = tmp_path / "session"
     (session_dir / "memory").mkdir(parents=True)
     (session_dir / "memory" / "note.md").write_text("# Important\nKnowledge.\n")
-    transcript = session_dir / "transcript.jsonl"
-    transcript.write_text("{}")
 
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.setattr("lorekeep.importer.claude.find_current_session", lambda: session_dir)
 
-    hook_input = json.dumps({"transcript_path": str(transcript)})
-    result = runner.invoke(app, ["hook"], input=hook_input)
+    result = runner.invoke(app, ["hook"])
     assert result.exit_code == 0, result.stdout
 
     imported = home / "raw" / "claude-memory" / "note.md"
@@ -49,11 +47,10 @@ def test_hook_no_session_silent_exit(tmp_path: Path, monkeypatch):
     (home / "raw").mkdir()
     (home / "graph").mkdir()
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
-    monkeypatch.setattr(
-        "lorekeep.importer.claude.find_current_session", lambda: None
-    )
+    monkeypatch.setattr("lorekeep.importer.claude.find_current_session", lambda: None)
+    monkeypatch.setattr("lorekeep.importer.codex.import_memories", lambda *a, **k: [])
 
-    result = runner.invoke(app, ["hook"], input="")
+    result = runner.invoke(app, ["hook"])
     assert result.exit_code == 0
 
 
@@ -66,11 +63,11 @@ def test_hook_no_memory_dir_silent_exit(tmp_path: Path, monkeypatch):
 
     session_dir = tmp_path / "session"
     session_dir.mkdir()
-    transcript = session_dir / "transcript.jsonl"
-    transcript.write_text("{}")
 
-    hook_input = json.dumps({"transcript_path": str(transcript)})
-    result = runner.invoke(app, ["hook"], input=hook_input)
+    monkeypatch.setattr("lorekeep.importer.claude.find_current_session", lambda: session_dir)
+    monkeypatch.setattr("lorekeep.importer.codex.import_memories", lambda *a, **k: [])
+
+    result = runner.invoke(app, ["hook"])
     assert result.exit_code == 0
 
 
@@ -86,14 +83,12 @@ def test_hook_idempotent(tmp_path: Path, monkeypatch):
     session_dir = tmp_path / "session"
     (session_dir / "memory").mkdir(parents=True)
     (session_dir / "memory" / "note.md").write_text("# Knowledge\n")
-    transcript = session_dir / "transcript.jsonl"
-    transcript.write_text("{}")
 
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.setattr("lorekeep.importer.claude.find_current_session", lambda: session_dir)
 
-    hook_input = json.dumps({"transcript_path": str(transcript)})
-    runner.invoke(app, ["hook"], input=hook_input)
-    result2 = runner.invoke(app, ["hook"], input=hook_input)
+    runner.invoke(app, ["hook"])
+    result2 = runner.invoke(app, ["hook"])
     assert result2.exit_code == 0
     assert "imported" not in result2.stdout.lower()
 
@@ -190,8 +185,8 @@ def test_mcp_add_writes_claude_hook(tmp_path: Path, monkeypatch):
     assert "SessionEnd" in data["hooks"]
 
 
-def test_mcp_add_opencode_no_hook(tmp_path: Path, monkeypatch):
-    """mcp add --agent opencode should NOT write a hook (no hook mechanism)."""
+def test_mcp_add_opencode_writes_hook(tmp_path: Path, monkeypatch):
+    """mcp add --agent opencode writes session.idle plugin."""
     home = tmp_path / "home"
     project = tmp_path / "project"
     project.mkdir()
@@ -204,7 +199,11 @@ def test_mcp_add_opencode_no_hook(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["mcp", "add", "--agent", "opencode", "--ns", "backend"])
     assert result.exit_code == 0, result.stdout
 
-    assert not (project / ".claude" / "settings.json").exists()
+    plugin = project / ".opencode" / "plugins" / "lorekeep.ts"
+    assert plugin.exists()
+    content = plugin.read_text()
+    assert "session.idle" in content
+    assert "lorekeep hook" in content
 
 
 # ── Cursor hook ───────────────────────────────────────────────────────────
@@ -244,3 +243,57 @@ def test_mcp_add_cursor_hook(tmp_path: Path, monkeypatch):
     assert hooks_path.exists()
     data = json.loads(hooks_path.read_text())
     assert "sessionEnd" in data["hooks"]
+
+
+# ── Codex hook ────────────────────────────────────────────────────────────
+
+
+def test_write_codex_hook(tmp_path: Path):
+    """write_hook for Codex creates .codex/hooks.json with Stop event."""
+    from lorekeep.integrations.codex import write_hook as write_codex_hook
+
+    path = write_codex_hook(tmp_path, "uvx", ["lorekeep", "hook"])
+    assert path == tmp_path / ".codex" / "hooks.json"
+    assert path.exists()
+
+    data = json.loads(path.read_text())
+    hooks = data["hooks"]["Stop"]
+    assert len(hooks) == 1
+    handler = hooks[0]["hooks"][0]
+    assert handler["type"] == "command"
+    assert "lorekeep hook" in handler["command"]
+    assert handler["timeout"] == 30
+
+
+def test_mcp_add_codex_hook(tmp_path: Path, monkeypatch):
+    """mcp add --agent codex writes Stop hook."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    home.mkdir()
+    (home / "config.yaml").write_text("install_source: pypi\n")
+
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["mcp", "add", "--agent", "codex", "--ns", "backend"])
+    assert result.exit_code == 0, result.stdout
+
+    hooks_path = project / ".codex" / "hooks.json"
+    assert hooks_path.exists()
+
+
+# ── opencode hook ─────────────────────────────────────────────────────────
+
+
+def test_write_opencode_hook(tmp_path: Path):
+    """write_hook for opencode creates .opencode/plugins/lorekeep.ts."""
+    from lorekeep.integrations.opencode import write_hook as write_oc_hook
+
+    path = write_oc_hook(tmp_path, "uvx", ["lorekeep", "hook"])
+    assert path == tmp_path / ".opencode" / "plugins" / "lorekeep.ts"
+    assert path.exists()
+
+    content = path.read_text()
+    assert "session.idle" in content
+    assert "uvx lorekeep hook" in content


### PR DESCRIPTION
## Summary

Unifies lifecycle across all 4 supported coding agents. Codex and opencode now have session importers alongside Claude and Cursor.

### Before

| Agent | MCP tools | Session import | Hook |
|---|---|---|---|
| Claude | ✅ | ✅ | ✅ |
| Cursor | ✅ | ✅ | ✅ |
| Codex | ✅ | ❌ | ❌ |
| opencode | ✅ | ❌ | ❌ |

### After

| Agent | MCP tools | Session import | Hook |
|---|---|---|---|
| Claude | ✅ | ✅ | ✅ |
| Cursor | ✅ | ✅ | ✅ |
| Codex | ✅ | ✅ | ❌ |
| opencode | ✅ | ✅ | ❌ |

### New importers

**`importer/codex.py`** — Codex CLI rollout JSONL parser:
- Reads `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl`
- Quick mode: copies `memories/*.md` (zero LLM)
- Deep mode: summarizes transcript via LLM (reuses `summarize_batch`)
- Strips `## My request for Codex:` prefix from user messages
- Session discovery: scans files by mtime, matches `payload.cwd`

**`importer/opencode.py`** — opencode SQLite reader:
- Reads `~/.local/share/opencode/opencode.db` (read-only)
- Deep-only (opencode has no memory dir)
- Queries `session JOIN project WHERE worktree = cwd`
- Extracts text/tool parts from `message → part` tables

Both have manifest dedup — idempotent re-import = zero LLM cost.

### CLI

```bash
lorekeep import --from codex      # quick: memories, deep: transcript
lorekeep import --from opencode   # deep-only
```

### Tests (23 new, 272 total)

- Codex: parse rollout, strip prefix, find session, memory import, deep import, idempotency, orchestrator (14 tests)
- opencode: find session, parse, deep import, idempotency, orchestrator (9 tests)

Closes #3, closes #5.