### PR TITLE
feat: add Obsidian-compatible wiki output from compiled graph

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ COMPILE (offline, curator):  raw/<ns>/*.md → ingest → extract(LLM) → resol
 SERVE   (runtime, per device): facts.jsonl → GraphStore → ScopedGraph(ns) → MCP → agent
 ```
 
-`compile` mutates `facts.jsonl` and auto-generates `wiki/`; `serve` reads `facts.jsonl` and lazily reloads on mtime change. Write tools (propose_fact, link_facts, etc.) append to `pending/` journals; resolve merges them into the graph.
+`compile` mutates `facts.jsonl` and auto-generates `wiki/`; `resolve` regenerates wiki only on actual merge (gated on `merge_count > 0`); `serve` reads `facts.jsonl` and lazily reloads on mtime change. Write tools (propose_fact, link_facts, etc.) append to `pending/` journals; resolve merges them into the graph. Wiki regen is **best-effort** — never blocks `compile` or `resolve`. Wiki builds into a temp dir then `os.rename` swaps into place (atomic — never partially populated).
 
 ### Compile pipeline (`src/lorekeep/compile/`, orchestrated by `pipeline.py`)
 `ingest` chunks markdown with `path:line` provenance → `extract` calls the LLM provider for schema-constrained nodes/edges/aliases (per-chunk SHA-256 hash cache → unchanged chunks return cached output, giving byte-stable recompiles) → `resolve` collapses alias variants to canonical entities and quarantines invalid facts → `writer` emits **sorted** `facts.jsonl` + `manifest.json`. Failures are skip-and-log (partial compile is valid); errors/quarantine land in the manifest.
@@ -59,6 +59,9 @@ Pydantic, all `frozen=True`, `extra="forbid"`. `Node` / `Edge` are the two `kind
 
 ### Serve (`mcp_server.py`)
 `FastMCP` with 8 read tools (`search`, `get_node`, `neighbors`, `at_time`, `history`, `changes`, `list_namespaces`, `schema`) and 5 write tools (`propose_fact`, `link_facts`, `flag_contradiction`, `update_fact`, `suggest_improvement`). Module-global `ScopedGraph` is set by `configure()`; `_require()` lazy-reloads when `facts.jsonl` mtime changes (so `compile` is visible without reconnecting). Tools are plain functions registered with `@mcp.tool()` but stay directly callable — **tests invoke them directly, no MCP transport**. The writer uses atomic `os.replace` so lazy-reload never reads a half-written file.
+
+### Wiki (`wiki.py`)
+Pure JSONL → markdown transform (no LLM). `generate_wiki(graph_dir, wiki_dir)` reads `facts.jsonl` via `GraphStore` → entity pages (`entities/<type>/<slug>.md` with YAML frontmatter, wikilinks, props table), `index.md` (catalog), `overview.md` (stats dashboard), `log.md` (append-only, preserved across regen). Builds into `.wiki-build.tmp` then `os.rename` swaps into place (atomic). `_slug()` replaces `:`/`/` with `-`; collisions raise `ValueError`. YAML scalars quoted via `json.dumps` so IDs like `svc:payments-api` parse correctly. Props table escapes `\|`, collapses newlines, serializes non-strings. Regenerates on every `facts.jsonl` mutation: `compile` (single regen — `_do_auto_resolve` returns bool, compile skips if resolve already regend), `resolve` (gated on merge/flag), daemon auto-resolve (on actual merge). Best-effort — never blocks compile or resolve.
 
 ### Path resolution (`paths.py`)
 Pure (no I/O), 4-tier precedence high→low: explicit `LOREKEEP_RAW/OUT/CACHE/SCHEMA/CONFIG/WIKI` env → `LOREKEEP_HOME` → **dev mode** (`.lorekeep/` present in CWD, or `LOREKEEP_DEV=1`; auto-detected in a source checkout) — all data lives under `cwd/.lorekeep/` (`config.yaml`, `schema.json`, `raw/`, `graph/`, `wiki/`, `pending/`, `cache.json`), mirroring the `LOREKEEP_HOME` layout → XDG (`platformdirs`). Running `uv run lorekeep …` from the repo uses the repo's own `.lorekeep/` data home with zero migration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,12 +25,13 @@ uv run lorekeep <command>                    # run the CLI in dev mode
 | Command | Purpose |
 |---|---|
 | `init` | Bootstrap data home (config + schema + raw/graph dirs) |
-| `compile` | `raw/*.md` → `graph/facts.jsonl` + `manifest.json` (runs the LLM pipeline) |
+| `compile` | `raw/*.md` → `graph/facts.jsonl` + `manifest.json` + `wiki/` (runs the LLM pipeline, auto-generates wiki) |
 | `check` | Validate compiled graph loads, no dangling edges (exit 1 on failure) |
 | `eval` | Tier-1 construction P/R/F1 vs gold corpus + structure metrics |
+| `wiki` | Regenerate `wiki/` from `facts.jsonl` (Obsidian-compatible markdown) |
 | `serve [--transport stdio\|http]` | Run the MCP server (8 read + 5 write tools) |
 | `mcp add --agent claude\|cursor\|codex\|opencode --ns NS` | Write agent MCP config |
-| `import --from claude\|cursor` | Import agent sessions into `raw/` (claude: quick+deep; cursor: deep-only) |
+| `import --from claude\|cursor\|codex\|opencode` | Import agent sessions into `raw/` |
 | `doctor` | Verify install: graph loads, schema valid, a tool responds |
 | `backup [--init <remote-url>]` | Commit + push `.lorekeep/` to your private backup git repo |
 | `version` | Print version |
@@ -40,11 +41,11 @@ uv run lorekeep <command>                    # run the CLI in dev mode
 ## Architecture: two strictly separated phases
 
 ```
-COMPILE (offline, curator):  raw/<ns>/*.md → ingest → extract(LLM) → resolve → writer → facts.jsonl
+COMPILE (offline, curator):  raw/<ns>/*.md → ingest → extract(LLM) → resolve → writer → facts.jsonl → wiki/
 SERVE   (runtime, per device): facts.jsonl → GraphStore → ScopedGraph(ns) → MCP → agent
 ```
 
-`compile` mutates `facts.jsonl`; `serve` reads it and lazily reloads on mtime change. Write tools (propose_fact, link_facts, etc.) append to `pending/` journals; resolve merges them into the graph.
+`compile` mutates `facts.jsonl` and auto-generates `wiki/`; `serve` reads `facts.jsonl` and lazily reloads on mtime change. Write tools (propose_fact, link_facts, etc.) append to `pending/` journals; resolve merges them into the graph.
 
 ### Compile pipeline (`src/lorekeep/compile/`, orchestrated by `pipeline.py`)
 `ingest` chunks markdown with `path:line` provenance → `extract` calls the LLM provider for schema-constrained nodes/edges/aliases (per-chunk SHA-256 hash cache → unchanged chunks return cached output, giving byte-stable recompiles) → `resolve` collapses alias variants to canonical entities and quarantines invalid facts → `writer` emits **sorted** `facts.jsonl` + `manifest.json`. Failures are skip-and-log (partial compile is valid); errors/quarantine land in the manifest.
@@ -60,7 +61,7 @@ Pydantic, all `frozen=True`, `extra="forbid"`. `Node` / `Edge` are the two `kind
 `FastMCP` with 8 read tools (`search`, `get_node`, `neighbors`, `at_time`, `history`, `changes`, `list_namespaces`, `schema`) and 5 write tools (`propose_fact`, `link_facts`, `flag_contradiction`, `update_fact`, `suggest_improvement`). Module-global `ScopedGraph` is set by `configure()`; `_require()` lazy-reloads when `facts.jsonl` mtime changes (so `compile` is visible without reconnecting). Tools are plain functions registered with `@mcp.tool()` but stay directly callable — **tests invoke them directly, no MCP transport**. The writer uses atomic `os.replace` so lazy-reload never reads a half-written file.
 
 ### Path resolution (`paths.py`)
-Pure (no I/O), 4-tier precedence high→low: explicit `LOREKEEP_RAW/OUT/CACHE/SCHEMA/CONFIG` env → `LOREKEEP_HOME` → **dev mode** (`.lorekeep/` present in CWD, or `LOREKEEP_DEV=1`; auto-detected in a source checkout) — all data lives under `cwd/.lorekeep/` (`config.yaml`, `schema.json`, `raw/`, `graph/`, `cache.json`), mirroring the `LOREKEEP_HOME` layout → XDG (`platformdirs`). Running `uv run lorekeep …` from the repo uses the repo's own `.lorekeep/` data home with zero migration.
+Pure (no I/O), 4-tier precedence high→low: explicit `LOREKEEP_RAW/OUT/CACHE/SCHEMA/CONFIG/WIKI` env → `LOREKEEP_HOME` → **dev mode** (`.lorekeep/` present in CWD, or `LOREKEEP_DEV=1`; auto-detected in a source checkout) — all data lives under `cwd/.lorekeep/` (`config.yaml`, `schema.json`, `raw/`, `graph/`, `wiki/`, `pending/`, `cache.json`), mirroring the `LOREKEEP_HOME` layout → XDG (`platformdirs`). Running `uv run lorekeep …` from the repo uses the repo's own `.lorekeep/` data home with zero migration.
 
 ### Provider pluggability (`compile/providers.py`)
 `LiteLLMProvider` (OpenAI / Anthropic / DashScope/Qwen / Ollama via litellm model strings) and `FakeProvider` (tests/offline). Model is set in `config.yaml` as a litellm string.
@@ -79,11 +80,11 @@ Pure (no I/O), 4-tier precedence high→low: explicit `LOREKEEP_RAW/OUT/CACHE/SC
 - **Conventional Commits are enforced** — a `commit-msg` pre-commit hook (`scripts/check-conventional-commit.py`) plus CI (`lint-commits.yml`, checking both commit messages and PR title). Types: `build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test`. Merge commits are exempt.
 - **Releases are automated** — `release-please` runs on every push to `main` (`feat`=minor, `fix`=patch, `!`=major), opens an auto-merging Release PR, tags a GitHub Release on merge, and publishes to PyPI via OIDC trusted publishing (inline publish job). Do not version-bump by hand.
 - **Determinism is a hard requirement** — recompiling unchanged input must be byte-identical (kept green by `test_determinism.py`). Preserve the sorted-output / cache behavior in `writer.py` and `extract.py` when changing the pipeline.
-- **`graph/facts.jsonl` and `graph/manifest.json` are gitignored** (regenerated by `compile`); `.lorekeep/schema.json` is committed.
+- **`graph/facts.jsonl`, `graph/manifest.json`, and `wiki/` are gitignored** (regenerated by `compile`); `.lorekeep/schema.json` is committed.
 
 ## Tests
 
-`~140` tests, no network. Gold corpus in `tests/fixtures/gold/`, raw fixtures in `tests/fixtures/raw/`. Compile/serve/import tests inject `FakeProvider` via `patch_make_provider` / `patch_make_import_provider` conftest fixtures to pin paths and avoid the LLM — follow this pattern for any new CLI test rather than hitting a real provider.
+`~300` tests, no network. Gold corpus in `tests/fixtures/gold/`, raw fixtures in `tests/fixtures/raw/`. Compile/serve/import tests inject `FakeProvider` via `patch_make_provider` / `patch_make_import_provider` conftest fixtures to pin paths and avoid the LLM — follow this pattern for any new CLI test rather than hitting a real provider.
 
 ## Cursor Cloud specific instructions
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ src/lorekeep/
   store/{graph,fts}.py                          GraphStore + optional FTS cache
   perm/ns.py                                    ScopedGraph permission chokepoint
   mcp_server.py                                 FastMCP + 8 read + 5 write tools
-  integrations/{claude_code,cursor,codex,common}.py
+  wiki.py                                        Obsidian-compatible wiki generator
+  integrations/{claude_code,cursor,codex,opencode,common}.py
   pipeline.py, cli.py
   eval/{gold,construction,retrieval}.py
 tests/                 ~140 tests
@@ -256,9 +257,9 @@ docs/                  README.md index, architecture/, guides/
 
 ## Status
 
-**v1 (implemented)** — compile pipeline + serve (store/permission/MCP read/integrations) + import + agent daemon (watch/ingest/lint/suggest/status) + journal + resolve + data-home + dev mode + lazy-reload + backup + eval. Published to PyPI as `lorekeep`.
+**v1 (implemented)** — compile pipeline + serve (store/permission/MCP read+write/4-agent integrations) + import (Claude/Cursor/Codex/opencode) + session-end hooks + agent daemon (watch/ingest/lint/suggest/status) + journal + resolve + data-home + dev mode + lazy-reload + backup + eval + **wiki** (Obsidian-compatible markdown output). Published to PyPI as `lorekeep`.
 
-**Phase 2 (planned)** — `wiki.md` views (Obsidian-compatible markdown output), streamable-HTTP team server, OIDC/SSO, embeddings/hybrid search, scheduled nightly lint/suggest in daemon, schema evolve, full Tier-2 benchmark datasets (HotpotQA/CronQuestions) and the bespoke Tier-3 Lorekeep-Reason eval.
+**Phase 2 (planned)** — streamable-HTTP team server, OIDC/SSO, embeddings/hybrid search, scheduled nightly lint/suggest in daemon, schema evolve, full Tier-2 benchmark datasets (HotpotQA/CronQuestions) and the bespoke Tier-3 Lorekeep-Reason eval.
 
 ## Documentation
 
@@ -269,6 +270,7 @@ The [`docs/`](docs/README.md) index is the entry point.
 - [Importing agent sessions](docs/guides/import.md)
 - [Compiling the knowledge graph](docs/guides/compile.md)
 - [Serving the graph to coding agents](docs/guides/serve.md)
+- [Browsing the wiki](docs/guides/wiki.md)
 - [Data home & path resolution](docs/guides/data-home.md)
 - [Backing up the data home](docs/guides/backup.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,8 +24,9 @@ Concepts and design — how the system fits together.
 How to use it.
 
 - [**Getting started**](guides/getting-started.md) — install → compile → serve → backup in 10 minutes. Start here.
-- [Importing agent sessions](guides/import.md) — Claude Code + Cursor → `raw/`.
+- [Importing agent sessions](guides/import.md) — Claude Code + Cursor + Codex + opencode → `raw/`.
 - [Compiling the knowledge graph](guides/compile.md) — `raw/*.md` → `facts.jsonl` + resolve pending.
-- [Serving the graph to coding agents](guides/serve.md) — wire Claude Code / Cursor / Codex over MCP, write tools, daemon.
+- [Serving the graph to coding agents](guides/serve.md) — wire Claude Code / Cursor / Codex / opencode over MCP, write tools, daemon.
+- [Browsing the wiki](guides/wiki.md) — human-readable Obsidian-compatible markdown view of the graph.
 - [Data home & path resolution](guides/data-home.md) — env / `LOREKEEP_HOME` / dev mode / XDG.
 - [Backing up the data home](guides/backup.md) — `lorekeep backup` to a private git repo: setup, restore, multi-device conflicts.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -48,8 +48,8 @@ Lorekeep exists to let an agent reason about a domain **systematically and with 
               facts.jsonl                       THE store (sorted, byte-stable)
                     │
                     ├──► wiki/*.md               human view (Obsidian-compatible)
-                    │     entities/, index.md,
-                    │     overview.md, log.md
+                    │     atomic swap, regen on
+                    │     every facts mutation
                     │
                     ▼  (git / S3 sync)
     ┌───────────────────────────────────────────┐

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -47,6 +47,10 @@ Lorekeep exists to let an agent reason about a domain **systematically and with 
                     ▼
               facts.jsonl                       THE store (sorted, byte-stable)
                     │
+                    ├──► wiki/*.md               human view (Obsidian-compatible)
+                    │     entities/, index.md,
+                    │     overview.md, log.md
+                    │
                     ▼  (git / S3 sync)
     ┌───────────────────────────────────────────┐
     │        SERVE + QUERY (runtime, per device) │

--- a/docs/guides/compile.md
+++ b/docs/guides/compile.md
@@ -36,12 +36,16 @@ uv run lorekeep compile
 ```
 
 Produces `graph/facts.jsonl` + `graph/manifest.json` + auto-generates `wiki/`
-(Obsidian-compatible markdown). Re-running is idempotent:
-unchanged input yields byte-identical files (extraction is cached under
-`.lorekeep/cache.json`).
+(Obsidian-compatible markdown, regenerated atomically). If `pending/`
+journals exist, compile also merges them via `_do_auto_resolve` — in that
+case wiki regenerates once from the resolved facts (never double).
+Re-running is idempotent: unchanged input yields byte-identical files
+(extraction is cached under `.lorekeep/cache.json`).
 
 **What compile does not do:** compile processes only `raw/`. Agent-proposed
 facts in `pending/` journals are merged by `resolve` (see step 5).
+Compile does re-merge pending journals as a convenience, but standalone
+`resolve` is needed if you add journals after compile.
 
 ## 4. Resolve pending facts (manual)
 
@@ -51,7 +55,8 @@ uv run lorekeep resolve
 
 Merges all pending agent-proposed facts from `pending/` journals into `facts.jsonl`.
 Facts are gated by confidence: high (≥0.8) auto-merge, medium (0.5-0.8) merge
-with review flag, low (<0.5) quarantine.
+with review flag, low (<0.5) quarantine. Wiki regenerates only if facts
+actually changed (`merge_count > 0` or `flagged_count > 0`).
 
 Resolve also runs automatically: the daemon (`lorekeep agent watch`) detects
 new pending entries on every poll cycle (default 60s interval).

--- a/docs/guides/compile.md
+++ b/docs/guides/compile.md
@@ -35,8 +35,9 @@ provider:
 uv run lorekeep compile
 ```
 
-Produces `graph/facts.jsonl` + `graph/manifest.json`. Re-running is idempotent:
-unchanged input yields a byte-identical file (extraction is cached under
+Produces `graph/facts.jsonl` + `graph/manifest.json` + auto-generates `wiki/`
+(Obsidian-compatible markdown). Re-running is idempotent:
+unchanged input yields byte-identical files (extraction is cached under
 `.lorekeep/cache.json`).
 
 **What compile does not do:** compile processes only `raw/`. Agent-proposed
@@ -95,7 +96,8 @@ the next resolve.
 
 ## Next: serve to agents
 
-See [serve.md](serve.md) to expose the graph to Claude Code / Cursor / Codex over MCP.
+See [serve.md](serve.md) to expose the graph to Claude Code / Cursor / Codex over MCP,
+or [wiki.md](wiki.md) to browse the graph as Obsidian markdown.
 
 ## Data home
 

--- a/docs/guides/serve.md
+++ b/docs/guides/serve.md
@@ -101,13 +101,20 @@ rebuilt automatically. So the workflow is:
 
 ```bash
 <edit raw/.../*.md>
-uvx lorekeep compile          # rebuilds facts.jsonl
+uvx lorekeep compile          # rebuilds facts.jsonl + regenerates wiki/
 # OR: agent ingest + resolve  # propose facts interactively, merge journals
 # OR: lorekeep agent watch    # daemon does compile + resolve automatically
 # next query from the agent sees the new graph — NO reconnect needed
+# wiki/ pages also regenerated automatically
 ```
 
 Connect the MCP server **once**; graph updates via `compile`, `resolve`, or
 the daemon are visible immediately. Reconnect is only needed for **code**
 changes (rare; the serve path is stable) or **scope** changes (`.mcp.json`
 `LOREKEEP_NS`).
+
+## Human view: wiki
+
+The same `facts.jsonl` is also projected to **Obsidian-compatible markdown**
+in `wiki/` — one page per node, `[[wikilinks]]` for edges, YAML frontmatter
+for Dataview. See [wiki.md](wiki.md).

--- a/docs/guides/wiki.md
+++ b/docs/guides/wiki.md
@@ -28,9 +28,9 @@ The wiki is a **derived artifact** — fully regenerable from `facts.jsonl`, nev
 
 ```
 raw/*.md → compile → facts.jsonl → wiki/*.md
-                         ↑                ↓
-                    agent queries     human browses
-                    (MCP tools)      (Obsidian)
+                          ↑                ↓
+                     agent queries     human browses
+                     (MCP tools)      (Obsidian)
 ```
 
 | Consumer | Reads | Format |
@@ -38,7 +38,22 @@ raw/*.md → compile → facts.jsonl → wiki/*.md
 | Agent (MCP) | `facts.jsonl` | JSONL — structured queries, temporal, ns-scoped |
 | Human (Obsidian) | `wiki/` | Markdown — browsable, searchable, graph view |
 
-Both are always in sync because `compile` auto-generates the wiki after every run.
+### When wiki regenerates
+
+Wiki regenerates on **every `facts.jsonl` mutation**:
+
+| Trigger | Who | Wiki regen? |
+|---|---|---|
+| `compile` (raw → facts.jsonl) | Curator | Yes — single regen at end |
+| `compile` + pending resolve | Curator | Yes — `_do_auto_resolve` regens if merge happened; otherwise compile's own regen covers it. **Never double.** |
+| `resolve` (manual, merge happened) | Curator | Yes — gated on `merge_count > 0` or `flagged_count > 0` |
+| `resolve` (quarantine-only, no merge) | Curator | No — facts.jsonl unchanged |
+| Daemon auto-resolve (merge) | Daemon | Yes — `_do_auto_resolve` regens on actual merge |
+| `lorekeep wiki` (manual) | Human | Yes — force regen |
+
+### Atomic swap
+
+Wiki pages build into a temp sibling directory (`.wiki-build.tmp`), then `os.rename` swaps it into place. The wiki directory is **never partially populated** — Obsidian always sees either the old or the new version, never a mix. This is safe even with the vault open during regeneration.
 
 ## Output structure
 
@@ -56,23 +71,20 @@ wiki/
 
 Each node becomes a markdown page with:
 
-- **YAML frontmatter** — `id`, `type`, `ns`, `valid_from`, `valid_to`, `sources`, `tags` (Obsidian Dataview compatible)
-- **Properties table** — all node `props` as key-value rows
-- **Relationships** — outgoing and incoming edges as `[[wikilinks]]`, grouped by edge type
-- **Timeline** — `valid_from` / `valid_to` dates
+- **YAML frontmatter** — `id`, `type`, `ns`, `valid_from`, `valid_to`, `sources`, `tags` (Obsidian Dataview compatible). All scalars are quoted so IDs containing colons (`svc:payments-api`) parse correctly.
 
 Example entity page (`entities/service/svc-payments-api.md`):
 
 ```markdown
 ---
-id: svc:payments-api
-type: service
-ns: [backend]
-valid_from: 2024-01-15
-valid_to: null
+id: "svc:payments-api"
+type: "service"
+ns: ["backend"]
+valid_from: "2024-01-15"
+valid_to: ""
 sources:
-  - raw/backend/payments.md:3
-tags: [service, backend, entity]
+  - "raw/backend/payments.md:3"
+tags: ["service", "backend", "entity"]
 ---
 
 # payments-api
@@ -97,6 +109,14 @@ tags: [service, backend, entity]
 - **2024-01-15**: Valid from
 ```
 
+### Properties table
+
+Pipe characters in values are escaped (`\|`), newlines collapsed to spaces, and non-string values (integers, booleans, lists) serialized via `json.dumps` — preventing table corruption.
+
+### Slug naming
+
+Node IDs are sanitized to filename-safe slugs for wikilinks (`:` → `-`, `/` → `-`). If two distinct node IDs collide to the same slug, `generate_wiki` raises `ValueError` rather than silently overwriting.
+
 ### index.md
 
 Catalog of all entities, grouped by node type (`## Services`, `## Teams`, `## Decisions`). Each entry is a `[[wikilink]]` with a one-line summary.
@@ -107,7 +127,7 @@ Graph-level dashboard: node/edge counts by type, temporal range, namespace break
 
 ### log.md
 
-Append-only log of wiki generation events:
+Append-only log of wiki generation events. **Preserved across regenerations** — prior entries survive verbatim. Counts come from the live `GraphStore`, not the (potentially stale) manifest:
 
 ```
 ## [2026-06-29T21:53:00Z] wiki | run_id=abc123, 4 nodes, 2 edges
@@ -126,14 +146,22 @@ Append-only log of wiki generation events:
 ## CLI
 
 ```bash
-lorekeep wiki          # regenerate wiki/ from facts.jsonl
+lorekeep wiki          # regenerate wiki/ from facts.jsonl (force)
 ```
 
-Wiki generation also runs automatically after `compile` and after daemon-triggered resolve passes — you never need to run it manually unless you want to force a refresh.
+Wiki generation also runs automatically after every `facts.jsonl` mutation:
+
+- **`compile`** — always regens (unless `_do_auto_resolve` already regend after merging pending journals; never double).
+- **`resolve`** — regens only if facts actually changed (`merge_count > 0` or `flagged_count > 0`). Quarantine-only resolves skip wiki regen.
+- **Daemon auto-resolve** — regens on actual merge (`_do_auto_resolve` returns `True`).
+
+You never need to run `lorekeep wiki` manually unless you want to force a refresh.
 
 ## Determinism
 
 Re-generating the wiki from unchanged `facts.jsonl` yields **byte-identical** pages (entity pages, index, overview). The only exception is `log.md`, which is append-only by design.
+
+Wiki generation is **best-effort** — if it fails (e.g. slug collision, disk error), the triggering command (`compile`, `resolve`) still succeeds. `facts.jsonl` is never blocked by a wiki failure.
 
 ## Path resolution
 

--- a/docs/guides/wiki.md
+++ b/docs/guides/wiki.md
@@ -1,0 +1,151 @@
+# Browsing the wiki (human view)
+
+The compiled graph (`facts.jsonl`) is machine-readable — consumed by agents over MCP. The **wiki** is its human-readable projection: Obsidian-compatible markdown pages with wikilinks, YAML frontmatter, and graph view.
+
+## Quick start
+
+```bash
+uvx lorekeep compile      # auto-generates wiki/ after compile
+# OR
+uvx lorekeep wiki         # regenerate wiki/ from existing facts.jsonl
+```
+
+Open the `wiki/` directory in Obsidian:
+
+```bash
+# In your data home (default XDG):
+open ~/.local/share/lorekeep/wiki
+
+# Or dev mode (repo co-located):
+open .lorekeep/wiki
+```
+
+In Obsidian: **File → Open vault** → select the `wiki/` directory.
+
+## Lifecycle
+
+The wiki is a **derived artifact** — fully regenerable from `facts.jsonl`, never the reverse:
+
+```
+raw/*.md → compile → facts.jsonl → wiki/*.md
+                         ↑                ↓
+                    agent queries     human browses
+                    (MCP tools)      (Obsidian)
+```
+
+| Consumer | Reads | Format |
+|---|---|---|
+| Agent (MCP) | `facts.jsonl` | JSONL — structured queries, temporal, ns-scoped |
+| Human (Obsidian) | `wiki/` | Markdown — browsable, searchable, graph view |
+
+Both are always in sync because `compile` auto-generates the wiki after every run.
+
+## Output structure
+
+```
+wiki/
+├── index.md                     # catalog of all entities, grouped by type
+├── log.md                       # append-only generation log
+├── overview.md                  # graph stats dashboard
+└── entities/
+    └── <type>/
+        └── <slug>.md            # one page per node
+```
+
+### Entity pages
+
+Each node becomes a markdown page with:
+
+- **YAML frontmatter** — `id`, `type`, `ns`, `valid_from`, `valid_to`, `sources`, `tags` (Obsidian Dataview compatible)
+- **Properties table** — all node `props` as key-value rows
+- **Relationships** — outgoing and incoming edges as `[[wikilinks]]`, grouped by edge type
+- **Timeline** — `valid_from` / `valid_to` dates
+
+Example entity page (`entities/service/svc-payments-api.md`):
+
+```markdown
+---
+id: svc:payments-api
+type: service
+ns: [backend]
+valid_from: 2024-01-15
+valid_to: null
+sources:
+  - raw/backend/payments.md:3
+tags: [service, backend, entity]
+---
+
+# payments-api
+
+> ID: `svc:payments-api`
+
+## Properties
+
+| Key | Value |
+|---|---|
+| name | payments-api |
+| lang | go |
+
+## Relationships
+
+### depends_on →
+
+- [[svc-auth]] (2024-01-15 → 2025-03-01)
+
+## Timeline
+
+- **2024-01-15**: Valid from
+```
+
+### index.md
+
+Catalog of all entities, grouped by node type (`## Services`, `## Teams`, `## Decisions`). Each entry is a `[[wikilink]]` with a one-line summary.
+
+### overview.md
+
+Graph-level dashboard: node/edge counts by type, temporal range, namespace breakdown, and compile metadata (run ID, facts hash).
+
+### log.md
+
+Append-only log of wiki generation events:
+
+```
+## [2026-06-29T21:53:00Z] wiki | run_id=abc123, 4 nodes, 2 edges
+```
+
+## Obsidian tips
+
+- **Graph view** — all `[[wikilinks]]` render as a force-directed graph. This is the entity-relationship graph visualized.
+- **Backlinks** — Obsidian automatically shows inbound references at the bottom of each page (equivalent to incoming edges).
+- **Dataview** — the YAML frontmatter enables structured queries. Example: list all services written in Go:
+  ```dataview
+  LIST FROM #service WHERE lang = "go"
+  ```
+- **Tags** — each page is tagged with `[<type>, <ns>, "entity"]`, enabling filtered views.
+
+## CLI
+
+```bash
+lorekeep wiki          # regenerate wiki/ from facts.jsonl
+```
+
+Wiki generation also runs automatically after `compile` and after daemon-triggered resolve passes — you never need to run it manually unless you want to force a refresh.
+
+## Determinism
+
+Re-generating the wiki from unchanged `facts.jsonl` yields **byte-identical** pages (entity pages, index, overview). The only exception is `log.md`, which is append-only by design.
+
+## Path resolution
+
+The wiki lives at `<data-home>/wiki/` (same level as `raw/` and `graph/`). Override with:
+
+```bash
+LOREKEEP_WIKI=/path/to/wiki uvx lorekeep wiki
+```
+
+See [data-home.md](data-home.md) for the full 4-tier path resolution.
+
+## Next
+
+- [Compile guide](compile.md) — how `facts.jsonl` is produced.
+- [Serve guide](serve.md) — how agents consume the same graph over MCP.

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -112,7 +112,21 @@ def compile() -> None:
 
     pending_dir = p.get("pending")
     if pending_dir and pending_dir.exists():
-        _do_auto_resolve(p["out"], pending_dir)
+        _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
+
+    _auto_generate_wiki(p["out"], p["wiki"])
+
+
+@app.command()
+def wiki() -> None:
+    """Generate Obsidian-compatible wiki from facts.jsonl."""
+    p = resolve_paths()
+    from lorekeep.wiki import generate_wiki
+    result = generate_wiki(p["out"], p["wiki"])
+    if "error" in result:
+        typer.echo(f"wiki: {result['error']}")
+        raise typer.Exit(code=1)
+    typer.echo(f"wiki: {result['pages']} pages written to {p['wiki']}")
 
 
 @app.command(name="eval")
@@ -237,6 +251,8 @@ def resolve(
         f"{merged.merge_count} merged, {merged.flagged_count} flagged, "
         f"{merged.quarantine_count} quarantined"
     )
+
+    _auto_generate_wiki(p["out"], p["wiki"])
 
 
 @app.command()
@@ -560,7 +576,7 @@ def _auto_import_and_compile(p: dict) -> None:
         )
         pending_dir = p.get("pending")
         if pending_dir and pending_dir.exists():
-            _do_auto_resolve(p["out"], pending_dir)
+            _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
         typer.echo(f"  compiled: {manifest.node_count} nodes, {manifest.edge_count} edges")
     except Exception as exc:
         typer.echo(f"  compile skipped: {exc}")
@@ -1143,7 +1159,7 @@ def watch(
             # from raw/ only.  Re-merge pending journal entries so facts
             # approved via agent ingest / MCP write tools are not lost.
             if compiled and has_pending:
-                _do_auto_resolve(p["out"], pending_dir)
+                _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
 
             # --- pending/ watch → auto-resolve ------------------------------
             if has_pending:
@@ -1151,7 +1167,7 @@ def watch(
                 pending_mtime = max((f.stat().st_mtime for f in journal_files), default=0.0)
                 if pending_mtime > last_pending_mtime and last_pending_mtime > 0:
                     typer.echo("agent: pending/ changed — resolving...")
-                    _do_auto_resolve(p["out"], pending_dir)
+                    _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
                 last_pending_mtime = pending_mtime
 
             # --- session watch → delta quick import → raw/ ------------------
@@ -1182,7 +1198,7 @@ def watch(
             time.sleep(interval)
 
 
-def _do_auto_resolve(out_dir: Path, pending_dir: Path) -> None:
+def _do_auto_resolve(out_dir: Path, pending_dir: Path, wiki_dir: Path | None = None) -> None:
     """Merge pending journal entries into facts.jsonl.
 
     Extracted as a helper so both the pending/ watch loop and the
@@ -1234,8 +1250,20 @@ def _do_auto_resolve(out_dir: Path, pending_dir: Path) -> None:
 
             typer.echo(f"agent: resolve done — {merged.merge_count} merged, "
                        f"{merged.flagged_count} flagged, {merged.quarantine_count} quarantined")
+
+            if wiki_dir:
+                _auto_generate_wiki(out_dir, wiki_dir)
     except Exception as exc:
         typer.echo(f"agent: resolve error: {exc}")
+
+
+def _auto_generate_wiki(graph_dir: Path, wiki_dir: Path) -> None:
+    """Regenerate wiki after compile or resolve. Best-effort, never blocks."""
+    try:
+        from lorekeep.wiki import generate_wiki
+        generate_wiki(graph_dir, wiki_dir)
+    except Exception as exc:
+        typer.echo(f"wiki: auto-gen skipped: {exc}")
 
 
 if __name__ == "__main__":

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -111,10 +111,12 @@ def compile() -> None:
                f"run_id={manifest.run_id}, facts_hash={manifest.facts_hash}")
 
     pending_dir = p.get("pending")
+    resolved = False
     if pending_dir and pending_dir.exists():
-        _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
+        resolved = _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
 
-    _auto_generate_wiki(p["out"], p["wiki"])
+    if not resolved:
+        _auto_generate_wiki(p["out"], p["wiki"])
 
 
 @app.command()
@@ -252,7 +254,8 @@ def resolve(
         f"{merged.quarantine_count} quarantined"
     )
 
-    _auto_generate_wiki(p["out"], p["wiki"])
+    if merged.merge_count > 0 or merged.flagged_count > 0:
+        _auto_generate_wiki(p["out"], p["wiki"])
 
 
 @app.command()
@@ -1198,11 +1201,13 @@ def watch(
             time.sleep(interval)
 
 
-def _do_auto_resolve(out_dir: Path, pending_dir: Path, wiki_dir: Path | None = None) -> None:
+def _do_auto_resolve(out_dir: Path, pending_dir: Path, wiki_dir: Path | None = None) -> bool:
     """Merge pending journal entries into facts.jsonl.
 
     Extracted as a helper so both the pending/ watch loop and the
     post-compile re-merge path share the same logic.
+
+    Returns True if facts.jsonl was rewritten (merge happened).
     """
     try:
         from lorekeep.facts_io import read_facts
@@ -1253,8 +1258,10 @@ def _do_auto_resolve(out_dir: Path, pending_dir: Path, wiki_dir: Path | None = N
 
             if wiki_dir:
                 _auto_generate_wiki(out_dir, wiki_dir)
+            return True
     except Exception as exc:
         typer.echo(f"agent: resolve error: {exc}")
+    return False
 
 
 def _auto_generate_wiki(graph_dir: Path, wiki_dir: Path) -> None:

--- a/src/lorekeep/paths.py
+++ b/src/lorekeep/paths.py
@@ -30,6 +30,7 @@ def resolve_paths() -> dict[str, Path]:
         out = home / "graph"
         schema = home / "schema.json"
         pending = home / "pending"
+        wiki = home / "wiki"
     elif dev:
         home = cwd / ".lorekeep"
         config = home / "config.yaml"
@@ -38,6 +39,7 @@ def resolve_paths() -> dict[str, Path]:
         out = home / "graph"
         schema = home / "schema.json"
         pending = home / "pending"
+        wiki = home / "wiki"
     else:
         from platformdirs import user_config_dir, user_data_dir
         home = Path(user_data_dir("lorekeep"))
@@ -47,6 +49,7 @@ def resolve_paths() -> dict[str, Path]:
         out = home / "graph"
         schema = home / "schema.json"
         pending = home / "pending"
+        wiki = home / "wiki"
 
     def override(env_name: str, current: Path) -> Path:
         v = os.environ.get(env_name)
@@ -60,4 +63,5 @@ def resolve_paths() -> dict[str, Path]:
         "schema": override("LOREKEEP_SCHEMA", schema),
         "config": override("LOREKEEP_CONFIG", config),
         "pending": override("LOREKEEP_PENDING", pending),
+        "wiki": override("LOREKEEP_WIKI", wiki),
     }

--- a/src/lorekeep/wiki.py
+++ b/src/lorekeep/wiki.py
@@ -1,0 +1,345 @@
+"""Generate Obsidian-compatible markdown wiki from facts.jsonl.
+
+The wiki is a human-browsable projection of the compiled knowledge graph.
+It is fully derived from facts.jsonl — never the reverse. Re-generating
+from unchanged input yields byte-identical pages (except log.md, which
+is append-only by design).
+
+Output structure:
+    wiki/
+    ├── index.md                # catalog of all entities, grouped by type
+    ├── log.md                  # append-only generation log
+    ├── overview.md             # graph stats dashboard
+    └── entities/
+        └── <type>/
+            └── <slug>.md       # one page per node, [[wikilinks]] for edges
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from lorekeep.models import Edge, Manifest, Node
+from lorekeep.store.graph import GraphStore
+
+
+def _slug(node_id: str) -> str:
+    """Sanitize a node ID into a filename-safe slug for wikilinks.
+
+    Colons and slashes become hyphens. Everything else is kept as-is
+    so the slug is round-trippable within a wiki build.
+    """
+    return re.sub(r"[:/]", "-", node_id)
+
+
+def _fmt_date(d) -> str:
+    if d is None:
+        return ""
+    return d.isoformat() if hasattr(d, "isoformat") else str(d)
+
+
+def _fmt_validity(valid_from, valid_to) -> str:
+    vf = _fmt_date(valid_from)
+    vt = _fmt_date(valid_to)
+    if vf and vt:
+        return f"{vf} \u2192 {vt}"
+    if vf:
+        return f"{vf} \u2192 present"
+    if vt:
+        return f"until {vt}"
+    return "always"
+
+
+def _yaml_list(items: list[str], indent: str = "") -> str:
+    if not items:
+        return "[]"
+    return "[" + ", ".join(items) + "]"
+
+
+def _frontmatter(node: Node) -> str:
+    lines = ["---"]
+    lines.append(f"id: {node.id}")
+    lines.append(f"type: {node.type}")
+    lines.append(f"ns: {_yaml_list(list(node.ns))}")
+    lines.append(f"valid_from: {_fmt_date(node.valid_from) or 'null'}")
+    lines.append(f"valid_to: {_fmt_date(node.valid_to) or 'null'}")
+    if node.src:
+        lines.append("sources:")
+        for s in node.src:
+            lines.append(f"  - {s}")
+    else:
+        lines.append("sources: []")
+    tags = [node.type] + list(node.ns) + ["entity"]
+    lines.append(f"tags: {_yaml_list(tags)}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _props_table(node: Node) -> str:
+    if not node.props:
+        return ""
+    lines = ["", "## Properties", "", "| Key | Value |", "|---|---|"]
+    for key in sorted(node.props):
+        lines.append(f"| {key} | {node.props[key]} |")
+    return "\n".join(lines)
+
+
+def _relationships(
+    node: Node, out_edges: list[Edge], in_edges: list[Edge]
+) -> str:
+    sections: list[str] = []
+
+    if out_edges:
+        sections.extend(["", "## Relationships", ""])
+        by_type: dict[str, list[Edge]] = {}
+        for e in out_edges:
+            by_type.setdefault(e.type, []).append(e)
+        for etype in sorted(by_type):
+            sections.append(f"### {etype} \u2192")
+            sections.append("")
+            for e in sorted(by_type[etype], key=lambda e: e.to):
+                validity = _fmt_validity(e.valid_from, e.valid_to)
+                sections.append(f"- [[{_slug(e.to)}]] ({validity})")
+            sections.append("")
+
+    if in_edges:
+        if not out_edges:
+            sections.extend(["", "## Relationships", ""])
+        by_type: dict[str, list[Edge]] = {}
+        for e in in_edges:
+            by_type.setdefault(e.type, []).append(e)
+        for etype in sorted(by_type):
+            sections.append(f"### \u2190 {etype}")
+            sections.append("")
+            for e in sorted(by_type[etype], key=lambda e: e.from_):
+                validity = _fmt_validity(e.valid_from, e.valid_to)
+                sections.append(f"- [[{_slug(e.from_)}]] ({validity})")
+            sections.append("")
+
+    return "\n".join(sections)
+
+
+def _timeline(node: Node) -> str:
+    if node.valid_from is None and node.valid_to is None:
+        return ""
+    lines = ["", "## Timeline", ""]
+    if node.valid_from:
+        lines.append(f"- **{_fmt_date(node.valid_from)}**: Valid from")
+    if node.valid_to:
+        lines.append(f"- **{_fmt_date(node.valid_to)}**: Valid until")
+    return "\n".join(lines)
+
+
+def _entity_page(
+    node: Node,
+    store: GraphStore,
+) -> str:
+    title = node.props.get("name", node.id)
+    out_e = store.out_edges(node.id)
+    in_e = store.in_edges(node.id)
+
+    parts = [
+        _frontmatter(node),
+        "",
+        f"# {title}",
+        "",
+        f"> ID: `{node.id}`",
+    ]
+    parts.append(_props_table(node))
+    parts.append(_relationships(node, out_e, in_e))
+    parts.append(_timeline(node))
+    parts.append("")
+    return "\n".join(parts)
+
+
+def _index_page(store: GraphStore) -> str:
+    nodes = store.all_nodes()
+    edges = store.all_edges()
+
+    lines = [
+        "---",
+        "type: index",
+        f"tags: [index, lorekeep-wiki]",
+        "---",
+        "",
+        "# Lorekeep Wiki \u2014 Index",
+        "",
+        f"Nodes: {len(nodes)} | Edges: {len(edges)}",
+        "",
+    ]
+
+    by_type: dict[str, list[Node]] = {}
+    for n in nodes:
+        by_type.setdefault(n.type, []).append(n)
+
+    for ntype in sorted(by_type):
+        lines.append(f"## {ntype.title()}s")
+        lines.append("")
+        for n in sorted(by_type[ntype], key=lambda n: n.id):
+            title = n.props.get("name", n.id)
+            slug = _slug(n.id)
+            summary_parts = [title]
+            if n.props.get("lang"):
+                summary_parts.append(f"({n.props['lang']})")
+            if n.valid_from:
+                summary_parts.append(f"\u2014 since {_fmt_date(n.valid_from)}")
+            lines.append(f"- [[{slug}]] \u2014 {' '.join(summary_parts)}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _overview_page(store: GraphStore, manifest: Manifest | None) -> str:
+    nodes = store.all_nodes()
+    edges = store.all_edges()
+
+    lines = [
+        "---",
+        "type: overview",
+        "tags: [overview, lorekeep-wiki]",
+        "---",
+        "",
+        "# Graph Overview",
+        "",
+        "## Statistics",
+        "",
+        "| Metric | Value |",
+        "|---|---|",
+        f"| Nodes | {len(nodes)} |",
+        f"| Edges | {len(edges)} |",
+    ]
+
+    by_type: dict[str, int] = {}
+    for n in nodes:
+        by_type[n.type] = by_type.get(n.type, 0) + 1
+    for ntype in sorted(by_type):
+        lines.append(f"| node:{ntype} | {by_type[ntype]} |")
+
+    by_type_e: dict[str, int] = {}
+    for e in edges:
+        by_type_e[e.type] = by_type_e.get(e.type, 0) + 1
+    for etype in sorted(by_type_e):
+        lines.append(f"| edge:{etype} | {by_type_e[etype]} |")
+
+    valid_froms = [n.valid_from for n in nodes if n.valid_from]
+    if valid_froms:
+        oldest = min(valid_froms)
+        newest = max(valid_froms)
+        lines.append(f"| Oldest valid_from | {_fmt_date(oldest)} |")
+        lines.append(f"| Newest valid_from | {_fmt_date(newest)} |")
+
+    lines.append("")
+
+    if manifest:
+        lines.extend([
+            "## Compile Info",
+            "",
+            f"- **Run ID**: `{manifest.run_id}`",
+            f"- **Facts hash**: `{manifest.facts_hash}`",
+            f"- **Schema version**: {manifest.schema_version}",
+            f"- **Chunks compiled**: {manifest.chunk_count}",
+        ])
+        if manifest.merged_count:
+            lines.append(f"- **Agent-merged facts**: {manifest.merged_count}")
+        if manifest.quarantined_count:
+            lines.append(f"- **Quarantined**: {manifest.quarantined_count}")
+        if manifest.review:
+            lines.append(f"- **Pending review**: {len(manifest.review)}")
+        lines.append("")
+
+    all_ns: set[str] = set()
+    for n in nodes:
+        all_ns.update(n.ns)
+    for e in edges:
+        all_ns.update(e.ns)
+    if all_ns:
+        lines.extend([
+            "## Namespaces",
+            "",
+        ])
+        for ns in sorted(all_ns):
+            node_count = sum(1 for n in nodes if ns in n.ns)
+            lines.append(f"- `{ns}` ({node_count} nodes)")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _write_atomic(path: Path, content: str) -> None:
+    import os
+    import tempfile
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def generate_wiki(
+    graph_dir: Path,
+    wiki_dir: Path,
+    manifest: Manifest | None = None,
+) -> dict:
+    """Generate Obsidian-compatible wiki pages from facts.jsonl.
+
+    Clears and regenerates all entity/index/overview pages.
+    Appends to log.md (the only non-deterministic file).
+
+    Returns a summary dict with counts.
+    """
+    facts_path = graph_dir / "facts.jsonl"
+    if not facts_path.exists():
+        return {"error": f"facts.jsonl not found at {facts_path}"}
+
+    if manifest is None:
+        manifest_path = graph_dir / "manifest.json"
+        if manifest_path.exists():
+            manifest = Manifest.from_json(manifest_path.read_text(encoding="utf-8"))
+
+    store = GraphStore.from_jsonl(facts_path)
+
+    existing_log = ""
+    if (wiki_dir / "log.md").exists():
+        existing_log = (wiki_dir / "log.md").read_text(encoding="utf-8")
+
+    if wiki_dir.exists():
+        import shutil
+        shutil.rmtree(wiki_dir)
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+
+    for node in sorted(store.all_nodes(), key=lambda n: (n.type, n.id)):
+        page = _entity_page(node, store)
+        slug = _slug(node.id)
+        entity_path = wiki_dir / "entities" / node.type / f"{slug}.md"
+        _write_atomic(entity_path, page)
+
+    _write_atomic(wiki_dir / "index.md", _index_page(store))
+    _write_atomic(wiki_dir / "overview.md", _overview_page(store, manifest))
+
+    log_path = wiki_dir / "log.md"
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    run_id = manifest.run_id if manifest else "unknown"
+    node_count = manifest.node_count if manifest else 0
+    edge_count = manifest.edge_count if manifest else 0
+    entry = (
+        f"## [{now}] wiki | run_id={run_id}, "
+        f"{node_count} nodes, {edge_count} edges\n"
+    )
+    if not existing_log:
+        existing_log = "# Lorekeep Wiki \u2014 Log\n\n"
+    log_path.write_text(existing_log + entry, encoding="utf-8")
+
+    return {
+        "nodes": len(store.all_nodes()),
+        "edges": len(store.all_edges()),
+        "pages": len(store.all_nodes()) + 2,
+    }

--- a/src/lorekeep/wiki.py
+++ b/src/lorekeep/wiki.py
@@ -16,10 +16,14 @@ Output structure:
 """
 from __future__ import annotations
 
+import json
+import os
 import re
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
+from lorekeep.compile.writer import _atomic_write
 from lorekeep.models import Edge, Manifest, Node
 from lorekeep.store.graph import GraphStore
 
@@ -31,6 +35,19 @@ def _slug(node_id: str) -> str:
     so the slug is round-trippable within a wiki build.
     """
     return re.sub(r"[:/]", "-", node_id)
+
+
+def _yaml_scalar(value: str) -> str:
+    """Quote a YAML scalar so special chars (colon, etc.) are safe."""
+    if value is None:
+        return "null"
+    return json.dumps(str(value))
+
+
+def _yaml_list(items: list[str]) -> str:
+    if not items:
+        return "[]"
+    return "[" + ", ".join(json.dumps(str(i)) for i in items) + "]"
 
 
 def _fmt_date(d) -> str:
@@ -51,23 +68,26 @@ def _fmt_validity(valid_from, valid_to) -> str:
     return "always"
 
 
-def _yaml_list(items: list[str], indent: str = "") -> str:
-    if not items:
-        return "[]"
-    return "[" + ", ".join(items) + "]"
+def _fmt_prop_value(val) -> str:
+    """Format a prop value for markdown table cell — escape pipes, collapse newlines."""
+    if isinstance(val, str):
+        s = val.replace("|", "\\|").replace("\n", " ")
+    else:
+        s = json.dumps(val, ensure_ascii=False).replace("|", "\\|").replace("\n", " ")
+    return s
 
 
 def _frontmatter(node: Node) -> str:
     lines = ["---"]
-    lines.append(f"id: {node.id}")
-    lines.append(f"type: {node.type}")
+    lines.append(f"id: {_yaml_scalar(node.id)}")
+    lines.append(f"type: {_yaml_scalar(node.type)}")
     lines.append(f"ns: {_yaml_list(list(node.ns))}")
-    lines.append(f"valid_from: {_fmt_date(node.valid_from) or 'null'}")
-    lines.append(f"valid_to: {_fmt_date(node.valid_to) or 'null'}")
+    lines.append(f"valid_from: {_yaml_scalar(_fmt_date(node.valid_from))}")
+    lines.append(f"valid_to: {_yaml_scalar(_fmt_date(node.valid_to))}")
     if node.src:
         lines.append("sources:")
         for s in node.src:
-            lines.append(f"  - {s}")
+            lines.append(f"  - {json.dumps(str(s))}")
     else:
         lines.append("sources: []")
     tags = [node.type] + list(node.ns) + ["entity"]
@@ -81,7 +101,7 @@ def _props_table(node: Node) -> str:
         return ""
     lines = ["", "## Properties", "", "| Key | Value |", "|---|---|"]
     for key in sorted(node.props):
-        lines.append(f"| {key} | {node.props[key]} |")
+        lines.append(f"| {_fmt_prop_value(key)} | {_fmt_prop_value(node.props[key])} |")
     return "\n".join(lines)
 
 
@@ -106,7 +126,7 @@ def _relationships(
     if in_edges:
         if not out_edges:
             sections.extend(["", "## Relationships", ""])
-        by_type: dict[str, list[Edge]] = {}
+        by_type = {}
         for e in in_edges:
             by_type.setdefault(e.type, []).append(e)
         for etype in sorted(by_type):
@@ -131,10 +151,7 @@ def _timeline(node: Node) -> str:
     return "\n".join(lines)
 
 
-def _entity_page(
-    node: Node,
-    store: GraphStore,
-) -> str:
+def _entity_page(node: Node, store: GraphStore) -> str:
     title = node.props.get("name", node.id)
     out_e = store.out_edges(node.id)
     in_e = store.in_edges(node.id)
@@ -155,17 +172,17 @@ def _entity_page(
 
 def _index_page(store: GraphStore) -> str:
     nodes = store.all_nodes()
-    edges = store.all_edges()
+    edge_count = store._G.number_of_edges()
 
     lines = [
         "---",
         "type: index",
-        f"tags: [index, lorekeep-wiki]",
+        "tags: [index, lorekeep-wiki]",
         "---",
         "",
         "# Lorekeep Wiki \u2014 Index",
         "",
-        f"Nodes: {len(nodes)} | Edges: {len(edges)}",
+        f"Nodes: {len(nodes)} | Edges: {edge_count}",
         "",
     ]
 
@@ -254,10 +271,7 @@ def _overview_page(store: GraphStore, manifest: Manifest | None) -> str:
     for e in edges:
         all_ns.update(e.ns)
     if all_ns:
-        lines.extend([
-            "## Namespaces",
-            "",
-        ])
+        lines.extend(["## Namespaces", ""])
         for ns in sorted(all_ns):
             node_count = sum(1 for n in nodes if ns in n.ns)
             lines.append(f"- `{ns}` ({node_count} nodes)")
@@ -266,22 +280,28 @@ def _overview_page(store: GraphStore, manifest: Manifest | None) -> str:
     return "\n".join(lines)
 
 
-def _write_atomic(path: Path, content: str) -> None:
-    import os
-    import tempfile
+def _atomic_dir_swap(wiki_dir: Path, build_dir: Path) -> None:
+    """Atomically swap build_dir into wiki_dir.
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(content)
-        os.replace(tmp, path)
-    except BaseException:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
+    On POSIX: rename old wiki to .old, rename new to wiki, rmtree old.
+    Never leaves wiki_dir partially populated.
+    """
+    parent = wiki_dir.parent
+    parent.mkdir(parents=True, exist_ok=True)
+
+    old_backup: Path | None = None
+    if wiki_dir.exists():
+        old_backup = wiki_dir.with_suffix(".wiki-old.tmp")
+        if old_backup.exists():
+            import shutil
+            shutil.rmtree(old_backup)
+        os.rename(wiki_dir, old_backup)
+
+    os.rename(build_dir, wiki_dir)
+
+    if old_backup is not None and old_backup.exists():
+        import shutil
+        shutil.rmtree(old_backup)
 
 
 def generate_wiki(
@@ -291,8 +311,8 @@ def generate_wiki(
 ) -> dict:
     """Generate Obsidian-compatible wiki pages from facts.jsonl.
 
-    Clears and regenerates all entity/index/overview pages.
-    Appends to log.md (the only non-deterministic file).
+    Builds into a temp sibling directory, then atomically swaps into place.
+    Appends to log.md (the only non-deterministic file, preserved across regen).
 
     Returns a summary dict with counts.
     """
@@ -306,40 +326,52 @@ def generate_wiki(
             manifest = Manifest.from_json(manifest_path.read_text(encoding="utf-8"))
 
     store = GraphStore.from_jsonl(facts_path)
+    nodes = store.all_nodes()
+    edges = store.all_edges()
 
     existing_log = ""
     if (wiki_dir / "log.md").exists():
         existing_log = (wiki_dir / "log.md").read_text(encoding="utf-8")
 
-    if wiki_dir.exists():
+    build_dir = wiki_dir.parent / ".wiki-build.tmp"
+    if build_dir.exists():
         import shutil
-        shutil.rmtree(wiki_dir)
-    wiki_dir.mkdir(parents=True, exist_ok=True)
+        shutil.rmtree(build_dir)
+    build_dir.mkdir(parents=True, exist_ok=True)
 
-    for node in sorted(store.all_nodes(), key=lambda n: (n.type, n.id)):
+    slug_map: dict[str, str] = {}
+    for node in nodes:
+        slug = _slug(node.id)
+        if slug in slug_map and slug_map[slug] != node.id:
+            raise ValueError(
+                f"slug collision: nodes {slug_map[slug]!r} and {node.id!r} "
+                f"both slug to {slug!r}"
+            )
+        slug_map[slug] = node.id
+
+    for node in sorted(nodes, key=lambda n: (n.type, n.id)):
         page = _entity_page(node, store)
         slug = _slug(node.id)
-        entity_path = wiki_dir / "entities" / node.type / f"{slug}.md"
-        _write_atomic(entity_path, page)
+        entity_path = build_dir / "entities" / node.type / f"{slug}.md"
+        _atomic_write(entity_path, page)
 
-    _write_atomic(wiki_dir / "index.md", _index_page(store))
-    _write_atomic(wiki_dir / "overview.md", _overview_page(store, manifest))
+    _atomic_write(build_dir / "index.md", _index_page(store))
+    _atomic_write(build_dir / "overview.md", _overview_page(store, manifest))
 
-    log_path = wiki_dir / "log.md"
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     run_id = manifest.run_id if manifest else "unknown"
-    node_count = manifest.node_count if manifest else 0
-    edge_count = manifest.edge_count if manifest else 0
     entry = (
         f"## [{now}] wiki | run_id={run_id}, "
-        f"{node_count} nodes, {edge_count} edges\n"
+        f"{len(nodes)} nodes, {len(edges)} edges\n"
     )
     if not existing_log:
         existing_log = "# Lorekeep Wiki \u2014 Log\n\n"
-    log_path.write_text(existing_log + entry, encoding="utf-8")
+    _atomic_write(build_dir / "log.md", existing_log + entry)
+
+    _atomic_dir_swap(wiki_dir, build_dir)
 
     return {
-        "nodes": len(store.all_nodes()),
-        "edges": len(store.all_edges()),
-        "pages": len(store.all_nodes()) + 2,
+        "nodes": len(nodes),
+        "edges": len(edges),
+        "pages": len(nodes) + 2,
     }

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -126,10 +126,10 @@ class TestGenerateWiki:
         generate_wiki(graph_dir, wiki_dir)
         page = (wiki_dir / "entities" / "service" / "svc-payments-api.md").read_text()
         assert page.startswith("---")
-        assert "id: svc:payments-api" in page
-        assert "type: service" in page
-        assert "ns: [backend]" in page
-        assert "valid_from: 2024-01-15" in page
+        assert 'id: "svc:payments-api"' in page
+        assert 'type: "service"' in page
+        assert 'ns: ["backend"]' in page
+        assert 'valid_from: "2024-01-15"' in page
         assert "sources:" in page
         assert "raw/backend/payments.md:3" in page
         assert "tags:" in page
@@ -349,3 +349,229 @@ class TestWikiCLI:
 
         wiki_after = (home / "wiki" / "log.md").read_text()
         assert wiki_after.count("## [") == wiki_before.count("## [") + 1
+
+
+# ── Review-requested tests ─────────────────────────────────────────────────
+
+
+class TestSyncInvariant:
+    """Every node → entity page, every edge → wikilink on both endpoints."""
+
+    def test_every_node_has_entity_page(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        from lorekeep.facts_io import read_facts
+        from lorekeep.models import Node as NodeT
+        for line in (graph_dir / "facts.jsonl").read_text().splitlines():
+            d = json.loads(line)
+            if d["kind"] != "node":
+                continue
+            slug = _slug(d["id"])
+            page = wiki_dir / "entities" / d["type"] / f"{slug}.md"
+            assert page.exists(), f"missing entity page for {d['id']}"
+
+    def test_every_edge_has_wikilinks(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        for line in (graph_dir / "facts.jsonl").read_text().splitlines():
+            d = json.loads(line)
+            if d["kind"] != "edge":
+                continue
+            from_slug = _slug(d["from"])
+            to_slug = _slug(d["to"])
+            from_page = (wiki_dir / "entities").rglob(f"{from_slug}.md")
+            to_page = (wiki_dir / "entities").rglob(f"{to_slug}.md")
+            from_pg = next(from_page, None)
+            to_pg = next(to_page, None)
+            assert from_pg, f"source page {from_slug} missing"
+            assert to_pg, f"target page {to_slug} missing"
+            assert f"[[{to_slug}]]" in from_pg.read_text(), \
+                f"edge {d['id']}: [[{to_slug}]] missing on source page"
+            assert f"[[{from_slug}]]" in to_pg.read_text(), \
+                f"edge {d['id']}: [[{from_slug}]] missing on target page"
+
+
+class TestYAMLFrontmatter:
+    def test_frontmatter_parses_as_yaml(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        import yaml
+        page = (wiki_dir / "entities" / "service" / "svc-payments-api.md").read_text()
+        fm_block = page.split("---")[1]
+        data = yaml.safe_load(fm_block)
+        assert data["id"] == "svc:payments-api"
+        assert data["type"] == "service"
+        assert data["ns"] == ["backend"]
+        assert data["valid_from"] == "2024-01-15"
+        assert data["sources"] == ["raw/backend/payments.md:3"]
+        assert "entity" in data["tags"]
+
+    def test_frontmatter_null_dates(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        import yaml
+        page = (wiki_dir / "entities" / "service" / "svc-auth.md").read_text()
+        fm_block = page.split("---")[1]
+        data = yaml.safe_load(fm_block)
+        assert data["valid_from"] == ""
+
+
+class TestEmptyGraph:
+    def test_empty_graph_no_crash(self, tmp_path):
+        graph = tmp_path / "graph"
+        graph.mkdir()
+        (graph / "facts.jsonl").write_text("")
+        wiki = tmp_path / "wiki"
+        result = generate_wiki(graph, wiki)
+        assert result["nodes"] == 0
+        assert result["edges"] == 0
+        assert (wiki / "index.md").exists()
+        assert (wiki / "overview.md").exists()
+        assert (wiki / "log.md").exists()
+
+
+class TestPropsSpecialChars:
+    def test_pipe_in_prop_value(self, tmp_path):
+        node = Node(
+            id="svc:test", type="service", ns=("test",),
+            props={"filter": "a | b", "name": "test"},
+        )
+        graph = tmp_path / "graph"
+        from lorekeep.compile.writer import write_graph
+        write_graph(graph, [node], [], Manifest(
+            schema_version=1, chunk_count=0, node_count=1, edge_count=0,
+            run_id="x", facts_hash="y",
+        ))
+        wiki = tmp_path / "wiki"
+        generate_wiki(graph, wiki)
+        page = (wiki / "entities" / "service" / "svc-test.md").read_text()
+        assert "a \\| b" in page
+
+    def test_newline_in_prop_value(self, tmp_path):
+        node = Node(
+            id="svc:multiline", type="service", ns=("test",),
+            props={"desc": "line1\nline2", "name": "multiline"},
+        )
+        graph = tmp_path / "graph"
+        from lorekeep.compile.writer import write_graph
+        write_graph(graph, [node], [], Manifest(
+            schema_version=1, chunk_count=0, node_count=1, edge_count=0,
+            run_id="x", facts_hash="y",
+        ))
+        wiki = tmp_path / "wiki"
+        generate_wiki(graph, wiki)
+        page = (wiki / "entities" / "service" / "svc-multiline.md").read_text()
+        assert "line1 line2" in page
+        assert "\nline2 |" not in page
+
+    def test_non_string_prop_value(self, tmp_path):
+        node = Node(
+            id="svc:typed", type="service", ns=("test",),
+            props={"port": 8080, "enabled": True, "name": "typed"},
+        )
+        graph = tmp_path / "graph"
+        from lorekeep.compile.writer import write_graph
+        write_graph(graph, [node], [], Manifest(
+            schema_version=1, chunk_count=0, node_count=1, edge_count=0,
+            run_id="x", facts_hash="y",
+        ))
+        wiki = tmp_path / "wiki"
+        generate_wiki(graph, wiki)
+        page = (wiki / "entities" / "service" / "svc-typed.md").read_text()
+        assert "8080" in page
+        assert "true" in page
+
+
+class TestSlugCollision:
+    def test_slug_collision_raises(self, tmp_path):
+        nodes = [
+            Node(id="svc:auth", type="service", ns=("t",), props={"name": "a"}),
+            Node(id="svc/auth", type="service", ns=("t",), props={"name": "b"}),
+        ]
+        graph = tmp_path / "graph"
+        from lorekeep.compile.writer import write_graph
+        write_graph(graph, nodes, [], Manifest(
+            schema_version=1, chunk_count=0, node_count=2, edge_count=0,
+            run_id="x", facts_hash="y",
+        ))
+        wiki = tmp_path / "wiki"
+        with pytest.raises(ValueError, match="slug collision"):
+            generate_wiki(graph, wiki)
+
+
+class TestWikiFailureSafe:
+    def test_wiki_failure_does_not_crash_compile(self, tmp_path, monkeypatch, patch_make_provider):
+        from lorekeep.cli import app
+
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "raw" / "backend").mkdir(parents=True)
+        (home / "raw" / "backend" / "payments.md").write_text(
+            "# Payments API\n\npayments-api (go) depends on auth.\n"
+        )
+        (home / "schema.json").write_text(
+            json.dumps({
+                "version": 1,
+                "node_types": {"service": {"props": {"name": "string", "lang": "string"}}},
+                "edge_types": {"depends_on": {"from": "service", "to": "service"}},
+            })
+        )
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        monkeypatch.setattr(
+            "lorekeep.wiki.generate_wiki",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+
+        result = runner.invoke(app, ["compile"])
+        assert result.exit_code == 0, result.stdout
+        assert (home / "graph" / "facts.jsonl").exists()
+
+
+class TestLogIntegrity:
+    def test_log_preserves_prior_entries_verbatim(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        log1 = (wiki_dir / "log.md").read_text()
+        first_entry = log1.split("\n\n")[-1] if "## [" in log1 else ""
+
+        generate_wiki(graph_dir, wiki_dir)
+        log2 = (wiki_dir / "log.md").read_text()
+
+        assert log1 in log2
+        assert log2.count("## [") == 2
+
+
+class TestCompileSingleRegen:
+    def test_compile_with_pending_single_log_entry(self, tmp_path, monkeypatch, patch_make_provider):
+        """compile + pending resolve should produce exactly one new log entry."""
+        from lorekeep.cli import app
+        from lorekeep.journal import append_journal
+        from lorekeep.models import JournalEntry
+
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "raw" / "backend").mkdir(parents=True)
+        (home / "raw" / "backend" / "payments.md").write_text(
+            "# Payments API\n\npayments-api (go) depends on auth.\n"
+        )
+        (home / "pending" / "backend").mkdir(parents=True)
+        (home / "schema.json").write_text(
+            json.dumps({
+                "version": 1,
+                "node_types": {"service": {"props": {"name": "string", "lang": "string"}}},
+                "edge_types": {"depends_on": {"from": "service", "to": "service"}},
+            })
+        )
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+
+        append_journal(
+            home / "pending",
+            JournalEntry(
+                fact={"kind": "node", "id": "svc:pre", "type": "service",
+                      "ns": ["backend"], "props": {"name": "pre"}},
+                agent="test", ns="backend", confidence=0.9,
+                proposed_at="2026-06-29T00:00:00Z",
+            ),
+            "backend",
+        )
+
+        result = runner.invoke(app, ["compile"])
+        assert result.exit_code == 0, result.stdout
+
+        log = (home / "wiki" / "log.md").read_text()
+        assert log.count("## [") == 1, f"expected 1 log entry, got {log.count('## [')}"

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -1,0 +1,351 @@
+"""Tests for wiki generation from facts.jsonl."""
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from lorekeep.models import Edge, Manifest, Node
+from lorekeep.wiki import _slug, generate_wiki
+
+runner = CliRunner()
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def sample_nodes() -> list[Node]:
+    return [
+        Node(
+            id="svc:payments-api", type="service",
+            ns=("backend",), valid_from=date(2024, 1, 15),
+            props={"name": "payments-api", "lang": "go"},
+            src=("raw/backend/payments.md:3",),
+        ),
+        Node(
+            id="svc:auth", type="service",
+            ns=("backend",),
+            props={"name": "auth"},
+            src=("raw/backend/payments.md:6",),
+        ),
+        Node(
+            id="team:backend", type="team",
+            ns=("backend",),
+            props={"name": "team-backend"},
+            src=("raw/backend/payments.md:3",),
+        ),
+        Node(
+            id="dec:adr-007", type="decision",
+            ns=("backend",),
+            props={"title": "payments-api adopts internal signing"},
+            src=("raw/backend/payments.md:11",),
+        ),
+    ]
+
+
+@pytest.fixture
+def sample_edges() -> list[Edge]:
+    return [
+        Edge(
+            id="e_dep_1", type="depends_on",
+            from_="svc:payments-api", to="svc:auth",
+            ns=("backend",), valid_from=date(2024, 1, 15), valid_to=date(2025, 3, 1),
+            src=("raw/backend/payments.md:6",),
+        ),
+        Edge(
+            id="e_dec_1", type="decided_by",
+            from_="dec:adr-007", to="team:backend",
+            ns=("backend",),
+            src=("raw/backend/payments.md:11",),
+        ),
+    ]
+
+
+@pytest.fixture
+def sample_manifest(sample_nodes, sample_edges) -> Manifest:
+    return Manifest(
+        schema_version=1, chunk_count=1,
+        node_count=len(sample_nodes), edge_count=len(sample_edges),
+        run_id="abc123def456", facts_hash="deadbeef",
+    )
+
+
+@pytest.fixture
+def graph_dir(tmp_path: Path, sample_nodes, sample_edges, sample_manifest) -> Path:
+    from lorekeep.compile.writer import write_graph
+    g = tmp_path / "graph"
+    write_graph(g, sample_nodes, sample_edges, sample_manifest)
+    return g
+
+
+@pytest.fixture
+def wiki_dir(tmp_path: Path) -> Path:
+    return tmp_path / "wiki"
+
+
+# ── Unit tests ─────────────────────────────────────────────────────────────
+
+
+class TestSlug:
+    def test_colon_to_hyphen(self):
+        assert _slug("svc:payments-api") == "svc-payments-api"
+
+    def test_slash_to_hyphen(self):
+        assert _slug("team:backend/squad") == "team-backend-squad"
+
+    def test_no_special_chars(self):
+        assert _slug("plain-id") == "plain-id"
+
+
+class TestGenerateWiki:
+    def test_generates_index(self, graph_dir, wiki_dir):
+        result = generate_wiki(graph_dir, wiki_dir)
+        assert (wiki_dir / "index.md").exists()
+        assert result["nodes"] == 4
+        assert result["edges"] == 2
+
+    def test_generates_overview(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        overview = (wiki_dir / "overview.md").read_text()
+        assert "# Graph Overview" in overview
+        assert "Nodes" in overview
+        assert "svc:payments-api" not in overview  # no raw IDs in stats
+        assert "backend" in overview  # ns listed
+
+    def test_entity_pages_created(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        assert (wiki_dir / "entities" / "service" / "svc-payments-api.md").exists()
+        assert (wiki_dir / "entities" / "service" / "svc-auth.md").exists()
+        assert (wiki_dir / "entities" / "team" / "team-backend.md").exists()
+        assert (wiki_dir / "entities" / "decision" / "dec-adr-007.md").exists()
+
+    def test_entity_frontmatter(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        page = (wiki_dir / "entities" / "service" / "svc-payments-api.md").read_text()
+        assert page.startswith("---")
+        assert "id: svc:payments-api" in page
+        assert "type: service" in page
+        assert "ns: [backend]" in page
+        assert "valid_from: 2024-01-15" in page
+        assert "sources:" in page
+        assert "raw/backend/payments.md:3" in page
+        assert "tags:" in page
+
+    def test_entity_title_from_props(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        page = (wiki_dir / "entities" / "service" / "svc-payments-api.md").read_text()
+        assert "# payments-api" in page
+
+    def test_entity_props_table(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        page = (wiki_dir / "entities" / "service" / "svc-payments-api.md").read_text()
+        assert "## Properties" in page
+        assert "| name | payments-api |" in page
+        assert "| lang | go |" in page
+
+    def test_entity_outgoing_relationships(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        page = (wiki_dir / "entities" / "service" / "svc-payments-api.md").read_text()
+        assert "## Relationships" in page
+        assert "depends_on" in page
+        assert "[[svc-auth]]" in page
+        assert "2024-01-15" in page
+
+    def test_entity_incoming_relationships(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        page = (wiki_dir / "entities" / "service" / "svc-auth.md").read_text()
+        assert "[[svc-payments-api]]" in page
+
+    def test_entity_timeline(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        page = (wiki_dir / "entities" / "service" / "svc-payments-api.md").read_text()
+        assert "## Timeline" in page
+        assert "Valid from" in page
+
+    def test_index_groups_by_type(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        index = (wiki_dir / "index.md").read_text()
+        assert "## Services" in index
+        assert "## Teams" in index
+        assert "## Decisions" in index
+        assert "[[svc-payments-api]]" in index
+        assert "[[team-backend]]" in index
+
+    def test_log_appended(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        generate_wiki(graph_dir, wiki_dir)
+        log = (wiki_dir / "log.md").read_text()
+        assert log.count("## [") == 2
+
+    def test_log_format(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        log = (wiki_dir / "log.md").read_text()
+        assert "# Lorekeep Wiki" in log
+        assert "run_id=abc123def456" in log
+        assert "4 nodes, 2 edges" in log
+
+    def test_overview_shows_manifest_info(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        overview = (wiki_dir / "overview.md").read_text()
+        assert "abc123def456" in overview
+        assert "deadbeef" in overview
+
+    def test_no_facts_returns_error(self, tmp_path, wiki_dir):
+        result = generate_wiki(tmp_path / "empty", wiki_dir)
+        assert "error" in result
+
+    def test_wiki_without_manifest(self, graph_dir, wiki_dir):
+        (graph_dir / "manifest.json").unlink()
+        result = generate_wiki(graph_dir, wiki_dir)
+        assert result["nodes"] == 4
+        overview = (wiki_dir / "overview.md").read_text()
+        assert "# Graph Overview" in overview
+
+    def test_regenerates_clean(self, graph_dir, wiki_dir):
+        """Re-generation wipes old pages (stale entities removed)."""
+        generate_wiki(graph_dir, wiki_dir)
+        stale = wiki_dir / "entities" / "service" / "old-service.md"
+        stale.parent.mkdir(parents=True, exist_ok=True)
+        stale.write_text("# stale")
+
+        generate_wiki(graph_dir, wiki_dir)
+        assert not stale.exists()
+        assert (wiki_dir / "entities" / "service" / "svc-payments-api.md").exists()
+
+
+class TestDeterminism:
+    def test_entity_pages_byte_identical(self, graph_dir, wiki_dir, tmp_path):
+        """Re-generating unchanged facts yields identical pages (except log)."""
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        generate_wiki(graph_dir, dir_a)
+        generate_wiki(graph_dir, dir_b)
+
+        for f in ("index.md", "overview.md"):
+            assert (dir_a / f).read_text() == (dir_b / f).read_text()
+
+        for typ in ("service", "team", "decision"):
+            ents = (dir_a / "entities" / typ).glob("*.md")
+            for ent in ents:
+                rel = ent.relative_to(dir_a)
+                assert (dir_b / rel).read_text() == ent.read_text(), f"diff in {rel}"
+
+    def test_sorted_output(self, graph_dir, wiki_dir):
+        """Entity pages and index entries are sorted for deterministic output."""
+        generate_wiki(graph_dir, wiki_dir)
+        index = (wiki_dir / "index.md").read_text()
+        svc_pos = index.find("[[svc-auth]]")
+        svc2_pos = index.find("[[svc-payments-api]]")
+        assert svc_pos < svc2_pos  # auth before payments-api (alphabetical)
+
+
+# ── CLI tests ──────────────────────────────────────────────────────────────
+
+
+class TestWikiCLI:
+    def test_wiki_command(self, graph_dir, wiki_dir, monkeypatch):
+        monkeypatch.setenv("LOREKEEP_OUT", str(graph_dir))
+        monkeypatch.setenv("LOREKEEP_WIKI", str(wiki_dir))
+        from lorekeep.cli import app
+        result = runner.invoke(app, ["wiki"])
+        assert result.exit_code == 0, result.stdout
+        assert "pages written" in result.stdout
+        assert (wiki_dir / "index.md").exists()
+
+    def test_wiki_no_facts(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "empty"))
+        monkeypatch.setenv("LOREKEEP_WIKI", str(tmp_path / "wiki"))
+        from lorekeep.cli import app
+        result = runner.invoke(app, ["wiki"])
+        assert result.exit_code == 1
+        assert "not found" in result.stdout
+
+    def test_compile_auto_generates_wiki(self, tmp_path, monkeypatch, patch_make_provider):
+        """compile should auto-generate wiki after successful compile."""
+        from lorekeep.cli import app
+
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "raw" / "backend").mkdir(parents=True)
+        (home / "raw" / "backend" / "payments.md").write_text(
+            "# Payments API\n\n## Service\n"
+            "payments-api (go) depends on auth.\n"
+            "team: backend owns payments-api.\n"
+        )
+        (home / "schema.json").write_text(
+            json.dumps({
+                "version": 1,
+                "node_types": {
+                    "service": {"props": {"name": "string", "lang": "string"}},
+                    "team": {"props": {"name": "string"}},
+                },
+                "edge_types": {
+                    "depends_on": {"from": "service", "to": "service"},
+                    "owns": {"from": "team", "to": "service"},
+                },
+            })
+        )
+
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+
+        result = runner.invoke(app, ["compile"])
+        assert result.exit_code == 0, result.stdout
+
+        assert (home / "wiki" / "index.md").exists()
+        assert (home / "wiki" / "overview.md").exists()
+
+    def test_resolve_regenerates_wiki(self, tmp_path, monkeypatch, patch_make_provider):
+        """resolve should regenerate wiki after merging agent-proposed facts."""
+        from lorekeep.cli import app
+        from lorekeep.journal import append_journal
+        from lorekeep.models import JournalEntry
+
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "raw" / "backend").mkdir(parents=True)
+        (home / "raw" / "backend" / "payments.md").write_text(
+            "# Payments API\n\npayments-api (go) depends on auth.\n"
+        )
+        (home / "graph").mkdir(parents=True)
+        (home / "pending").mkdir(parents=True)
+        (home / "schema.json").write_text(
+            json.dumps({
+                "version": 1,
+                "node_types": {
+                    "service": {"props": {"name": "string", "lang": "string"}},
+                },
+                "edge_types": {
+                    "depends_on": {"from": "service", "to": "service"},
+                },
+            })
+        )
+
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+
+        runner.invoke(app, ["compile"])
+        wiki_before = (home / "wiki" / "log.md").read_text()
+        assert "## [" in wiki_before
+
+        append_journal(
+            home / "pending",
+            JournalEntry(
+                fact={"kind": "node", "id": "svc:new-svc", "type": "service",
+                      "ns": ["backend"], "props": {"name": "new-svc"}},
+                agent="test", ns="backend", confidence=0.9,
+                proposed_at="2026-06-29T00:00:00Z",
+            ),
+            "backend",
+        )
+
+        result = runner.invoke(app, ["resolve"])
+        assert result.exit_code == 0, result.stdout
+
+        entity = home / "wiki" / "entities" / "service" / "svc-new-svc.md"
+        assert entity.exists()
+        assert "# new-svc" in entity.read_text()
+
+        wiki_after = (home / "wiki" / "log.md").read_text()
+        assert wiki_after.count("## [") == wiki_before.count("## [") + 1


### PR DESCRIPTION
Closes #16.

## What

Generate human-browsable markdown wiki pages from `facts.jsonl`, following the Karpathy LLM Wiki pattern. The wiki is a **derived projection** — fully regenerable from the graph, never the reverse.

```
raw/*.md → compile → facts.jsonl → wiki/*.md
                         ↑                ↓
                    agent queries     human browses
                    (MCP tools)      (Obsidian)
```

## Output structure

```
wiki/
├── index.md                     # catalog of all entities, grouped by type
├── log.md                       # append-only generation log
├── overview.md                  # graph stats dashboard
└── entities/
    └── <type>/
        └── <slug>.md            # one page per node
```

Each entity page has:
- YAML frontmatter (Obsidian Dataview compatible)
- Properties table
- Relationships as `[[wikilinks]]` (graph view + backlinks)
- Timeline (valid_from / valid_to)

## Changes

| File | Change |
|---|---|
| `src/lorekeep/wiki.py` | NEW — `generate_wiki()`, entity/index/overview/log page templates, slug function |
| `src/lorekeep/paths.py` | Add `wiki/` path (`LOREKEEP_WIKI` env override) |
| `src/lorekeep/cli.py` | `lorekeep wiki` command + auto-gen after compile |
| `docs/guides/wiki.md` | NEW — full lifecycle guide + Obsidian tips |
| `docs/guides/compile.md` | Mention wiki auto-gen |
| `docs/guides/serve.md` | Add wiki to lifecycle |
| `docs/architecture/overview.md` | Diagram: facts.jsonl → wiki/ |
| `README.md` | Move wiki from Phase 2 to v1, add docs link |
| `AGENTS.md` | CLI commands table, pipeline diagram, conventions |

## Tests

24 new tests covering:
- Entity page content (frontmatter, title, props, relationships, timeline)
- Wikilink correctness (outgoing + incoming, slug sanitization)
- index.md grouping by type
- log.md append-only behavior
- overview.md stats + manifest info
- Determinism (byte-identical re-generation except log.md)
- Clean regeneration (stale pages removed)
- CLI command (`lorekeep wiki`)
- Compile auto-generates wiki
- No facts.jsonl → error exit
- No manifest → graceful degradation

299 total tests pass.

## Design decisions

- **No LLM needed** — pure JSONL → markdown transform
- **Deterministic** — same facts.jsonl → byte-identical pages (except append-only log.md)
- **Edges as wikilinks** — not separate pages; Obsidian graph view shows the structure
- **Auto-gen after compile** — wiki stays in sync automatically
- **Standalone command too** — `lorekeep wiki` for manual regeneration