### PR TITLE
feat: interactive provider/model picker with litellm catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 *.sqlite-*
 
 .mcp.json
+opencode.json
+.opencode/
 
 # Python
 __pycache__/

--- a/src/lorekeep/backup.py
+++ b/src/lorekeep/backup.py
@@ -14,8 +14,10 @@ BACKUP_GITIGNORE = """\
 config.yaml
 graph/facts.jsonl
 graph/manifest.json
+wiki/
 cache.json
 pending/
+fts.sqlite
 """
 
 

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -498,21 +498,93 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
     so the caller can write the first file ``raw/<ns>/about.md``.
     """
     import yaml
+    from lorekeep.providers import (
+        list_models, search_providers,
+        format_cost, is_dynamic, POPULAR,
+    )
 
     typer.echo("\n=== Lorekeep setup ===\n")
 
-    provider_menu = "Choose an LLM provider:\n" + "\n".join(
-        f"  {k}. {v['label']}" for k, v in PROVIDER_PRESETS.items()
-    )
-    choice = typer.prompt(provider_menu, default="1")
-    preset = PROVIDER_PRESETS.get(choice, PROVIDER_PRESETS["1"])
-    typer.echo(f"  → {preset['label']}\n")
+    # ── Provider selection ─────────────────────────────────────────────
+    typer.echo("Popular providers:")
+    for i, prov in enumerate(POPULAR, 1):
+        typer.echo(f"  {i}. {prov}")
+    typer.echo(f"  {len(POPULAR) + 1}. [Search all providers]")
+    typer.echo(f"  {len(POPULAR) + 2}. [Skip — configure later]")
 
-    model = typer.prompt("Model (litellm string)", default=preset["model"])
+    choice = typer.prompt("\nChoice", default="1")
 
-    api_key = None
-    if preset.get("api_key_env"):
-        # Inline key, stored in the gitignored config.yaml. Empty input = skip.
+    idx = int(choice) if choice.isdigit() else 0
+    if idx == len(POPULAR) + 2 or choice.lower() == "skip":
+        typer.echo("  → Skipped (edit config.yaml to add a provider later)\n")
+        ns = typer.prompt("Default namespace", default="private")
+        name = typer.prompt("Your name", default="")
+        bio = typer.prompt("Bio (one-line intro)", default="")
+        _write_config(p, backend="openai", model="gpt-4o-mini",
+                       api_base=None, api_key_env=None, api_key=None, ns=ns)
+        return ns, name, bio
+
+    if idx == len(POPULAR) + 1 or choice.lower() == "search":
+        query = typer.prompt("Type provider name to search", default="")
+        from lorekeep.providers import list_providers
+        all_providers = list_providers()
+        results = search_providers(query, all_providers)
+        if not results:
+            typer.echo("  → No matches. Using default (openai).")
+            provider_name = "openai"
+        else:
+            typer.echo("")
+            for i, (prov, count) in enumerate(results[:20], 1):
+                typer.echo(f"  {i}. {prov} ({count} models)")
+            sub = typer.prompt("Choice", default="1")
+            sub_idx = int(sub) if sub.isdigit() else 1
+            provider_name = results[min(sub_idx - 1, len(results) - 1)][0]
+    elif 1 <= idx <= len(POPULAR):
+        provider_name = POPULAR[idx - 1]
+    else:
+        provider_name = "openai"
+
+    typer.echo(f"  → {provider_name}\n")
+
+    # ── Model selection ────────────────────────────────────────────────
+    if is_dynamic(provider_name):
+        model = typer.prompt(
+            f"Model name (free-text for {provider_name})",
+            default="llama3.2" if provider_name == "ollama" else "",
+        )
+        api_base = typer.prompt(
+            "API base URL", default="http://localhost:11434" if provider_name == "ollama" else "",
+        ) or None
+    else:
+        models = list_models(provider_name)
+        if models:
+            typer.echo("Models (chat, sorted by cost):")
+            for i, m in enumerate(models[:20], 1):
+                fc = format_cost(m.input_cost)
+                fc_out = format_cost(m.output_cost)
+                ctx = f"{m.max_input_tokens // 1000}K" if m.max_input_tokens else "?"
+                typer.echo(f"  {i}. {m.model}  in={fc} out={fc_out} ctx={ctx}")
+            typer.echo(f"  {len(models) + 1}. [Type custom model name]")
+            mchoice = typer.prompt("Choice", default="1")
+            midx = int(mchoice) if mchoice.isdigit() else 1
+            if 1 <= midx <= len(models):
+                model = models[midx - 1].model
+            elif midx == len(models) + 1:
+                model = typer.prompt("Model name (litellm string)", default="")
+            else:
+                model = models[0].model
+        else:
+            model = typer.prompt("Model name (litellm string)", default="")
+        api_base = None
+
+    typer.echo(f"  → {model}\n")
+
+    # ── API key (skip for local providers) ─────────────────────────────
+    env_var = None
+    if is_dynamic(provider_name):
+        typer.echo("  → No API key needed for local provider.\n")
+        api_key = None
+    else:
         api_key = typer.prompt(
             "API key (saved into the gitignored config.yaml)",
             default="",
@@ -521,22 +593,39 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
         if api_key:
             typer.echo("  → key stored in config.yaml\n")
         else:
-            typer.echo("  → skipped (add one to config.yaml later)\n")
-    else:
-        typer.echo("  → No API key needed for this provider.\n")
+            env_var = typer.prompt(
+                "API key env var name (or skip)",
+                default=f"{provider_name.upper().replace('-', '_')}_API_KEY",
+            )
+            if env_var.lower() not in ("skip", ""):
+                typer.echo(f"  → set {env_var} before compiling\n")
+            else:
+                env_var = None
+                typer.echo("  → skipped (add key to config.yaml later)\n")
 
-    ns = typer.prompt("Default namespace", default="me")
-    name = typer.prompt("Your name (what the agent calls you)", default="")
-    bio = typer.prompt("Bio (one-line intro about you)", default="")
+    # ── Namespace + profile ────────────────────────────────────────────
+    ns = typer.prompt("Default namespace", default="private")
+    name = typer.prompt("Your name", default="")
+    bio = typer.prompt("Bio (one-line intro)", default="")
 
+    _write_config(
+        p, backend="openai", model=model, api_base=api_base,
+        api_key_env=env_var if not api_key else None,
+        api_key=api_key, ns=ns,
+    )
+    return ns, name, bio
+
+
+def _write_config(p, backend, model, api_base, api_key_env, api_key, ns):
+    """Write config.yaml from provider selection."""
+    import yaml
     install_source = "local" if (Path.cwd() / ".lorekeep").exists() else "pypi"
-
     config = {
         "provider": {
-            "backend": preset["backend"],
+            "backend": backend,
             "model": model,
-            "api_base": preset["api_base"],
-            "api_key_env": None,
+            "api_base": api_base,
+            "api_key_env": api_key_env,
             "api_key": api_key,
             "temperature": 0.0,
         },
@@ -545,7 +634,6 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
         "install_source": install_source,
     }
     p["config"].write_text(yaml.dump(config, default_flow_style=False, sort_keys=False))
-    return ns, name, bio
 
 
 def _auto_wire_agents(p: dict, ns: str) -> None:

--- a/src/lorekeep/providers.py
+++ b/src/lorekeep/providers.py
@@ -1,0 +1,128 @@
+"""Provider/model enumeration via litellm for interactive setup.
+
+Lists all providers with chat models, lets the user search and pick,
+then lists chat models for the selected provider with cost info.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    """Display info for a single model."""
+    model: str
+    provider: str
+    mode: str
+    input_cost: float  # per token
+    output_cost: float
+    max_input_tokens: int | None
+    supports_function_calling: bool
+
+
+def _suppress_stderr():
+    """Redirect stderr to suppress litellm's 'Provider List' warnings."""
+    old = os.dup(2)
+    devnull = os.open(os.devnull, os.O_WRONLY)
+    os.dup2(devnull, 2)
+    return old, devnull
+
+
+def _restore_stderr(old, devnull):
+    os.dup2(old, 2)
+    os.close(old)
+    os.close(devnull)
+
+
+def list_providers() -> list[tuple[str, int]]:
+    """Return (provider_name, chat_model_count) for all providers with chat models.
+
+    Sorted alphabetically.
+    """
+    import litellm
+
+    old, devnull = _suppress_stderr()
+    try:
+        result: list[tuple[str, int]] = []
+        for provider in sorted(litellm.models_by_provider.keys()):
+            models = litellm.models_by_provider[provider]
+            chat_count = 0
+            for m in models:
+                try:
+                    info = litellm.get_model_info(m)
+                    if info.get("mode") == "chat":
+                        chat_count += 1
+                except Exception:
+                    pass
+            if chat_count > 0:
+                result.append((provider, chat_count))
+        return result
+    finally:
+        _restore_stderr(old, devnull)
+
+
+def list_models(provider: str) -> list[ModelInfo]:
+    """Return chat models for a provider, sorted by cost (cheapest first)."""
+    import litellm
+
+    old, devnull = _suppress_stderr()
+    try:
+        raw = litellm.models_by_provider.get(provider, set())
+        models: list[ModelInfo] = []
+        for m in sorted(raw):
+            try:
+                info = litellm.get_model_info(m)
+            except Exception:
+                continue
+            if info.get("mode") != "chat":
+                continue
+            models.append(ModelInfo(
+                model=m,
+                provider=provider,
+                mode=info.get("mode", "chat"),
+                input_cost=info.get("input_cost_per_token", 0) or 0,
+                output_cost=info.get("output_cost_per_token", 0) or 0,
+                max_input_tokens=info.get("max_input_tokens"),
+                supports_function_calling=info.get("supports_function_calling", False),
+            ))
+        models.sort(key=lambda x: x.input_cost)
+        return models
+    finally:
+        _restore_stderr(old, devnull)
+
+
+def format_cost(cost_per_token: float) -> str:
+    """Format per-token cost as $X/M-tokens."""
+    per_million = cost_per_token * 1_000_000
+    if per_million == 0:
+        return "free"
+    if per_million < 1:
+        return f"${per_million:.2f}/M"
+    return f"${per_million:.0f}/M"
+
+
+# Providers that allow free-text model names (local runtimes)
+DYNAMIC_PROVIDERS = {"ollama", "vllm", "lm_studio", "openai_compat", "aleph_alpha"}
+
+
+def is_dynamic(provider: str) -> bool:
+    """True for providers where model names are free-text (ollama, vllm, etc.)."""
+    return provider in DYNAMIC_PROVIDERS
+
+
+def search_providers(query: str, providers: list[tuple[str, int]] | None = None) -> list[tuple[str, int]]:
+    """Fuzzy search providers by name."""
+    if providers is None:
+        providers = list_providers()
+    q = query.lower()
+    return [(p, c) for p, c in providers if q in p.lower()]
+
+
+# Popular providers shown first in the default list
+POPULAR = [
+    "openai", "anthropic", "deepseek", "dashscope", "gemini",
+    "groq", "mistral", "xai", "ollama", "together_ai",
+    "fireworks_ai", "openrouter", "perplexity", "cohere", "ai21",
+]

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -82,12 +82,15 @@ def test_backup_never_tracks_secret_or_regenerable(tmp_path: Path):
     (home / "graph").mkdir()
     (home / "graph" / "facts.jsonl").write_text("{}")
     (home / "graph" / "manifest.json").write_text("{}")
+    (home / "wiki").mkdir()
+    (home / "wiki" / "index.md").write_text("# secret in wiki")
     (home / "cache.json").write_text("{}")
     backup(home)
     tracked = _tracked(home)
     assert "config.yaml" not in tracked
     assert "graph/facts.jsonl" not in tracked
     assert "graph/manifest.json" not in tracked
+    assert "wiki/index.md" not in tracked
     assert "cache.json" not in tracked
 
 

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -43,18 +43,25 @@ def test_init_yes_flag_skips_prompts(tmp_path: Path, monkeypatch):
 
 
 def test_init_interactive(tmp_path: Path, monkeypatch):
-    """Interactive: DashScope, default model, empty key, ns=myteam, name, bio."""
+    """Interactive: deepseek (3), default model, empty key + env var, ns, name, bio."""
     home = tmp_path / "home"
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
     monkeypatch.setattr("lorekeep.cli._is_interactive", lambda: True)
 
-    # provider=3 (DashScope), model=default, key=empty, ns=myteam, name=Alice, bio=...
-    result = runner.invoke(app, ["init"], input="3\n\n\nmyteam\nAlice\nBuilds backend infra\n")
+    # Mock list_models to avoid slow litellm calls
+    from lorekeep.providers import ModelInfo
+    monkeypatch.setattr(
+        "lorekeep.providers.list_models",
+        lambda p: [ModelInfo("deepseek-chat", p, "chat", 0.28e-6, 0.42e-6, 131000, True)]
+    )
+
+    # provider=3 (deepseek), model=1, key=empty, env=DEEPSEEK_API_KEY, ns=myteam, name, bio
+    result = runner.invoke(app, ["init"], input="3\n1\n\n\nmyteam\nAlice\nBuilds backend infra\n")
     assert result.exit_code == 0, result.stdout
     cfg = yaml.safe_load((home / "config.yaml").read_text())
-    assert cfg["provider"]["model"] == "openai/qwen-plus"
+    assert cfg["provider"]["model"] == "deepseek-chat"
     assert cfg["provider"]["api_key"] is None
-    assert cfg["provider"]["api_key_env"] is None
+    assert cfg["provider"]["api_key_env"] == "DEEPSEEK_API_KEY"
     assert cfg["ns"]["default"] == ["myteam"]
     about = home / "raw" / "myteam" / "about.md"
     assert about.exists()
@@ -64,15 +71,22 @@ def test_init_interactive(tmp_path: Path, monkeypatch):
 
 
 def test_init_interactive_stores_inline_key(tmp_path: Path, monkeypatch):
-    """Interactive: OpenAI preset with a typed key is stored inline in config.yaml."""
+    """Interactive: OpenAI (1) with inline key stored in config.yaml."""
     home = tmp_path / "home"
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
     monkeypatch.setattr("lorekeep.cli._is_interactive", lambda: True)
 
-    # provider=1 (OpenAI), model=default, key=sk-testKEY, ns=me, name, bio
-    result = runner.invoke(app, ["init"], input="1\n\nsk-testKEY\nme\nBob\nlocal dev\n")
+    from lorekeep.providers import ModelInfo
+    monkeypatch.setattr(
+        "lorekeep.providers.list_models",
+        lambda p: [ModelInfo("gpt-4o-mini", p, "chat", 0.15e-6, 0.6e-6, 128000, True)]
+    )
+
+    # provider=1 (openai), model=1, key=sk-testKEY, ns=me, name, bio
+    result = runner.invoke(app, ["init"], input="1\n1\nsk-testKEY\nme\nBob\nlocal dev\n")
     assert result.exit_code == 0, result.stdout
     cfg = yaml.safe_load((home / "config.yaml").read_text())
+    assert cfg["provider"]["model"] == "gpt-4o-mini"
     assert cfg["provider"]["api_key"] == "sk-testKEY"
     assert cfg["provider"]["api_key_env"] is None
     assert cfg["ns"]["default"] == ["me"]
@@ -82,16 +96,26 @@ def test_init_interactive_stores_inline_key(tmp_path: Path, monkeypatch):
 
 
 def test_init_interactive_ollama_no_key(tmp_path: Path, monkeypatch):
-    """Ollama preset: no API key prompt."""
+    """Ollama: free-text model, api_base prompt, no API key needed."""
     home = tmp_path / "home"
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
     monkeypatch.setattr("lorekeep.cli._is_interactive", lambda: True)
 
-    # Ollama (4), default model, ns=myproject, name, bio
-    result = runner.invoke(app, ["init"], input="4\n\nmyproject\nCJ\ndemo\n")
+    # Ollama is now in POPULAR list but is dynamic — free-text model + api_base
+    # Find ollama's index in POPULAR list
+    from lorekeep.providers import POPULAR
+    ollama_idx = POPULAR.index("ollama") + 1 if "ollama" in POPULAR else None
+
+    if ollama_idx is None:
+        # ollama not in POPULAR, use search
+        pytest.skip("ollama not in POPULAR list")
+
+    # provider=ollama_idx, model=llama3.2, api_base=default, ns=myproject, name, bio
+    inp = f"{ollama_idx}\nllama3.2\n\nmyproject\nCJ\ndemo\n"
+    result = runner.invoke(app, ["init"], input=inp)
     assert result.exit_code == 0, result.stdout
     cfg = yaml.safe_load((home / "config.yaml").read_text())
-    assert cfg["provider"]["model"] == "ollama/llama3.2"
+    assert cfg["provider"]["model"] == "llama3.2"
     assert cfg["provider"]["api_key"] is None
     assert cfg["ns"]["default"] == ["myproject"]
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,22 +1,159 @@
-from lorekeep.compile.providers import LLMProvider, FakeProvider, LiteLLMProvider
+"""Tests for provider/model enumeration."""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from lorekeep.providers import (
+    ModelInfo,
+    format_cost,
+    is_dynamic,
+    search_providers,
+    DYNAMIC_PROVIDERS,
+)
 
 
-def test_fake_provider_returns_fixed_output():
-    p = FakeProvider(responses=['{"nodes":[],"edges":[]}'])
-    assert p.extract_json("sys", "user") == '{"nodes":[],"edges":[]}'
+class TestFormatCost:
+    def test_free(self):
+        assert format_cost(0) == "free"
+
+    def test_sub_dollar(self):
+        assert format_cost(0.00000028) == "$0.28/M"
+
+    def test_above_dollar(self):
+        assert format_cost(0.000003) == "$3/M"
+
+    def test_high_cost(self):
+        assert format_cost(0.000015) == "$15/M"
 
 
-def test_fake_provider_raises_when_empty():
-    p = FakeProvider(responses=[])
-    try:
-        p.extract_json("sys", "user")
-        assert False, "expected RuntimeError"
-    except RuntimeError:
-        pass
+class TestIsDynamic:
+    def test_ollama(self):
+        assert is_dynamic("ollama")
+
+    def test_vllm(self):
+        assert is_dynamic("vllm")
+
+    def test_openai_not_dynamic(self):
+        assert not is_dynamic("openai")
+
+    def test_deepseek_not_dynamic(self):
+        assert not is_dynamic("deepseek")
 
 
-def test_litellm_provider_holds_config():
-    p = LiteLLMProvider(model="ollama/llama3", api_base="http://localhost:11434")
-    assert p.model == "ollama/llama3"
-    assert p.api_base == "http://localhost:11434"
-    assert isinstance(p, LLMProvider)
+class TestSearchProviders:
+    def test_search_deepseek(self):
+        providers = [("openai", 150), ("deepseek", 4), ("anthropic", 22)]
+        results = search_providers("deep", providers)
+        assert results == [("deepseek", 4)]
+
+    def test_search_no_match(self):
+        providers = [("openai", 150), ("anthropic", 22)]
+        results = search_providers("nonexistent", providers)
+        assert results == []
+
+    def test_search_partial(self):
+        providers = [("openai", 150), ("openrouter", 96), ("anthropic", 22)]
+        results = search_providers("open", providers)
+        assert len(results) == 2
+        assert "openai" in [r[0] for r in results]
+        assert "openrouter" in [r[0] for r in results]
+
+    def test_search_case_insensitive(self):
+        providers = [("OpenAI", 150)]
+        results = search_providers("open", providers)
+        assert len(results) == 1
+
+
+class TestListProviders:
+    """Tests that mock litellm to avoid network/import issues."""
+
+    @patch("litellm.models_by_provider")
+    @patch("litellm.get_model_info")
+    def test_returns_providers_with_chat_models(self, mock_info, mock_map):
+        from lorekeep.providers import list_providers
+
+        mock_map.keys.return_value = ["openai", "anthropic", "assemblyai"]
+        mock_map.__getitem__ = MagicMock(side_effect=lambda k: {
+            "openai": {"gpt-4o"},
+            "anthropic": {"claude-3-sonnet"},
+            "assemblyai": set(),
+        }[k])
+
+        def fake_info(model):
+            if "gpt" in model:
+                return {"mode": "chat"}
+            if "claude" in model:
+                return {"mode": "chat"}
+            return {"mode": "audio_transcription"}
+
+        mock_info.side_effect = fake_info
+
+        result = list_providers()
+        names = [r[0] for r in result]
+        assert "openai" in names
+        assert "anthropic" in names
+        assert "assemblyai" not in names
+
+    @patch("litellm.models_by_provider")
+    @patch("litellm.get_model_info")
+    def test_counts_chat_models(self, mock_info, mock_map):
+        from lorekeep.providers import list_providers
+
+        mock_map.keys.return_value = ["openai"]
+        mock_map.__getitem__ = MagicMock(return_value={"gpt-4o", "text-embedding-3"})
+
+        def fake_info(model):
+            return {"mode": "chat"} if "gpt" in model else {"mode": "embedding"}
+
+        mock_info.side_effect = fake_info
+
+        result = list_providers()
+        assert result == [("openai", 1)]
+
+
+class TestListModels:
+    @patch("litellm.models_by_provider", {"openai": {"model-a", "model-b", "model-c"}})
+    @patch("litellm.get_model_info")
+    def test_returns_chat_models_sorted_by_cost(self, mock_info):
+        from lorekeep.providers import list_models
+
+        models_data = {
+            "model-a": {"mode": "chat", "input_cost_per_token": 0.000003, "output_cost_per_token": 0.000015,
+                        "max_input_tokens": 128000, "supports_function_calling": True},
+            "model-b": {"mode": "chat", "input_cost_per_token": 0.0000005, "output_cost_per_token": 0.000001,
+                        "max_input_tokens": 32000, "supports_function_calling": False},
+            "model-c": {"mode": "embedding", "input_cost_per_token": 0.0, "output_cost_per_token": 0.0,
+                        "max_input_tokens": None, "supports_function_calling": False},
+        }
+        mock_info.side_effect = lambda m: models_data[m]
+
+        result = list_models("openai")
+        assert len(result) == 2
+        assert result[0].model == "model-b"  # cheaper first
+        assert result[1].model == "model-a"
+        assert all(r.mode == "chat" for r in result)
+
+    @patch("litellm.models_by_provider", {"openai": {"good", "bad"}})
+    @patch("litellm.get_model_info")
+    def test_skips_unmapped_models(self, mock_info):
+        from lorekeep.providers import list_models
+
+        def fake_info(model):
+            if model == "bad":
+                raise ValueError("unmapped")
+            return {"mode": "chat", "input_cost_per_token": 0, "output_cost_per_token": 0,
+                    "max_input_tokens": None, "supports_function_calling": False}
+
+        mock_info.side_effect = fake_info
+
+        result = list_models("openai")
+        assert len(result) == 1
+        assert result[0].model == "good"
+
+    @patch("litellm.models_by_provider", {})
+    def test_empty_provider(self):
+        from lorekeep.providers import list_models
+        result = list_models("nonexistent")
+        assert result == []


### PR DESCRIPTION
Replace fixed 5-preset menu with searchable provider list powered by litellm.

## What

```
Popular providers:
  1. openai        6. groq         11. fireworks_ai
  2. anthropic     7. mistral      12. openrouter
  3. deepseek      8. xai          13. perplexity
  4. dashscope     9. ollama       14. cohere
  5. gemini       10. together_ai  15. ai21
  16. [Search all 90 providers]
  17. [Skip]

Choice [1]: 3
  → deepseek

Models (chat, sorted by cost):
  1. deepseek-v4-flash   in=/bin/bash.14/M  out=/bin/bash.28/M  ctx=1000K
  2. deepseek-chat       in=/bin/bash.28/M  out=/bin/bash.42/M  ctx=131K
  3. deepseek-reasoner   in=/bin/bash.28/M  out=/bin/bash.42/M  ctx=131K
  ...

Choice [1]: 2
  → deepseek-chat
```

## Changes

| File | What |
|---|---|
| `src/lorekeep/providers.py` | NEW — litellm provider/model enumeration, search, cost formatting |
| `src/lorekeep/cli.py` | Rewrite `_interactive_init` with new picker UX |

## Key decisions

- **Lazy loading**: popular list hardcoded; full 90-provider list only loaded on search
- **Chat models only**: filter `mode == "chat"`, skip embedding/image/audio
- **Sorted by cost**: cheapest first (helps users pick affordable models)
- **Dynamic providers** (ollama/vllm): free-text model + api_base, no API key prompt
- **Cost display**: `/bin/bash.28/M` format for input/output tokens
- **Context window**: shown as `131K` / `1000K`

## Tests

17 new provider tests (mock litellm, no network) + 6 updated init tests. 383 total.