### PR TITLE
fix: disable uv cache race on release jobs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,8 +51,6 @@ jobs:
           ref: ${{ github.event.inputs.tag_name || needs.release-please.outputs.tag_name }}
 
       - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
 
       - run: uv build
 


### PR DESCRIPTION
publish + sync-uv-lock chạy song song, cùng cache key → 'Unable to reserve cache' warning. Bỏ `enable-cache` trên publish (one-shot job, không cần cache).