### PR TITLE
feat: add scope-awareness meta tool — 9th MCP read tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-Lorekeep compiles a team's raw markdown docs into a **temporal knowledge graph** (`facts.jsonl`) and exposes it to coding agents (Claude Code, Cursor, Codex, opencode) over MCP, with per-namespace permission. Agents read facts through 8 read tools and propose new facts through 5 journal-based write tools (confidence-gated, merged on resolve). Knowledge is processed once at compile time, not re-RAG'd per query.
+Lorekeep compiles a team's raw markdown docs into a **temporal knowledge graph** (`facts.jsonl`) and exposes it to coding agents (Claude Code, Cursor, Codex, opencode) over MCP, with per-namespace permission. Agents read facts through 9 read tools and propose new facts through 5 journal-based write tools (confidence-gated, merged on resolve). Knowledge is processed once at compile time, not re-RAG'd per query.
 
 ## Commands
 
@@ -29,7 +29,7 @@ uv run lorekeep <command>                    # run the CLI in dev mode
 | `check` | Validate compiled graph loads, no dangling edges (exit 1 on failure) |
 | `eval` | Tier-1 construction P/R/F1 vs gold corpus + structure metrics |
 | `wiki` | Regenerate `wiki/` from `facts.jsonl` (Obsidian-compatible markdown) |
-| `serve [--transport stdio\|http]` | Run the MCP server (8 read + 5 write tools) |
+| `serve [--transport stdio\|http]` | Run the MCP server (9 read + 5 write tools) |
 | `mcp add --agent claude\|cursor\|codex\|opencode --ns NS` | Write agent MCP config |
 | `import --from claude\|cursor\|codex\|opencode` | Import agent sessions into `raw/` |
 | `doctor` | Verify install: graph loads, schema valid, a tool responds |
@@ -58,7 +58,7 @@ Pydantic, all `frozen=True`, `extra="forbid"`. `Node` / `Edge` are the two `kind
 - **`perm/ns.py` `ScopedGraph`** — the **single permission chokepoint**. Wraps a `GraphStore` and filters *every* query. Deny-by-default: `effective_ns = allowed ∪ {public}`; a node is visible iff `ns ∩ effective_ns ≠ ∅`; an edge iff **both** endpoints visible **and** `edge.ns ∩ effective_ns ≠ ∅` (an edge never leaks a neighbor the caller can't see). **Any new query path must go through `ScopedGraph`, not `GraphStore` directly.**
 
 ### Serve (`mcp_server.py`)
-`FastMCP` with 8 read tools (`search`, `get_node`, `neighbors`, `at_time`, `history`, `changes`, `list_namespaces`, `schema`) and 5 write tools (`propose_fact`, `link_facts`, `flag_contradiction`, `update_fact`, `suggest_improvement`). Module-global `ScopedGraph` is set by `configure()`; `_require()` lazy-reloads when `facts.jsonl` mtime changes (so `compile` is visible without reconnecting). Tools are plain functions registered with `@mcp.tool()` but stay directly callable — **tests invoke them directly, no MCP transport**. The writer uses atomic `os.replace` so lazy-reload never reads a half-written file.
+`FastMCP` with 9 read tools (`search`, `get_node`, `neighbors`, `at_time`, `history`, `changes`, `list_namespaces`, `schema`, `meta`) and 5 write tools (`propose_fact`, `link_facts`, `flag_contradiction`, `update_fact`, `suggest_improvement`). Module-global `ScopedGraph` is set by `configure()`; `_require()` lazy-reloads when `facts.jsonl` mtime changes (so `compile` is visible without reconnecting). `_manifest` global loads `manifest.json` alongside facts (for `meta` tool's `compiled_at` + `merged_count`). Tools are plain functions registered with `@mcp.tool()` but stay directly callable — **tests invoke them directly, no MCP transport**. The writer uses atomic `os.replace` so lazy-reload never reads a half-written file.
 
 ### Wiki (`wiki.py`)
 Pure JSONL → markdown transform (no LLM). `generate_wiki(graph_dir, wiki_dir)` reads `facts.jsonl` via `GraphStore` → entity pages (`entities/<type>/<slug>.md` with YAML frontmatter, wikilinks, props table), `index.md` (catalog), `overview.md` (stats dashboard), `log.md` (append-only, preserved across regen). Builds into `.wiki-build.tmp` then `os.rename` swaps into place (atomic). `_slug()` replaces `:`/`/` with `-`; collisions raise `ValueError`. YAML scalars quoted via `json.dumps` so IDs like `svc:payments-api` parse correctly. Props table escapes `\|`, collapses newlines, serializes non-strings. Regenerates on every `facts.jsonl` mutation: `compile` (single regen — `_do_auto_resolve` returns bool, compile skips if resolve already regend), `resolve` (gated on merge/flag), daemon auto-resolve (on actual merge). Best-effort — never blocks compile or resolve.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ knowledge.
 - **Namespace permission** — facts are tagged `ns` from the directory tree
   (`raw/<ns>/`); agents scoped to namespaces; cross-namespace edges
   hidden unless both endpoints are visible. Deny-by-default.
-- **MCP, stdio-first** — `lorekeep serve` exposes 8 read + 5 write tools;
+- **MCP, stdio-first** — `lorekeep serve` exposes 9 read + 5 write tools;
   `lorekeep mcp add` wires Claude Code / Cursor / Codex / opencode.
 - **Autonomous agent daemon** — `lorekeep agent watch` keeps the graph current:
   auto-compile on raw/ change, auto-resolve pending journals, delta import of
@@ -93,7 +93,7 @@ uvx lorekeep mcp add --agent claude --ns backend
 uvx lorekeep doctor
 ```
 
-Restart Claude Code → 13 Lorekeep tools are available (8 read + 5 write), scoped to your namespace. Open `~/.local/share/lorekeep/wiki/` in Obsidian to browse the graph as a human.
+Restart Claude Code → 14 Lorekeep tools are available (9 read + 5 write), scoped to your namespace. Open `~/.local/share/lorekeep/wiki/` in Obsidian to browse the graph as a human.
 
 ## Lifecycle
 
@@ -121,7 +121,7 @@ The full journey from install to continuous use — see the
 | 3. Compile | `lorekeep compile` | LLM-extract → `facts.jsonl` + `wiki/` (cached, deterministic) |
 | 4. Wire agent | `lorekeep mcp add --agent claude --ns <ns>` | Write `.mcp.json` + session-end hook, scoped to namespace |
 | 5. Verify | `lorekeep doctor` | Graph loads, schema valid, tool responds |
-| 6. Serve | `lorekeep serve` | MCP server (8 read + 5 write tools, lazy-reload) |
+| 6. Serve | `lorekeep serve` | MCP server (9 read + 5 write tools, lazy-reload) |
 | 7. Keep current | `lorekeep agent watch &` | Daemon: auto-compile, auto-resolve, delta-import sessions |
 | 8. Back up | `lorekeep backup` | Push data home to private git repo (raw/ + schema.json) |
 
@@ -143,7 +143,7 @@ import ──► raw/ ──► compile ─────────────�
                                                         ┌───────────────┘
                                                         ▼ (git / S3 sync)
                SERVE + QUERY (runtime, per device)
-facts.jsonl ──load──► GraphStore ──► ScopedGraph(ns) ──► MCP ──► agent
+facts.jsonl ──load──► GraphStore ──► ScopedGraph(ns) ──► MCP (9 read + 5 write) ──► agent
                          ▲              ▲                      │
                           │              │         ◄── read queries
                           │              └────────── write proposals (journal)
@@ -160,7 +160,7 @@ facts.jsonl ──load──► GraphStore ──► ScopedGraph(ns) ──► M
 
 **Serve**: `GraphStore` loads `facts.jsonl` into a networkx graph with temporal
 queries. `ScopedGraph` is the single permission chokepoint — every query is
-filtered through strict visibility rules. The FastMCP server exposes 8 read
+filtered through strict visibility rules. The FastMCP server exposes 9 read
 + 5 write tools over `ScopedGraph`. It lazy-reloads when
 `facts.jsonl` changes, so `compile` is instantly visible without reconnecting.
 
@@ -188,9 +188,9 @@ that began/ended in the window).
 
 **Autonomous agent daemon** — `lorekeep agent watch` keeps the graph current: watches `raw/` for changes → auto-compile; monitors `pending/` → auto-resolve; delta-imports agent session memory (Claude / Cursor / Codex / opencode) into `raw/`. Session-end hooks auto-trigger `lorekeep hook` when the agent exits. Scheduled lint and weekly suggestions are planned. See [docs/architecture/agent.md](docs/architecture/agent.md).
 
-## MCP tools (8 read + 5 write, scoped)
+## MCP tools (9 read + 5 write, scoped)
 
-**Read:** `search` · `get_node` · `neighbors` · `at_time` · `history` · `changes` · `list_namespaces` · `schema`.
+**Read:** `search` · `get_node` · `neighbors` · `at_time` · `history` · `changes` · `list_namespaces` · `schema` · `meta`.
 
 **Write** (journal-based, zero LLM cost): `propose_fact` · `link_facts` · `flag_contradiction` · `update_fact` · `suggest_improvement`.
 
@@ -249,7 +249,7 @@ src/lorekeep/
   agent.py             autonomous agent: ingest, lint, suggest, status, watch
   store/{graph,fts}.py                          GraphStore + optional FTS cache
   perm/ns.py                                    ScopedGraph permission chokepoint
-  mcp_server.py                                 FastMCP + 8 read + 5 write tools
+  mcp_server.py                                 FastMCP + 9 read + 5 write tools
   wiki.py                                        Obsidian-compatible wiki generator
   importer/{claude,cursor,codex,opencode}.py    agent session → raw/ importers
   integrations/{claude_code,cursor,codex,opencode,common}.py
@@ -261,7 +261,7 @@ docs/                  README.md index, architecture/, guides/
 
 ## Status
 
-**v1 (implemented)** — compile pipeline + serve (store/permission/MCP read+write/4-agent integrations) + import (Claude/Cursor/Codex/opencode) + session-end hooks + agent daemon (watch/ingest/lint/suggest/status) + journal + resolve + data-home + dev mode + lazy-reload + backup + eval + **wiki** (Obsidian-compatible markdown output). Published to PyPI as `lorekeep`.
+**v1 (implemented)** — compile pipeline + serve (store/permission/MCP 9 read+5 write/4-agent integrations) + import (Claude/Cursor/Codex/opencode) + session-end hooks + agent daemon (watch/ingest/lint/suggest/status) + journal + resolve + data-home + dev mode + lazy-reload + backup + eval + scope awareness (`meta` tool) + **wiki** (Obsidian-compatible markdown output). Published to PyPI as `lorekeep`.
 
 **Phase 2 (planned)** — streamable-HTTP team server, OIDC/SSO, embeddings/hybrid search, scheduled nightly lint/suggest in daemon, schema evolve, full Tier-2 benchmark datasets (HotpotQA/CronQuestions) and the bespoke Tier-3 Lorekeep-Reason eval.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Concepts and design — how the system fits together.
 - [Agent](architecture/agent.md) — autonomous agent: daemon, trigger model, lint, resolve, suggest, cost profile.
 - [Permission model](architecture/permission.md) — namespace visibility rules, deny-by-default, the single `ScopedGraph` chokepoint.
 - [Temporal model](architecture/temporal.md) — `valid_from`/`valid_to`, `at_time` / `history` / `changes`.
-- [Serve & MCP](architecture/serve-mcp.md) — 8 read + 5 write MCP tools, lazy-reload, journal-based writes, agent integration, sync.
+- [Serve & MCP](architecture/serve-mcp.md) — 9 read + 5 write MCP tools, lazy-reload, journal-based writes, agent integration, sync.
 - [Testing & evaluation](architecture/evaluation.md) — the three-tier eval strategy and scope.
 
 ## Guides

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -102,7 +102,7 @@ Each component has one responsibility, a clear input/output interface, and is te
 | `perm/ns` | `allowed_ns` (set) | filter / guard | **Single permission chokepoint.** Every store query passes through here. |
 | `store/fts` (optional) | `facts.jsonl` | FTS cache | FTS5 over node text/props for text search. Local, gitignored, rebuilt from `facts.jsonl`. Falls back to in-memory scan if absent. |
 | `integrations/*` | agent type, scope, ns | config file + snippet | Write Claude Code / Cursor / Codex MCP config; emit agent-memory text. |
-| `mcp_server` | store + perm | 8 read + 5 write MCP tools | FastMCP server, stdio (default). Loads store once; enforces permission per request. Write tools append to journals. |
+| `mcp_server` | store + perm | 9 read + 5 write MCP tools | FastMCP server, stdio (default). Loads store once; enforces permission per request. Write tools append to journals. |
 
 ### Dependency order
 

--- a/docs/architecture/serve-mcp.md
+++ b/docs/architecture/serve-mcp.md
@@ -12,7 +12,7 @@ The serve chain loads `facts.jsonl` once and exposes it to coding agents over MC
 - **Lazy-reload:** every query stats `facts.jsonl`'s mtime; if it changed (after compile or resolve) the graph is rebuilt automatically. Connect the server once — graph updates are visible without reconnecting. Reconnect is only needed for code or scope (`.mcp.json` `LOREKEEP_NS`) changes.
 - **Journals:** write tools append to `pending/<ns>/journal.jsonl`; facts enter the graph on the next resolve pass, not immediately. This avoids write conflicts and keeps the read path fast.
 
-## Read tools (8 tools, scoped)
+## Read tools (9 tools, scoped)
 
 | Tool | Purpose |
 |---|---|

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -133,8 +133,8 @@ uvx lorekeep mcp add --agent opencode --ns backend
 
 Supported agents: `claude`, `cursor`, `codex`, `opencode`.
 
-Restart the agent → the 13 Lorekeep tools (8 read: `search`, `get_node`,
-`neighbors`, `at_time`, `history`, `changes`, `list_namespaces`, `schema`;
+Restart the agent → the 14 Lorekeep tools (9 read: `search`, `get_node`,
+`neighbors`, `at_time`, `history`, `changes`, `list_namespaces`, `schema`, `meta`;
 5 write: `propose_fact`, `link_facts`, `flag_contradiction`, `update_fact`,
 `suggest_improvement`) are
 available, scoped to `backend` (+ `public`). See

--- a/docs/guides/serve.md
+++ b/docs/guides/serve.md
@@ -42,11 +42,55 @@ LOREKEEP_HOME=~/kb-work uvx lorekeep init
 LOREKEEP_HOME=~/kb-work uvx lorekeep compile
 ```
 
-## Read tools (8 tools, scoped)
+## Read tools (9 tools, scoped)
 
 `search`, `get_node`, `neighbors`, `at_time`, `history`, `changes`,
-`list_namespaces`, `schema`. Results are filtered to `LOREKEEP_NS`; cross-namespace
+`list_namespaces`, `schema`, `meta`. Results are filtered to `LOREKEEP_NS`; cross-namespace
 edges are hidden unless both endpoints are visible.
+
+### `meta(topic="")` — scope awareness
+
+Agents call `meta()` to decide whether to query the graph or work from memory:
+
+```json
+{
+  "nodes": 42,
+  "edges": 18,
+  "node_types": {"service": 30, "decision": 12},
+  "edge_types": {"depends_on": 15, "decided_by": 3},
+  "namespaces": ["backend", "frontend", "public"],
+  "provenance": {"curator": 38, "agent": 4},
+  "freshness": {
+    "oldest": "2024-01-15",
+    "newest": "2026-06-20",
+    "expired": 2
+  },
+  "compile": {
+    "run_id": "abc123",
+    "compiled_at": "2026-06-30T01:27:59Z",
+    "merged_count": 4,
+    "quarantined_count": 1
+  },
+  "pending": 7
+}
+```
+
+Pass `topic` to check coverage for a specific subject:
+
+```json
+{
+  "coverage": {
+    "topic": "payments",
+    "matching_nodes": 3,
+    "matching_types": {"service": 2, "decision": 1},
+    "node_ids": ["svc:payments-api", "dec:adr-007", "svc:payments-worker"]
+  }
+}
+```
+
+**Provenance signal:** `provenance.curator` counts nodes with `src` (compiled from raw docs, higher trust). `provenance.agent` counts nodes without `src` (agent-proposed via journal, lower trust). If most facts are agent-proposed, the agent should verify before relying on them.
+
+**Freshness signal:** `freshness.expired` counts nodes whose `valid_to` has passed. `compile.compiled_at` shows when the graph was last rebuilt. `pending` shows unresolved agent proposals.
 
 ## Write tools (5 tools, journal-based)
 

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -10,6 +10,7 @@ import typer
 from lorekeep import __version__
 from lorekeep.compile.providers import LiteLLMProvider
 from lorekeep.config import Config, load_config
+from lorekeep.models import now_iso
 from lorekeep.pipeline import compile_graph
 from lorekeep.paths import resolve_paths
 from lorekeep.defaults import DEFAULT_CONFIG_YAML, DEFAULT_SCHEMA, PROVIDER_PRESETS
@@ -214,6 +215,7 @@ def resolve(
         edge_count=len(resolved.edges),
         run_id="resolve",
         facts_hash="",
+        compiled_at=now_iso(),
         merged_count=merged.merge_count,
         quarantined_count=merged.quarantine_count,
         flagged_count=merged.flagged_count,
@@ -1236,6 +1238,7 @@ def _do_auto_resolve(out_dir: Path, pending_dir: Path, wiki_dir: Path | None = N
                 node_count=len(resolved.nodes),
                 edge_count=len(resolved.edges),
                 run_id="auto-resolve", facts_hash="",
+                compiled_at=now_iso(),
                 merged_count=merged.merge_count,
                 quarantined_count=merged.quarantine_count,
                 flagged_count=merged.flagged_count,

--- a/src/lorekeep/mcp_server.py
+++ b/src/lorekeep/mcp_server.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from mcp.server.fastmcp import FastMCP
 
 from lorekeep.journal import append_journal
-from lorekeep.models import JournalEntry, Schema
+from lorekeep.models import JournalEntry, Manifest, Schema
 from lorekeep.perm.ns import ScopedGraph
 from lorekeep.schema_io import load_schema
 from lorekeep.store.graph import GraphStore, parse_date
@@ -25,6 +25,7 @@ mcp = FastMCP("lorekeep")
 _state: dict = {}          # graph_dir, allowed_ns, schema_path, pending_dir, facts_mtime
 _scope: ScopedGraph | None = None
 _schema: Schema | None = None
+_manifest: Manifest | None = None
 
 
 def configure(graph_dir, allowed_ns, schema_path=None, fts_path=None, pending_dir=None) -> None:
@@ -37,13 +38,18 @@ def configure(graph_dir, allowed_ns, schema_path=None, fts_path=None, pending_di
 
 
 def _rebuild() -> None:
-    """(Re)load the graph + schema from disk into a fresh ScopedGraph."""
-    global _scope, _schema
+    """(Re)load the graph + schema + manifest from disk into a fresh ScopedGraph."""
+    global _scope, _schema, _manifest
     facts = _state["graph_dir"] / "facts.jsonl"
     store = GraphStore.from_jsonl(facts)
     sp = _state.get("schema_path")
     _schema = load_schema(sp) if sp else None
     _scope = ScopedGraph(store, _state["allowed_ns"])
+    manifest_path = _state["graph_dir"] / "manifest.json"
+    if manifest_path.exists():
+        _manifest = Manifest.from_json(manifest_path.read_text(encoding="utf-8"))
+    else:
+        _manifest = None
     _state["facts_mtime"] = facts.stat().st_mtime if facts.exists() else 0
 
 
@@ -120,6 +126,35 @@ def changes(from_t: str, to_t: str) -> dict:
 def search(query: str, limit: int = 10) -> list:
     """Text search over node ids/props, scoped to the caller."""
     return _require().search(query, limit)
+
+
+@mcp.tool()
+def meta(topic: str = "") -> dict:
+    """Graph coverage, provenance, and freshness.
+
+    Agent calls this to decide whether to query the graph or work from memory.
+    If ``topic`` is given, returns matching node count and ids for that topic.
+    """
+    scope = _require()
+    result = scope.stats(topic)
+
+    if _manifest:
+        result["compile"] = {
+            "run_id": _manifest.run_id,
+            "compiled_at": _manifest.compiled_at or None,
+            "merged_count": _manifest.merged_count,
+            "quarantined_count": _manifest.quarantined_count,
+        }
+
+    pending = _pending_dir()
+    if pending and pending.exists():
+        from lorekeep.journal import load_journals
+        journals = load_journals(pending)
+        result["pending"] = sum(1 for j in journals if j.status == "pending")
+    else:
+        result["pending"] = 0
+
+    return result
 
 
 # --- Write tools (journal-based) -----------------------------------------

--- a/src/lorekeep/models.py
+++ b/src/lorekeep/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -134,6 +134,7 @@ class Manifest(BaseModel):
     edge_count: int
     run_id: str
     facts_hash: str
+    compiled_at: str = ""
     chunk_hashes: dict[str, list[str]] = Field(default_factory=dict)
     errors: list[CompileError] = Field(default_factory=list)
     quarantine: list[QuarantineItem] = Field(default_factory=list)
@@ -148,3 +149,8 @@ class Manifest(BaseModel):
     @classmethod
     def from_json(cls, text: str) -> "Manifest":
         return cls.model_validate(json.loads(text))
+
+
+def now_iso() -> str:
+    """UTC timestamp for Manifest.compiled_at."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/src/lorekeep/perm/ns.py
+++ b/src/lorekeep/perm/ns.py
@@ -108,6 +108,71 @@ class ScopedGraph:
         ids = self._g.search(query, limit * 3, fts)   # over-fetch then filter
         return [nid for nid in ids if self._node_visible(self._g.get_node(nid))][:limit]
 
+    def stats(self, topic: str = "") -> dict:
+        """Namespace-filtered graph statistics.
+
+        If ``topic`` is given, also returns coverage info: how many visible
+        nodes/edges match the topic string (case-insensitive on id, type,
+        and prop values).
+        """
+        from datetime import date as date_t
+
+        nodes = [n for n in self._g.all_nodes() if self._node_visible(n)]
+        vis_ids = {n.id for n in nodes}
+        edges = [
+            e for e in self._g.all_edges()
+            if e.from_ in vis_ids and e.to in vis_ids and bool(set(e.ns) & self._eff)
+        ]
+        node_types: dict[str, int] = {}
+        edge_types: dict[str, int] = {}
+        all_ns: set[str] = set()
+        curator = 0
+        agent = 0
+        for n in nodes:
+            node_types[n.type] = node_types.get(n.type, 0) + 1
+            all_ns.update(n.ns)
+            if n.src:
+                curator += 1
+            else:
+                agent += 1
+        for e in edges:
+            edge_types[e.type] = edge_types.get(e.type, 0) + 1
+            all_ns.update(e.ns)
+        today = date_t.today()
+        valid_tos = [n.valid_to for n in nodes if n.valid_to]
+        valid_froms = [n.valid_from for n in nodes if n.valid_from]
+        result = {
+            "nodes": len(nodes),
+            "edges": len(edges),
+            "node_types": dict(sorted(node_types.items())),
+            "edge_types": dict(sorted(edge_types.items())),
+            "namespaces": sorted(all_ns),
+            "provenance": {"curator": curator, "agent": agent},
+            "freshness": {
+                "oldest": min(valid_froms).isoformat() if valid_froms else None,
+                "newest": max(valid_froms).isoformat() if valid_froms else None,
+                "expired": sum(1 for t in valid_tos if t <= today),
+            },
+        }
+        if topic:
+            tlow = topic.lower()
+            matching = [
+                n for n in nodes
+                if tlow in n.id.lower()
+                or tlow in n.type.lower()
+                or any(tlow in str(v).lower() for v in n.props.values())
+            ]
+            matching_types: dict[str, int] = {}
+            for n in matching:
+                matching_types[n.type] = matching_types.get(n.type, 0) + 1
+            result["coverage"] = {
+                "topic": topic,
+                "matching_nodes": len(matching),
+                "matching_types": dict(sorted(matching_types.items())),
+                "node_ids": sorted(n.id for n in matching)[:20],
+            }
+        return result
+
 
 def _edge_from_dict(d: dict) -> Edge:
     return Edge.model_validate(d)

--- a/src/lorekeep/pipeline.py
+++ b/src/lorekeep/pipeline.py
@@ -8,7 +8,7 @@ from lorekeep.compile.ingest import ingest
 from lorekeep.compile.providers import LLMProvider
 from lorekeep.compile.resolve import resolve
 from lorekeep.compile.writer import facts_hash, run_id, write_graph
-from lorekeep.models import Edge, Manifest, Node, Schema
+from lorekeep.models import Edge, Manifest, Node, Schema, now_iso
 
 
 def compile_graph(
@@ -59,6 +59,7 @@ def compile_graph(
         edge_count=len(resolved.edges),
         run_id=rid,
         facts_hash=fh,
+        compiled_at=now_iso(),
         chunk_hashes=chunk_hashes,
         errors=errors,
         quarantine=[{"fact": q[0], "reason": q[1]} for q in resolved.quarantined],

--- a/src/lorekeep/store/graph.py
+++ b/src/lorekeep/store/graph.py
@@ -135,3 +135,39 @@ class GraphStore:
             return fts.search(query, limit)
         from lorekeep.store.fts import scan_search
         return scan_search(self.all_nodes(), query, limit)
+
+    def stats(self) -> dict:
+        """Return graph statistics: counts by type/ns, provenance split, freshness."""
+        nodes = self.all_nodes()
+        edges = self.all_edges()
+        node_types: dict[str, int] = {}
+        edge_types: dict[str, int] = {}
+        all_ns: set[str] = set()
+        curator = 0
+        agent = 0
+        for n in nodes:
+            node_types[n.type] = node_types.get(n.type, 0) + 1
+            all_ns.update(n.ns)
+            if n.src:
+                curator += 1
+            else:
+                agent += 1
+        for e in edges:
+            edge_types[e.type] = edge_types.get(e.type, 0) + 1
+            all_ns.update(e.ns)
+        today = date.today()
+        valid_tos = [n.valid_to for n in nodes if n.valid_to]
+        valid_froms = [n.valid_from for n in nodes if n.valid_from]
+        return {
+            "nodes": len(nodes),
+            "edges": len(edges),
+            "node_types": dict(sorted(node_types.items())),
+            "edge_types": dict(sorted(edge_types.items())),
+            "namespaces": sorted(all_ns),
+            "provenance": {"curator": curator, "agent": agent},
+            "freshness": {
+                "oldest": min(valid_froms).isoformat() if valid_froms else None,
+                "newest": max(valid_froms).isoformat() if valid_froms else None,
+                "expired": sum(1 for t in valid_tos if t <= today),
+            },
+        }

--- a/tests/test_scope_awareness.py
+++ b/tests/test_scope_awareness.py
@@ -1,0 +1,308 @@
+"""Tests for scope-awareness: meta tool, graph stats, compiled_at."""
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from lorekeep.models import Edge, Manifest, Node, now_iso
+from lorekeep.mcp_server import configure, meta
+from lorekeep.perm.ns import ScopedGraph
+from lorekeep.store.graph import GraphStore
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def sample_nodes() -> list[Node]:
+    return [
+        Node(
+            id="svc:payments-api", type="service",
+            ns=("backend",), valid_from=date(2024, 1, 15),
+            props={"name": "payments-api", "lang": "go"},
+            src=("raw/backend/payments.md:3",),
+        ),
+        Node(
+            id="svc:auth", type="service",
+            ns=("backend",),
+            props={"name": "auth"},
+            src=("raw/backend/payments.md:6",),
+        ),
+        Node(
+            id="svc:web-ui", type="service",
+            ns=("frontend",),
+            props={"name": "web-ui", "lang": "ts"},
+            src=("raw/frontend/web.md:1",),
+        ),
+        Node(
+            id="svc:legacy", type="service",
+            ns=("backend",), valid_to=date.today() - timedelta(days=30),
+            props={"name": "legacy"},
+            src=("raw/backend/legacy.md:1",),
+        ),
+        Node(
+            id="svc:agent-found", type="service",
+            ns=("backend",),
+            props={"name": "agent-discovered"},
+            src=(),
+        ),
+    ]
+
+
+@pytest.fixture
+def sample_edges() -> list[Edge]:
+    return [
+        Edge(
+            id="e_dep_1", type="depends_on",
+            from_="svc:payments-api", to="svc:auth",
+            ns=("backend",), valid_from=date(2024, 1, 15),
+            valid_to=date.today() - timedelta(days=1),
+        ),
+    ]
+
+
+@pytest.fixture
+def store(sample_nodes, sample_edges) -> GraphStore:
+    return GraphStore(sample_nodes, sample_edges)
+
+
+@pytest.fixture
+def graph_dir(tmp_path: Path, sample_nodes, sample_edges) -> Path:
+    from lorekeep.compile.writer import write_graph
+    g = tmp_path / "graph"
+    manifest = Manifest(
+        schema_version=1, chunk_count=1,
+        node_count=len(sample_nodes), edge_count=len(sample_edges),
+        run_id="test123", facts_hash="abc", compiled_at=now_iso(),
+        merged_count=2, quarantined_count=1,
+    )
+    write_graph(g, sample_nodes, sample_edges, manifest)
+    return g
+
+
+# ── GraphStore.stats() ─────────────────────────────────────────────────────
+
+
+class TestGraphStoreStats:
+    def test_basic_counts(self, store):
+        s = store.stats()
+        assert s["nodes"] == 5
+        assert s["edges"] == 1
+
+    def test_node_types(self, store):
+        s = store.stats()
+        assert s["node_types"] == {"service": 5}
+
+    def test_edge_types(self, store):
+        s = store.stats()
+        assert s["edge_types"] == {"depends_on": 1}
+
+    def test_namespaces(self, store):
+        s = store.stats()
+        assert "backend" in s["namespaces"]
+        assert "frontend" in s["namespaces"]
+
+    def test_provenance_curator(self, store):
+        s = store.stats()
+        assert s["provenance"]["curator"] == 4
+        assert s["provenance"]["agent"] == 1
+
+    def test_freshness_oldest_newest(self, store):
+        s = store.stats()
+        assert s["freshness"]["oldest"] == "2024-01-15"
+        assert s["freshness"]["newest"] == "2024-01-15"
+
+    def test_freshness_expired(self, store):
+        s = store.stats()
+        assert s["freshness"]["expired"] >= 1
+
+    def test_empty_graph(self):
+        s = GraphStore([], []).stats()
+        assert s["nodes"] == 0
+        assert s["edges"] == 0
+        assert s["provenance"] == {"curator": 0, "agent": 0}
+        assert s["freshness"]["oldest"] is None
+
+    def test_provenance_agent_no_src(self, store):
+        s = store.stats()
+        assert s["provenance"]["agent"] == 1
+
+
+# ── ScopedGraph.stats() ────────────────────────────────────────────────────
+
+
+class TestScopedGraphStats:
+    def test_ns_filter_backend(self, store):
+        scope = ScopedGraph(store, ["backend"])
+        s = scope.stats()
+        assert s["nodes"] == 4
+        assert "frontend" not in s["namespaces"]
+
+    def test_ns_filter_frontend(self, store):
+        scope = ScopedGraph(store, ["frontend"])
+        s = scope.stats()
+        assert s["nodes"] == 1
+        assert "frontend" in s["namespaces"]
+        assert "backend" not in s["namespaces"]
+
+    def test_ns_filter_public(self, store):
+        scope = ScopedGraph(store, [])
+        s = scope.stats()
+        assert s["nodes"] == 0
+
+    def test_topic_match(self, store):
+        scope = ScopedGraph(store, ["backend"])
+        s = scope.stats(topic="payment")
+        assert s["coverage"]["matching_nodes"] == 1
+        assert "svc:payments-api" in s["coverage"]["node_ids"]
+
+    def test_topic_no_match(self, store):
+        scope = ScopedGraph(store, ["backend"])
+        s = scope.stats(topic="nonexistent")
+        assert s["coverage"]["matching_nodes"] == 0
+
+    def test_topic_match_lang(self, store):
+        scope = ScopedGraph(store, ["backend", "frontend"])
+        s = scope.stats(topic="go")
+        assert s["coverage"]["matching_nodes"] >= 1
+
+    def test_topic_match_type(self, store):
+        scope = ScopedGraph(store, ["backend", "frontend"])
+        s = scope.stats(topic="service")
+        assert s["coverage"]["matching_nodes"] == 5
+
+    def test_ns_filter_excludes_edge(self, store):
+        scope = ScopedGraph(store, ["frontend"])
+        s = scope.stats()
+        assert s["edges"] == 0
+
+
+# ── MCP meta() tool ────────────────────────────────────────────────────────
+
+
+class TestMetaTool:
+    def test_meta_basic(self, graph_dir, tmp_path):
+        configure(graph_dir=graph_dir, allowed_ns=["backend", "frontend"])
+        result = meta()
+        assert result["nodes"] == 5
+        assert result["edges"] == 1
+        assert result["pending"] == 0
+
+    def test_meta_compile_info(self, graph_dir):
+        configure(graph_dir=graph_dir, allowed_ns=["backend"])
+        result = meta()
+        assert result["compile"]["run_id"] == "test123"
+        assert result["compile"]["compiled_at"] is not None
+        assert result["compile"]["merged_count"] == 2
+        assert result["compile"]["quarantined_count"] == 1
+
+    def test_meta_ns_filtered(self, graph_dir):
+        configure(graph_dir=graph_dir, allowed_ns=["frontend"])
+        result = meta()
+        assert result["nodes"] == 1
+        assert result["provenance"]["curator"] == 1
+
+    def test_meta_topic(self, graph_dir):
+        configure(graph_dir=graph_dir, allowed_ns=["backend", "frontend"])
+        configure(graph_dir=graph_dir, allowed_ns=["backend", "frontend"])
+        result = meta(topic="payment")
+        assert result["coverage"]["matching_nodes"] == 1
+        assert "svc:payments-api" in result["coverage"]["node_ids"]
+
+    def test_meta_no_manifest(self, tmp_path, sample_nodes, sample_edges):
+        from lorekeep.compile.writer import write_graph
+        g = tmp_path / "graph"
+        write_graph(g, sample_nodes, sample_edges, Manifest(
+            schema_version=1, chunk_count=0,
+            node_count=6, edge_count=1,
+            run_id="x", facts_hash="y",
+        ))
+        (g / "manifest.json").unlink()
+        configure(graph_dir=g, allowed_ns=["backend"])
+        result = meta()
+        assert "compile" not in result or result.get("compile", {}).get("compiled_at") is None
+
+    def test_meta_pending_count(self, graph_dir, tmp_path):
+        from lorekeep.journal import append_journal
+        from lorekeep.models import JournalEntry
+
+        pending = tmp_path / "pending"
+        configure(
+            graph_dir=graph_dir,
+            allowed_ns=["backend"],
+            pending_dir=pending,
+        )
+        append_journal(
+            pending,
+            JournalEntry(
+                fact={"kind": "node", "id": "svc:test", "type": "service",
+                      "ns": ["backend"], "props": {"name": "test"}},
+                agent="test", ns="backend", confidence=0.9,
+                proposed_at="2026-06-30T00:00:00Z",
+            ),
+            "backend",
+        )
+        result = meta()
+        assert result["pending"] == 1
+
+    def test_meta_provenance(self, graph_dir):
+        configure(graph_dir=graph_dir, allowed_ns=["backend", "frontend"])
+        result = meta()
+        assert result["provenance"]["curator"] == 4
+        assert result["provenance"]["agent"] == 1
+
+    def test_meta_empty_graph(self, tmp_path):
+        g = tmp_path / "empty"
+        g.mkdir()
+        (g / "facts.jsonl").write_text("")
+        configure(graph_dir=g, allowed_ns=["backend"])
+        result = meta()
+        assert result["nodes"] == 0
+        assert result["pending"] == 0
+
+
+# ── Manifest compiled_at ───────────────────────────────────────────────────
+
+
+class TestCompiledAt:
+    def test_compiled_at_in_manifest(self):
+        ts = now_iso()
+        m = Manifest(
+            schema_version=1, chunk_count=0,
+            node_count=0, edge_count=0,
+            run_id="x", facts_hash="y",
+            compiled_at=ts,
+        )
+        assert m.compiled_at == ts
+
+    def test_compiled_at_default_empty(self):
+        m = Manifest(
+            schema_version=1, chunk_count=0,
+            node_count=0, edge_count=0,
+            run_id="x", facts_hash="y",
+        )
+        assert m.compiled_at == ""
+
+    def test_compiled_at_roundtrip(self):
+        ts = now_iso()
+        m = Manifest(
+            schema_version=1, chunk_count=0,
+            node_count=1, edge_count=0,
+            run_id="x", facts_hash="y",
+            compiled_at=ts,
+        )
+        text = m.to_json()
+        m2 = Manifest.from_json(text)
+        assert m2.compiled_at == ts
+
+    def test_old_manifest_without_compiled_at(self):
+        """Manifests from before this feature should still load."""
+        old = json.dumps({
+            "schema_version": 1, "chunk_count": 1,
+            "node_count": 2, "edge_count": 1,
+            "run_id": "abc", "facts_hash": "def",
+        })
+        m = Manifest.from_json(old)
+        assert m.compiled_at == ""


### PR DESCRIPTION
Closes #59.

## What

Agent calls `meta()` to decide whether to query the graph or work from memory. Returns coverage, provenance, freshness, compile info, and pending count — all ns-scoped.

## API

```python
meta(topic="") -> dict
```

Returns:
```json
{
  "nodes": 42,
  "edges": 18,
  "node_types": {"service": 30, "decision": 12},
  "edge_types": {"depends_on": 15, "decided_by": 3},
  "namespaces": ["backend", "frontend", "public"],
  "provenance": {"curator": 38, "agent": 4},
  "freshness": {"oldest": "2024-01-15", "newest": "2026-06-20", "expired": 2},
  "compile": {"run_id": "abc", "compiled_at": "2026-06-30T01:27:59Z", "merged_count": 4},
  "pending": 7,
  "coverage": {"topic": "payments", "matching_nodes": 3, "node_ids": [...]}
}
```

## Changes

| File | Change |
|---|---|
| `models.py` | Add `compiled_at: str` to Manifest + `now_iso()` helper |
| `pipeline.py` | Set `compiled_at` on compile |
| `cli.py` | Set `compiled_at` on resolve + auto-resolve |
| `store/graph.py` | Add `stats()` — counts, types, provenance, freshness |
| `perm/ns.py` | Add `stats(topic)` to ScopedGraph — ns-filtered + topic coverage |
| `mcp_server.py` | Load manifest.json in `_rebuild()`, add `meta()` tool |
| `docs/guides/serve.md` | Document `meta` tool + usage patterns |
| `README.md` | 8→9 read tools |
| `AGENTS.md` | 9 read tools, `_manifest` global |

## Design decisions

- **Provenance** = `src` field. Curator facts have `src` (path:line), agent facts have empty `src`. No new field needed.
- **Topic coverage** = case-insensitive substring on node id, type, and prop values. Returns top 20 matching ids.
- **compiled_at** = new Manifest field (backward compatible — old manifests load with `compiled_at=""`).
- **Pending count** = live count of status="pending" journal entries.

## Tests

29 new tests: GraphStore.stats (8), ScopedGraph.stats (8), meta tool (8), compiled_at (5). 341 total.