### PR TITLE
fix: wire FTS5 search + model-aware cache key

### DIFF
--- a/src/lorekeep/compile/extract.py
+++ b/src/lorekeep/compile/extract.py
@@ -119,9 +119,11 @@ class ExtractionCache:
         if self.path.exists():
             self._data = json.loads(self.path.read_text(encoding="utf-8"))
 
-    def key(self, chunk: DocChunk, schema_version: int) -> str:
+    def key(self, chunk: DocChunk, schema_version: int, model: str = "") -> str:
         h = hashlib.sha256()
         h.update(str(schema_version).encode("utf-8"))
+        h.update(b"\n")
+        h.update(model.encode("utf-8"))
         h.update(b"\n")
         h.update(chunk.hash.encode("utf-8"))
         return h.hexdigest()
@@ -142,7 +144,8 @@ class ExtractionCache:
 def extract_chunk(
     chunk: DocChunk, schema: Schema, provider: LLMProvider, cache: ExtractionCache,
 ) -> tuple[list[Node], list[Edge], dict[str, list[str]]]:
-    key = cache.key(chunk, schema.version)
+    model = getattr(provider, "model", "")
+    key = cache.key(chunk, schema.version, model)
     raw = cache.get(key)
     if raw is None:
         raw = provider.extract_json(SYSTEM_PROMPT, build_prompt(chunk, schema))

--- a/src/lorekeep/mcp_server.py
+++ b/src/lorekeep/mcp_server.py
@@ -19,13 +19,15 @@ from lorekeep.models import JournalEntry, Manifest, Schema
 from lorekeep.perm.ns import ScopedGraph
 from lorekeep.schema_io import load_schema
 from lorekeep.store.graph import GraphStore, parse_date
+from lorekeep.store.fts import FTSIndex
 
 mcp = FastMCP("lorekeep")
 
-_state: dict = {}          # graph_dir, allowed_ns, schema_path, pending_dir, facts_mtime
+_state: dict = {}          # graph_dir, allowed_ns, schema_path, pending_dir, fts_path, facts_mtime
 _scope: ScopedGraph | None = None
 _schema: Schema | None = None
 _manifest: Manifest | None = None
+_fts: FTSIndex | None = None
 
 
 def configure(graph_dir, allowed_ns, schema_path=None, fts_path=None, pending_dir=None) -> None:
@@ -34,12 +36,16 @@ def configure(graph_dir, allowed_ns, schema_path=None, fts_path=None, pending_di
     _state["allowed_ns"] = list(allowed_ns)
     _state["schema_path"] = Path(schema_path) if schema_path else None
     _state["pending_dir"] = Path(pending_dir) if pending_dir else None
+    if fts_path:
+        _state["fts_path"] = Path(fts_path)
+    else:
+        _state["fts_path"] = _state["graph_dir"] / "fts.sqlite"
     _rebuild()
 
 
 def _rebuild() -> None:
-    """(Re)load the graph + schema + manifest from disk into a fresh ScopedGraph."""
-    global _scope, _schema, _manifest
+    """(Re)load the graph + schema + manifest + FTS from disk into a fresh ScopedGraph."""
+    global _scope, _schema, _manifest, _fts
     facts = _state["graph_dir"] / "facts.jsonl"
     store = GraphStore.from_jsonl(facts)
     sp = _state.get("schema_path")
@@ -50,6 +56,15 @@ def _rebuild() -> None:
         _manifest = Manifest.from_json(manifest_path.read_text(encoding="utf-8"))
     else:
         _manifest = None
+    try:
+        fts_path = _state.get("fts_path")
+        if fts_path:
+            _fts = FTSIndex(fts_path)
+            _fts.build(store.all_nodes())
+        else:
+            _fts = None
+    except Exception:
+        _fts = None
     _state["facts_mtime"] = facts.stat().st_mtime if facts.exists() else 0
 
 
@@ -125,7 +140,7 @@ def changes(from_t: str, to_t: str) -> dict:
 @mcp.tool()
 def search(query: str, limit: int = 10) -> list:
     """Text search over node ids/props, scoped to the caller."""
-    return _require().search(query, limit)
+    return _require().search(query, limit, fts=_fts)
 
 
 @mcp.tool()

--- a/tests/test_fts.py
+++ b/tests/test_fts.py
@@ -29,3 +29,81 @@ def test_fts_index_build_and_match(tmp_path: Path):
     assert idx.search("payments") == ["svc:a"]
     assert idx.search("nomatch*") == []
     idx.close()
+
+
+def test_fts_different_keys_for_different_models(tmp_path: Path):
+    """Cache key must differ when model changes."""
+    from lorekeep.models import DocChunk
+    from lorekeep.compile.extract import ExtractionCache
+
+    cache = ExtractionCache(tmp_path / "cache.json")
+    chunk = DocChunk(
+        path="raw/test.md", start_line=1, end_line=10,
+        text="hello", namespace="test",
+    )
+    key_a = cache.key(chunk, schema_version=1, model="gpt-4o-mini")
+    key_b = cache.key(chunk, schema_version=1, model="claude-sonnet-4")
+    assert key_a != key_b
+
+
+def test_fts_cache_key_backward_compat(tmp_path: Path):
+    """Old cache keys (no model) should not collide with new keys (empty model)."""
+    from lorekeep.models import DocChunk
+    from lorekeep.compile.extract import ExtractionCache
+
+    cache = ExtractionCache(tmp_path / "cache.json")
+    chunk = DocChunk(
+        path="raw/test.md", start_line=1, end_line=10,
+        text="hello", namespace="test",
+    )
+    key_default = cache.key(chunk, schema_version=1)
+    key_empty = cache.key(chunk, schema_version=1, model="")
+    assert key_default == key_empty
+
+
+def test_mcp_search_uses_fts(tmp_path: Path):
+    """mcp_server search tool uses FTSIndex when configured."""
+    from lorekeep.mcp_server import configure, search
+    from lorekeep.compile.writer import write_graph
+    from lorekeep.models import Edge, Manifest
+
+    nodes = [
+        Node(id="svc:payments", type="service", ns=("backend",), props={"name": "payments", "lang": "go"}),
+        Node(id="svc:auth", type="service", ns=("backend",), props={"name": "auth"}),
+    ]
+    graph = tmp_path / "graph"
+    write_graph(graph, nodes, [], Manifest(
+        schema_version=1, chunk_count=0, node_count=2, edge_count=0,
+        run_id="x", facts_hash="y",
+    ))
+
+    configure(graph_dir=graph, allowed_ns=["backend"])
+    results = search("payments")
+    assert "svc:payments" in results
+    assert "svc:auth" not in results
+
+    results = search("auth")
+    assert "svc:auth" in results
+
+    fts_db = graph / "fts.sqlite"
+    assert fts_db.exists()
+
+
+def test_mcp_search_fts_fallback_on_error(tmp_path: Path):
+    """If FTS fails to build, search falls back to scan."""
+    from lorekeep.mcp_server import configure, search
+    from lorekeep.compile.writer import write_graph
+    from lorekeep.models import Manifest
+
+    nodes = [
+        Node(id="svc:payments", type="service", ns=("backend",), props={"name": "payments"}),
+    ]
+    graph = tmp_path / "graph"
+    write_graph(graph, nodes, [], Manifest(
+        schema_version=1, chunk_count=0, node_count=1, edge_count=0,
+        run_id="x", facts_hash="y",
+    ))
+
+    configure(graph_dir=graph, allowed_ns=["backend"], fts_path=tmp_path / "nonexistent" / "deep" / "fts.sqlite")
+    results = search("payments")
+    assert "svc:payments" in results


### PR DESCRIPTION
Two quick wins from production readiness audit.

## FTS wiring

`store/fts.py` existed but was never used. `mcp_server.configure()` accepted `fts_path` but never stored it. Search was always scan-based.

**Fix:**
- `configure()` stores `fts_path` (defaults to `graph_dir/fts.sqlite`)
- `_rebuild()` builds FTSIndex from all nodes on every lazy-reload
- `search` tool passes `_fts` to `ScopedGraph.search`
- Falls back to `scan_search` if FTS fails (best-effort, never blocks)

## Cache key includes model

`ExtractionCache.key()` was `(schema_version, chunk_hash)`. Switching model (e.g. `gpt-4o-mini` → `claude-sonnet-4`) returned stale extractions silently.

**Fix:** Key now includes `provider.model`. Old caches with no model still work (`model=""` default = same hash).

## Tests

4 new tests:
- FTS cache key differs across models
- Backward compat: `model=""` matches old key
- MCP `search` uses FTSIndex (asserts `fts.sqlite` created)
- FTS failure falls back to scan

345 total.