### PR TITLE
feat: cross-agent session watch + init→graph + daemon hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,9 @@ Pure JSONL → markdown transform (no LLM). `generate_wiki(graph_dir, wiki_dir)`
 ### Path resolution (`paths.py`)
 Pure (no I/O), 4-tier precedence high→low: explicit `LOREKEEP_RAW/OUT/CACHE/SCHEMA/CONFIG/WIKI` env → `LOREKEEP_HOME` → **dev mode** (`.lorekeep/` present in CWD, or `LOREKEEP_DEV=1`; auto-detected in a source checkout) — all data lives under `cwd/.lorekeep/` (`config.yaml`, `schema.json`, `raw/`, `graph/`, `wiki/`, `pending/`, `cache.json`), mirroring the `LOREKEEP_HOME` layout → XDG (`platformdirs`). Running `uv run lorekeep …` from the repo uses the repo's own `.lorekeep/` data home with zero migration.
 
+### Daemon (`cli.py` watch command)
+Polls every 60s. `_discover_watchable_sessions()` finds Claude `memory/` + Codex `memories/` dirs (called every cycle — detects new sessions after daemon start). `_quick_import_session()` dispatches per-agent quick import (zero LLM cost — copies `.md` files to `raw/<agent>-memory/`). Cursor/opencode have no quick-import path — handled by session-end hooks (`lorekeep hook`). raw/ watch tracks both file count AND mtime — detects new files even if mtime is same (fast filesystem). pending/ watch triggers `_do_auto_resolve()` → merge journals → wiki regen. Init calls `_auto_import_and_compile()` which runs compile + wiki regen + auto-resolve — graph + wiki produced immediately if API key available.
+
 ### Provider pluggability (`compile/providers.py`)
 `LiteLLMProvider` (OpenAI / Anthropic / DashScope/Qwen / Ollama via litellm model strings) and `FakeProvider` (tests/offline). Model is set in `config.yaml` as a litellm string.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ uv run lorekeep <command>                    # run the CLI in dev mode
 | `wiki` | Regenerate `wiki/` from `facts.jsonl` (Obsidian-compatible markdown) |
 | `serve [--transport stdio\|http]` | Run the MCP server (9 read + 5 write tools) |
 | `mcp add --agent claude\|cursor\|codex\|opencode --ns NS` | Write agent MCP config |
+| `config show` | Print config.yaml |
+| `config set <key> <value>` | Set nested config value (dot notation) |
 | `import --from claude\|cursor\|codex\|opencode` | Import agent sessions into `raw/` |
 | `doctor` | Verify install: graph loads, schema valid, a tool responds |
 | `backup [--init <remote-url>]` | Commit + push `.lorekeep/` to your private backup git repo |
@@ -71,7 +73,7 @@ Pure (no I/O), 4-tier precedence high→low: explicit `LOREKEEP_RAW/OUT/CACHE/SC
 Polls every 60s. `_discover_watchable_sessions()` finds Claude `memory/` + Codex `memories/` dirs (called every cycle — detects new sessions after daemon start). `_quick_import_session()` dispatches per-agent quick import (zero LLM cost — copies `.md` files to `raw/<agent>-memory/`). Cursor/opencode have no quick-import path — handled by session-end hooks (`lorekeep hook`). raw/ watch tracks both file count AND mtime — detects new files even if mtime is same (fast filesystem). pending/ watch triggers `_do_auto_resolve()` → merge journals → wiki regen. Init calls `_auto_import_and_compile()` which runs compile + wiki regen + auto-resolve — graph + wiki produced immediately if API key available.
 
 ### Provider pluggability (`compile/providers.py`)
-`LiteLLMProvider` (OpenAI / Anthropic / DashScope/Qwen / Ollama via litellm model strings) and `FakeProvider` (tests/offline). Model is set in `config.yaml` as a litellm string.
+`LiteLLMProvider` (OpenAI / Anthropic / DashScope/Qwen / DeepSeek / Ollama via litellm model strings) and `FakeProvider` (tests/offline). Model is set in `config.yaml` as a litellm string. `setup_observability()` configures litellm success/failure callbacks for Langfuse or Langsmith when `observability.provider` is set in config. Prefix cache optimized: schema in system prompt (constant across chunks), user message = chunk text only.
 
 ## Configuration & keys
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The full journey from install to continuous use — see the
 | 6. Serve | `lorekeep serve` | MCP server (9 read + 5 write tools, lazy-reload) |
 | 7. Keep current | `lorekeep agent watch &` | Daemon: auto-compile, auto-resolve, delta-import sessions |
 | 8. Back up | `lorekeep backup` | Push data home to private git repo (raw/ + schema.json) |
+| 9. Persist daemon | `lorekeep agent daemon install` | Survive restart (systemd/launchd/startup) |
 
 Steps 1–6 are one-time setup. Step 7 runs in the background for continuous
 updates. Step 8 syncs across machines.

--- a/README.md
+++ b/README.md
@@ -244,6 +244,21 @@ The north star is *systematic thinking with complete information* — memory-rec
 benchmarks (LoCoMo, LongMemEval) are parity checks, not the optimization target.
 See [`docs/architecture/evaluation.md`](docs/architecture/evaluation.md).
 
+## Configuration
+
+After `init`, adjust settings without editing YAML:
+
+```bash
+lorekeep config show                                    # print current config
+lorekeep config set provider.model deepseek/deepseek-chat
+lorekeep config set provider.api_key_env DEEPSEEK_API_KEY
+lorekeep config set ns.default backend,frontend
+lorekeep config set observability.provider langfuse     # optional tracing
+```
+
+Observability (optional): set `observability.provider` to `langfuse` or
+`langsmith` for LLM call tracing via litellm callbacks.
+
 ## Project layout
 
 ```
@@ -251,13 +266,14 @@ src/lorekeep/
   models.py            shared contract (Node/Edge/Schema/Manifest)
   facts_io.py          facts.jsonl loader (store + eval)
   paths.py             4-tier path resolution (env/home/dev/XDG)
+  providers.py         litellm provider/model enumeration for init
   defaults.py          default schema + config (for `init`)
   config.py, schema_io.py
   compile/{ingest,extract,resolve,writer}.py    the compile pipeline
-  compile/providers.py                          LiteLLMProvider (OpenAI/Anthropic/Ollama)
+  compile/providers.py                          LiteLLMProvider + observability
   journal.py           append-only journal writer + loader
   agent.py             autonomous agent: ingest, lint, suggest, status, watch
-  store/{graph,fts}.py                          GraphStore + optional FTS cache
+  store/{graph,fts}.py                          GraphStore + FTS5 cache
   perm/ns.py                                    ScopedGraph permission chokepoint
   mcp_server.py                                 FastMCP + 9 read + 5 write tools
   wiki.py                                        Obsidian-compatible wiki generator
@@ -266,7 +282,7 @@ src/lorekeep/
   pipeline.py, cli.py
   eval/{gold,construction,retrieval}.py
   eval/locomo.py                                Tier-2 LoCoMo eval
-tests/                 ~310 tests
+tests/                 ~410 tests
 docs/                  README.md index, architecture/, guides/
 ```
 

--- a/docs/architecture/agent.md
+++ b/docs/architecture/agent.md
@@ -1,6 +1,6 @@
 # Autonomous agent
 
-> **Status: partially implemented.** The daemon (`lorekeep agent watch`), `agent ingest`, `agent lint`, `agent suggest`, and `agent status` are shipped. The daemon auto-compiles on `raw/` change, auto-resolves pending journals, and delta-imports Claude session memory. Scheduled nightly lint / weekly suggest, schema evolve (`agent evolve`), and `--auto-fix` are planned. MCP write tools (runtime fact proposals) are tracked in [#15](https://github.com/manhhailua/lorekeep/issues/15).
+> **Status: partially implemented.** The daemon (`lorekeep agent watch`), `agent ingest`, `agent lint`, `agent suggest`, and `agent status` are shipped. The daemon auto-compiles on `raw/` change (file count + mtime tracking), auto-resolves pending journals, and delta-imports **Claude + Codex** session memory. Session re-discovery happens every polling cycle (detects new sessions after daemon start). Cursor/opencode are handled by session-end hooks (`lorekeep hook`). Scheduled nightly lint / weekly suggest, schema evolve (`agent evolve`), and `--auto-fix` are planned.
 
 The autonomous agent (`lorekeep agent`) is the engine that keeps the knowledge graph continuously up-to-date. It watches for changes, triggers compiles and resolves, runs health checks, and suggests improvements — all without manual curator intervention for routine operations.
 
@@ -29,16 +29,15 @@ Runs continuously, polling or watching the filesystem. Handles all routine maint
 
 ```
 lorekeep agent watch
-  ├── Watch raw/ for new or changed .md files
-  │   └── On change → hash check → auto-compile → resolve
-  ├── Watch agent session dirs for new sessions
-  │   └── On new session → auto-import (quick mode)
-  ├── Periodic lint (nightly, configurable)
-  │   └── Generate report + auto-fix high-confidence issues
-  ├── Periodic resolve (every 5 min if pending)
-  │   └── Merge pending journals into facts.jsonl
-  └── Periodic suggest (weekly)
-      └── Analyze graph structure → report gaps, orphans, stale
+  ├── Watch raw/ for new or changed .md files (count + mtime)
+  │   └── On change → hash check → auto-compile → resolve → wiki
+  ├── Watch pending/ for new journal entries
+  │   └── On change → auto-resolve → wiki regen
+  ├── Watch Claude memory/ + Codex memories/ (re-discover every cycle)
+  │   └── On change → delta quick import → raw/ (zero LLM cost)
+  │       → triggers raw/ watch → auto-compile
+  │   Cursor/opencode: no quick-import path → session-end hooks
+  └── (planned) Periodic lint, suggest, schema evolve
 ```
 
 ### Compile trigger

--- a/docs/guides/serve.md
+++ b/docs/guides/serve.md
@@ -122,9 +122,11 @@ Three approaches, from fully automatic to manual:
 ```bash
 # 1. Daemon (recommended) — fully autonomous
 uvx lorekeep agent watch
-# Watches raw/ → auto-compile on change
+# Watches raw/ → auto-compile on change (file count + mtime tracking)
 # Watches pending/ → auto-resolve
-# Watches Claude session memory/ → delta quick-import into raw/
+# Watches Claude memory/ + Codex memories/ → delta quick-import (zero LLM)
+# Session re-discovery every cycle — detects new sessions after daemon start
+# Cursor/opencode: no quick-import → session-end hooks (`lorekeep hook`)
 # Use --no-watch-sessions to disable session watching
 
 # 2. Manual with cron — scheduled (Linux/macOS cron)

--- a/docs/guides/serve.md
+++ b/docs/guides/serve.md
@@ -117,26 +117,24 @@ entries, polling every 60s).
 
 ## Keeping the graph current
 
-Three approaches, from fully automatic to manual:
+Two modes, from fully automatic to agent-controlled:
 
 ```bash
-# 1. Daemon (recommended) — fully autonomous
+# Mode 1: Daemon (default) — fully autonomous, follows Karpathy LLM Wiki pattern
 uvx lorekeep agent watch
-# Watches raw/ → auto-compile on change (file count + mtime tracking)
+# Watches raw/ → auto-compile (file count + mtime tracking)
 # Watches pending/ → auto-resolve
 # Watches Claude memory/ + Codex memories/ → delta quick-import (zero LLM)
 # Session re-discovery every cycle — detects new sessions after daemon start
-# Cursor/opencode: no quick-import → session-end hooks (`lorekeep hook`)
+# Survives restart: lorekeep agent daemon install (systemd/launchd/startup)
 # Use --no-watch-sessions to disable session watching
 
-# 2. Manual with cron — scheduled (Linux/macOS cron)
-# */5 * * * * cd /path/to/lorekeep && uvx lorekeep resolve
-# 0 3 * * *   cd /path/to/lorekeep && uvx lorekeep agent lint
-
-# 3. Manual — curator-triggered
-uvx lorekeep compile          # rebuild from raw/
-uvx lorekeep resolve          # merge pending journals into facts.jsonl
-uvx lorekeep agent lint       # health check
+# Mode 2: Agent-controlled (--no-watch on init) — no daemon
+# The coding agent triggers updates via shell commands:
+#   lorekeep compile   # does compile + resolve + wiki (all-in-one, uses LLM)
+#   lorekeep resolve   # merge agent-proposed facts only (zero LLM cost)
+#   lorekeep wiki      # regenerate wiki from existing graph
+# MCP server lazy-reloads facts.jsonl on next query — no daemon needed
 ```
 
 ## Connect once (lazy-reload)

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -27,6 +27,17 @@ def _main() -> None:
 
 def _build_provider(config: Config) -> LiteLLMProvider:
     """Create a real LLM provider from config.  Shared by compile + import."""
+    from lorekeep.compile.providers import setup_observability
+
+    obs = config.observability
+    if obs.provider:
+        setup_observability(
+            provider=obs.provider,
+            api_key_env=obs.api_key_env,
+            project=obs.project,
+            api_url=obs.api_url,
+        )
+
     api_key = None
     if config.provider.api_key_env:
         api_key = os.environ.get(config.provider.api_key_env)
@@ -333,6 +344,59 @@ def serve(
 
 mcp_app = typer.Typer(help="Coding-agent integration.")
 app.add_typer(mcp_app, name="mcp")
+
+config_app = typer.Typer(help="View and edit lorekeep config.")
+app.add_typer(config_app, name="config")
+
+
+@config_app.command("show")
+def config_show() -> None:
+    """Print the current config.yaml."""
+    p = resolve_paths()
+    if not p["config"].exists():
+        typer.echo("No config.yaml found — run `lorekeep init` first.")
+        raise typer.Exit(code=1)
+    typer.echo(p["config"].read_text(encoding="utf-8"))
+
+
+@config_app.command("set")
+def config_set(
+    key: str = typer.Argument(..., help="Dot-notation key (e.g. provider.model)"),
+    value: str = typer.Argument(..., help="Value to set"),
+) -> None:
+    """Set a config value (e.g. `config set provider.model deepseek/deepseek-chat`)."""
+    import yaml
+    p = resolve_paths()
+    if not p["config"].exists():
+        typer.echo("No config.yaml found — run `lorekeep init` first.")
+        raise typer.Exit(code=1)
+
+    data = yaml.safe_load(p["config"].read_text(encoding="utf-8")) or {}
+
+    keys = key.split(".")
+    target = data
+    for k in keys[:-1]:
+        target = target.setdefault(k, {})
+
+    final_key = keys[-1]
+    if isinstance(target.get(final_key), list):
+        target[final_key] = [v.strip() for v in value.split(",")]
+    elif isinstance(target.get(final_key), bool):
+        target[final_key] = value.lower() in ("true", "1", "yes")
+    elif isinstance(target.get(final_key), int):
+        target[final_key] = int(value)
+    elif isinstance(target.get(final_key), float):
+        target[final_key] = float(value)
+    elif value.lower() in ("null", "none", ""):
+        target[final_key] = None
+    else:
+        target[final_key] = value
+
+    p["config"].write_text(
+        yaml.dump(data, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+    typer.echo(f"  {key} = {value}")
 
 
 @mcp_app.command("add")

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -1067,8 +1067,46 @@ def import_cmd(
 
 # --- Agent subcommand group -----------------------------------------------
 
-agent_app = typer.Typer(help="Autonomous agent operations: ingest, lint, suggest, status, watch.")
+agent_app = typer.Typer(help="Autonomous agent operations: ingest, lint, suggest, status, watch, daemon.")
 app.add_typer(agent_app, name="agent")
+
+daemon_app = typer.Typer(help="Install/uninstall daemon as persistent OS service.")
+agent_app.add_typer(daemon_app, name="daemon")
+
+
+@daemon_app.command("install")
+def daemon_install() -> None:
+    """Install daemon as a persistent OS service (survives restart).
+
+    Linux: systemd user service. macOS: launchd LaunchAgent. Windows: Startup folder.
+    """
+    from lorekeep.daemon_service import install as svc_install
+    p = resolve_paths()
+    try:
+        platform_name, config_path = svc_install(p["home"])
+        typer.echo(f"daemon: installed as {platform_name} service → {config_path}")
+        typer.echo(f"daemon: will auto-start on login/restart")
+    except RuntimeError as exc:
+        typer.echo(f"daemon: {exc}")
+        raise typer.Exit(code=1)
+
+
+@daemon_app.command("uninstall")
+def daemon_uninstall() -> None:
+    """Remove the persistent daemon service."""
+    from lorekeep.daemon_service import uninstall as svc_uninstall
+    removed = svc_uninstall()
+    if removed:
+        typer.echo("daemon: service removed")
+    else:
+        typer.echo("daemon: no service found")
+
+
+@daemon_app.command("status")
+def daemon_status() -> None:
+    """Check if the persistent daemon service is installed and running."""
+    from lorekeep.daemon_service import status as svc_status
+    typer.echo(svc_status())
 
 
 @agent_app.command()

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -109,7 +109,7 @@ def hook() -> None:
 
 @app.command()
 def compile() -> None:
-    """Compile raw/ into graph/facts.jsonl."""
+    """Compile raw/ → facts.jsonl + merge pending + generate wiki (all-in-one)."""
     p = resolve_paths()
     schema = load_schema(p["schema"])
     config = load_config(p["config"])
@@ -571,6 +571,13 @@ def init(
         _start_daemon(p)
     elif watch and not _is_interactive():
         typer.echo("\n  (skipped daemon start in non-interactive mode — run `lorekeep agent watch` manually)")
+    else:
+        typer.echo(
+            "\n  Daemon disabled (--no-watch). Agent-controlled mode:\n"
+            "  - Run `lorekeep compile` after editing raw/*.md (does compile + resolve + wiki)\n"
+            "  - Run `lorekeep resolve` to merge agent-proposed facts (zero LLM cost)\n"
+            "  - MCP server lazy-reloads on next query — no daemon needed"
+        )
 
     if config_existed:
         typer.echo("\nAlready initialized.")

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -756,8 +756,11 @@ def _auto_import_and_compile(p: dict) -> None:
             chunk_lines=config.compile.chunk_lines,
         )
         pending_dir = p.get("pending")
+        resolved = False
         if pending_dir and pending_dir.exists():
-            _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
+            resolved = _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
+        if not resolved:
+            _auto_generate_wiki(p["out"], p["wiki"])
         typer.echo(f"  compiled: {manifest.node_count} nodes, {manifest.edge_count} edges")
     except Exception as exc:
         typer.echo(f"  compile skipped: {exc}")
@@ -1265,6 +1268,47 @@ def status() -> None:
     typer.echo(f"pending journals: {dash.pending_journals}")
 
 
+def _discover_watchable_sessions() -> list[tuple[str, Path, Path]]:
+    """Find agent session memory dirs that support quick import.
+
+    Returns [(agent_name, session_dir, memory_dir), ...].
+    Only Claude + Codex have memory dirs for zero-LLM quick import.
+    Cursor/opencode are deep-only — handled by session-end hooks.
+    """
+    sessions: list[tuple[str, Path, Path]] = []
+
+    try:
+        from lorekeep.importer.claude import find_current_session as find_claude
+        sd = find_claude()
+        if sd and (sd / "memory").is_dir() and any((sd / "memory").glob("*.md")):
+            sessions.append(("claude", sd, sd / "memory"))
+    except Exception:
+        pass
+
+    try:
+        from lorekeep.importer.codex import _codex_home
+        mem_dir = _codex_home() / "memories"
+        if mem_dir.is_dir() and any(mem_dir.glob("*.md")):
+            sessions.append(("codex", mem_dir.parent, mem_dir))
+    except Exception:
+        pass
+
+    return sessions
+
+
+def _quick_import_session(agent: str, session_dir: Path, memory_dir: Path, raw_dir: Path) -> int:
+    """Quick-import memory files for one agent. Returns file count."""
+    if agent == "claude":
+        from lorekeep.importer.claude import import_memories
+        written = import_memories(session_dir, raw_dir, "claude-memory")
+        return len(written)
+    if agent == "codex":
+        from lorekeep.importer.codex import import_memories
+        written = import_memories(raw_dir, "codex-memory")
+        return len(written)
+    return 0
+
+
 @agent_app.command()
 def watch(
     interval: int = typer.Option(
@@ -1278,9 +1322,10 @@ def watch(
 ) -> None:
     """Run the autonomous agent daemon: watch raw/, pending/, and agent sessions.
 
-    Watches raw/ for new/changed markdown sources → auto-compile.
+    Watches raw/ for new/changed markdown → auto-compile.
     Watches pending/ for new journal entries → auto-resolve.
-    Watches agent session dirs (Claude memory/) → delta quick import → raw/.
+    Watches Claude + Codex memory dirs → delta quick import → raw/.
+    Cursor/opencode are handled by session-end hooks (`lorekeep hook`).
     """
     import time
     p = resolve_paths()
@@ -1289,37 +1334,57 @@ def watch(
 
     typer.echo(f"agent watch: monitoring raw={raw_dir}, pending={pending_dir}, interval={interval}s")
     typer.echo("agent: auto-compile (raw/) and auto-resolve (pending/) enabled")
-
-    # Attempt session discovery once at startup
-    session_dir = None
-    session_memory_dir = None
     if watch_sessions:
-        try:
-            from lorekeep.importer.claude import find_current_session
-            sd = find_current_session()
-            if sd is not None and (sd / "memory").is_dir():
-                session_dir = sd
-                session_memory_dir = sd / "memory"
-                typer.echo(f"agent: watching session memory={session_memory_dir}")
-        except Exception:
-            pass
-
+        typer.echo("agent: session watch enabled (Claude + Codex memory dirs)")
     typer.echo("agent: MCP server lazy-reloads facts.jsonl — no reconnect needed")
+
+    pid_file = p["home"] / ".daemon.pid"
+    if pid_file.exists():
+        try:
+            old_pid = int(pid_file.read_text().strip())
+            import os as _os
+            _os.kill(old_pid, 0)
+            typer.echo(f"agent: daemon already running (PID {old_pid}), exiting")
+            raise typer.Exit(code=1)
+        except (ProcessLookupError, ValueError, PermissionError):
+            pass
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    pid_file.write_text(str(os.getpid()))
+
     last_raw_mtime = 0.0
+    last_raw_count = -1
     last_pending_mtime = 0.0
-    last_session_mtime = 0.0
-    last_session_import = 0.0          # debounce timer (seconds since epoch)
-    has_raw = raw_dir.exists()
-    has_pending = pending_dir and pending_dir.exists()
+    session_state: dict[str, float] = {}
+    session_import_time: dict[str, float] = {}
+
+    # One-time resolve of pending journals present at startup
+    if pending_dir and pending_dir.exists():
+        from lorekeep.journal import load_journals
+        journals = load_journals(pending_dir)
+        if any(j.status == "pending" for j in journals):
+            typer.echo("agent: resolving pending journals at startup...")
+            _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
 
     while True:
         try:
+            # Re-check existence each cycle (raw/ or pending/ may be created after start)
+            has_raw = raw_dir.exists()
+            has_pending = pending_dir and pending_dir.exists()
             # --- raw/ watch → auto-compile ----------------------------------
             raw_files = sorted(raw_dir.rglob("*.md")) if has_raw else []
             raw_mtime = max((f.stat().st_mtime for f in raw_files), default=0.0)
+            raw_count = len(raw_files)
             compiled = False
-            if raw_mtime > last_raw_mtime and last_raw_mtime > 0:
-                typer.echo(f"agent: raw/ changed ({len(raw_files)} files) — compiling...")
+
+            should_compile = False
+            if last_raw_count >= 0:
+                if raw_count != last_raw_count:
+                    should_compile = True
+                elif raw_mtime > last_raw_mtime:
+                    should_compile = True
+
+            if should_compile:
+                typer.echo(f"agent: raw/ changed ({raw_count} files) — compiling...")
                 try:
                     schema = load_schema(p["schema"])
                     config = load_config(p["config"])
@@ -1334,11 +1399,8 @@ def watch(
                 except Exception as exc:
                     typer.echo(f"agent: compile error: {exc}")
             last_raw_mtime = raw_mtime
+            last_raw_count = raw_count
 
-            # --- After compile, re-merge pending journals -------------------
-            # compile is a destructive overwrite that regenerates facts.jsonl
-            # from raw/ only.  Re-merge pending journal entries so facts
-            # approved via agent ingest / MCP write tools are not lost.
             if compiled and has_pending:
                 _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
 
@@ -1352,23 +1414,28 @@ def watch(
                 last_pending_mtime = pending_mtime
 
             # --- session watch → delta quick import → raw/ ------------------
-            if session_memory_dir and session_memory_dir.is_dir():
-                mem_files = sorted(session_memory_dir.glob("*.md"))
-                session_mtime = max((f.stat().st_mtime for f in mem_files), default=0.0)
+            # Re-discover every cycle (cheap — just directory scans).
+            # Detects new sessions opened after daemon start.
+            if watch_sessions:
                 now = time.monotonic()
-                # Debounce: max once per 30 seconds
-                if (session_mtime > last_session_mtime and last_session_mtime > 0
-                        and now - last_session_import >= 30):
-                    typer.echo(f"agent: session memory changed ({len(mem_files)} files) — importing...")
-                    try:
-                        from lorekeep.importer.claude import import_memories
-                        written = import_memories(session_dir, raw_dir, "claude-memory")
-                        if written:
-                            typer.echo(f"agent: session import done — {len(written)} files -> raw/claude-memory/")
-                            last_session_import = now
-                    except Exception as exc:
-                        typer.echo(f"agent: session import error: {exc}")
-                last_session_mtime = session_mtime
+                sessions = _discover_watchable_sessions()
+                for agent_name, session_dir, memory_dir in sessions:
+                    mem_files = sorted(memory_dir.glob("*.md"))
+                    mem_mtime = max((f.stat().st_mtime for f in mem_files), default=0.0)
+                    prev = session_state.get(agent_name, 0.0)
+                    last_import = session_import_time.get(agent_name, 0.0)
+
+                    if (mem_mtime > prev and prev > 0
+                            and now - last_import >= 30):
+                        typer.echo(f"agent: {agent_name} memory changed ({len(mem_files)} files) — importing...")
+                        try:
+                            count = _quick_import_session(agent_name, session_dir, memory_dir, raw_dir)
+                            if count:
+                                typer.echo(f"agent: {agent_name} import done — {count} files → raw/{agent_name}-memory/")
+                                session_import_time[agent_name] = now
+                        except Exception as exc:
+                            typer.echo(f"agent: {agent_name} import error: {exc}")
+                    session_state[agent_name] = mem_mtime
 
             time.sleep(interval)
         except KeyboardInterrupt:
@@ -1377,6 +1444,8 @@ def watch(
         except Exception as exc:
             typer.echo(f"agent: error: {exc}")
             time.sleep(interval)
+
+    pid_file.unlink(missing_ok=True)
 
 
 def _do_auto_resolve(out_dir: Path, pending_dir: Path, wiki_dir: Path | None = None) -> bool:

--- a/src/lorekeep/compile/extract.py
+++ b/src/lorekeep/compile/extract.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from lorekeep.models import DocChunk, Edge, Node, Schema
 
-SYSTEM_PROMPT = (
+SYSTEM_PROMPT_BASE = (
     "You are a knowledge-graph extractor. Read the document chunk and emit a JSON "
     'object {"nodes":[...], "edges":[...], "aliases":{...}}. '
     "Only use node_types and edge_types listed in the provided schema. "
@@ -19,18 +19,35 @@ SYSTEM_PROMPT = (
 )
 
 
-def build_prompt(chunk: DocChunk, schema: Schema) -> str:
+def build_system_prompt(schema: Schema) -> str:
+    """Build a constant system prompt including schema — cacheable across chunks.
+
+    Keeping schema in the system prompt (not user message) maximizes prefix
+    cache hits: the system message is identical for every chunk in a compile run.
+    """
     node_types = ", ".join(schema.node_types.keys())
     edge_types = ", ".join(
         f"{k}({v.from_}->{v.to})" for k, v in schema.edge_types.items()
     )
     return (
+        f"{SYSTEM_PROMPT_BASE}\n\n"
         f"Allowed node_types: {node_types}\n"
-        f"Allowed edge_types: {edge_types}\n\n"
-        f"Source: {chunk.src}\n"
-        f"Namespace: {chunk.namespace}\n\n"
-        f"Document chunk:\n{chunk.text}\n"
+        f"Allowed edge_types: {edge_types}"
     )
+
+
+# Backward compat
+SYSTEM_PROMPT = SYSTEM_PROMPT_BASE
+
+
+def build_prompt(chunk: DocChunk, schema: Schema) -> str:
+    """Build user message — just the chunk text (no schema/src/ns).
+
+    Schema is in the system prompt (see build_system_prompt). src and ns
+    are extracted from chunk by parse_response for provenance, not needed
+    in the LLM prompt.
+    """
+    return chunk.text
 
 
 def _parse_date(v: Any) -> date | None:
@@ -148,6 +165,7 @@ def extract_chunk(
     key = cache.key(chunk, schema.version, model)
     raw = cache.get(key)
     if raw is None:
-        raw = provider.extract_json(SYSTEM_PROMPT, build_prompt(chunk, schema))
+        system = build_system_prompt(schema)
+        raw = provider.extract_json(system, chunk.text)
         cache.set(key, raw)
     return parse_response(raw, chunk, schema)

--- a/src/lorekeep/compile/providers.py
+++ b/src/lorekeep/compile/providers.py
@@ -52,6 +52,38 @@ class LiteLLMProvider:
         self.temperature = temperature
         self.api_key = api_key
 
+
+def setup_observability(
+    provider: str | None = None,
+    api_key_env: str | None = None,
+    project: str | None = None,
+    api_url: str | None = None,
+) -> None:
+    """Configure litellm callbacks for observability (langfuse/langsmith).
+
+    Called from cli._build_provider when observability config is set.
+    """
+    if not provider:
+        return
+
+    import os
+    import litellm
+
+    callbacks: list[str] = []
+
+    if provider == "langfuse":
+        callbacks.append("langfuse")
+        if api_url:
+            os.environ.setdefault("LANGFUSE_HOST", api_url)
+    elif provider == "langsmith":
+        callbacks.append("langsmith")
+        if project:
+            os.environ.setdefault("LANGCHAIN_PROJECT", project)
+
+    if callbacks:
+        litellm.success_callback = callbacks
+        litellm.failure_callback = callbacks
+
     def extract_json(self, system: str, user: str) -> str:
         import litellm  # imported lazily so tests need not install it
         resp = litellm.completion(

--- a/src/lorekeep/config.py
+++ b/src/lorekeep/config.py
@@ -25,10 +25,19 @@ class NsConfig(BaseModel):
     token_map: dict[str, list[str]] = Field(default_factory=dict)
 
 
+class ObservabilityConfig(BaseModel):
+    """Optional observability integration via litellm callbacks."""
+    provider: str | None = None      # langfuse | langsmith
+    api_key_env: str | None = None   # env var name (e.g. LANGFUSE_PUBLIC_KEY)
+    project: str | None = None       # project name / dataset name
+    api_url: str | None = None       # self-hosted endpoint (langfuse)
+
+
 class Config(BaseModel):
     provider: ProviderConfig = Field(default_factory=ProviderConfig)
     compile: CompileConfig = Field(default_factory=CompileConfig)
     ns: NsConfig = Field(default_factory=NsConfig)
+    observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
     install_source: str | None = None      # pypi | local | git+URL | path
 
 

--- a/src/lorekeep/daemon_service.py
+++ b/src/lorekeep/daemon_service.py
@@ -1,0 +1,249 @@
+"""OS service integration: install lorekeep daemon as a persistent service.
+
+Supports:
+  - Linux: systemd user service
+  - macOS: launchd LaunchAgent
+  - Windows: Startup folder VBS script
+
+Generated configs use the lorekeep data home path + the resolved
+lorekeep command (uvx or direct binary).
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _find_lorekeep_command() -> tuple[str, list[str]]:
+    """Find the lorekeep executable.
+
+    Returns (command, prefix_args). For uvx: ('uvx', ['lorekeep']).
+    For direct install: ('lorekeep', []).
+    """
+    lorekeep_path = shutil.which("lorekeep")
+    if lorekeep_path:
+        return (lorekeep_path, [])
+
+    uvx_path = shutil.which("uvx")
+    if uvx_path:
+        return (uvx_path, ["lorekeep"])
+
+    return ("lorekeep", [])
+
+
+def _service_label() -> str:
+    return "com.lorekeep.daemon"
+
+
+# ── systemd (Linux) ────────────────────────────────────────────────────────
+
+
+def _systemd_unit_path() -> Path:
+    return Path.home() / ".config" / "systemd" / "user" / "lorekeep.service"
+
+
+def _systemd_unit(home: Path) -> str:
+    cmd, args = _find_lorekeep_command()
+    exec_parts = " ".join([cmd] + args + ["agent", "watch"])
+    return f"""\
+[Unit]
+Description=Lorekeep Knowledge Graph Daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={exec_parts}
+Restart=on-failure
+RestartSec=10
+Environment=LOREKEEP_HOME={home}
+
+[Install]
+WantedBy=default.target
+"""
+
+
+def install_systemd(home: Path) -> Path:
+    """Install systemd user service. Returns the unit file path."""
+    unit_path = _systemd_unit_path()
+    unit_path.parent.mkdir(parents=True, exist_ok=True)
+    unit_path.write_text(_systemd_unit(home), encoding="utf-8")
+    subprocess.run(["systemctl", "--user", "daemon-reload"], check=False)
+    subprocess.run(["systemctl", "--user", "enable", "lorekeep"], check=False)
+    subprocess.run(["systemctl", "--user", "start", "lorekeep"], check=False)
+    return unit_path
+
+
+def uninstall_systemd() -> bool:
+    """Remove systemd user service. Returns True if removed."""
+    unit_path = _systemd_unit_path()
+    if not unit_path.exists():
+        return False
+    subprocess.run(["systemctl", "--user", "stop", "lorekeep"], check=False)
+    subprocess.run(["systemctl", "--user", "disable", "lorekeep"], check=False)
+    unit_path.unlink()
+    subprocess.run(["systemctl", "--user", "daemon-reload"], check=False)
+    return True
+
+
+def status_systemd() -> str:
+    """Return systemd service status string."""
+    r = subprocess.run(
+        ["systemctl", "--user", "is-active", "lorekeep"],
+        capture_output=True, text=True,
+    )
+    return r.stdout.strip() or r.stderr.strip()
+
+
+# ── launchd (macOS) ────────────────────────────────────────────────────────
+
+
+def _launchd_plist_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{_service_label()}.plist"
+
+
+def _launchd_plist(home: Path) -> str:
+    cmd, args = _find_lorekeep_command()
+    all_args = args + ["agent", "watch"]
+    args_xml = "\n".join(f"        <string>{a}</string>" for a in all_args)
+    return f"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{_service_label()}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{cmd}</string>
+{args_xml}
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>LOREKEEP_HOME</key>
+        <string>{home}</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{home}/daemon.log</string>
+    <key>StandardErrorPath</key>
+    <string>{home}/daemon.err.log</string>
+</dict>
+</plist>
+"""
+
+
+def install_launchd(home: Path) -> Path:
+    """Install launchd LaunchAgent. Returns the plist path."""
+    plist_path = _launchd_plist_path()
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    plist_path.write_text(_launchd_plist(home), encoding="utf-8")
+    subprocess.run(["launchctl", "load", str(plist_path)], check=False)
+    return plist_path
+
+
+def uninstall_launchd() -> bool:
+    """Remove launchd LaunchAgent. Returns True if removed."""
+    plist_path = _launchd_plist_path()
+    if not plist_path.exists():
+        return False
+    subprocess.run(["launchctl", "unload", str(plist_path)], check=False)
+    plist_path.unlink()
+    return True
+
+
+def status_launchd() -> str:
+    """Return launchd service status."""
+    r = subprocess.run(
+        ["launchctl", "list", _service_label()],
+        capture_output=True, text=True,
+    )
+    if r.returncode == 0:
+        return "running"
+    return "not loaded"
+
+
+# ── Startup folder (Windows) ───────────────────────────────────────────────
+
+
+def _windows_startup_path() -> Path:
+    appdata = os.environ.get("APPDATA", str(Path.home() / "AppData" / "Roaming"))
+    return Path(appdata) / "Microsoft" / "Windows" / "Start Menu" / "Programs" / "Startup"
+
+
+def _windows_script(home: Path) -> str:
+    cmd, args = _find_lorekeep_command()
+    full_cmd = " ".join([cmd] + args + ["agent", "watch"])
+    return f'''\
+Set WshShell = CreateObject("WScript.Shell")
+WshShell.Run "cmd /c set LOREKEEP_HOME={home} && {full_cmd}", 0, False
+Set WshShell = Nothing
+'''
+
+
+def install_windows(home: Path) -> Path:
+    """Install Windows startup script. Returns the script path."""
+    startup = _windows_startup_path()
+    startup.mkdir(parents=True, exist_ok=True)
+    script_path = startup / "lorekeep-daemon.vbs"
+    script_path.write_text(_windows_script(home), encoding="utf-8")
+    return script_path
+
+
+def uninstall_windows() -> bool:
+    """Remove Windows startup script. Returns True if removed."""
+    script_path = _windows_startup_path() / "lorekeep-daemon.vbs"
+    if not script_path.exists():
+        return False
+    script_path.unlink()
+    return True
+
+
+def status_windows() -> str:
+    """Return Windows startup script status."""
+    script_path = _windows_startup_path() / "lorekeep-daemon.vbs"
+    return "installed" if script_path.exists() else "not installed"
+
+
+# ── Platform dispatch ──────────────────────────────────────────────────────
+
+
+def install(home: Path) -> tuple[str, Path]:
+    """Install daemon service for the current platform.
+
+    Returns (platform_name, config_path).
+    """
+    if sys.platform == "linux":
+        return ("systemd", install_systemd(home))
+    if sys.platform == "darwin":
+        return ("launchd", install_launchd(home))
+    if sys.platform == "win32":
+        return ("startup", install_windows(home))
+    raise RuntimeError(f"Unsupported platform: {sys.platform}")
+
+
+def uninstall() -> bool:
+    """Uninstall daemon service for the current platform."""
+    if sys.platform == "linux":
+        return uninstall_systemd()
+    if sys.platform == "darwin":
+        return uninstall_launchd()
+    if sys.platform == "win32":
+        return uninstall_windows()
+    return False
+
+
+def status() -> str:
+    """Return daemon service status for the current platform."""
+    if sys.platform == "linux":
+        return f"systemd: {status_systemd()}"
+    if sys.platform == "darwin":
+        return f"launchd: {status_launchd()}"
+    if sys.platform == "win32":
+        return f"startup: {status_windows()}"
+    return f"unsupported: {sys.platform}"

--- a/tests/test_daemon_multi_agent.py
+++ b/tests/test_daemon_multi_agent.py
@@ -1,0 +1,265 @@
+"""Tests for daemon multi-agent session watch + file count tracking."""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from lorekeep.cli import _discover_watchable_sessions, _quick_import_session
+
+runner = CliRunner()
+
+
+class TestDiscoverSessions:
+    """Test multi-agent session discovery."""
+
+    def test_returns_empty_when_no_agents(self, monkeypatch):
+        monkeypatch.setattr(
+            "lorekeep.importer.claude.find_current_session", lambda: None
+        )
+        monkeypatch.setattr(
+            "lorekeep.importer.codex._codex_home", lambda: Path("/nonexistent")
+        )
+        result = _discover_watchable_sessions()
+        assert result == []
+
+    def test_finds_claude_session(self, tmp_path, monkeypatch):
+        session_dir = tmp_path / "claude-session"
+        (session_dir / "memory").mkdir(parents=True)
+        (session_dir / "memory" / "note.md").write_text("# Note")
+
+        monkeypatch.setattr(
+            "lorekeep.importer.claude.find_current_session", lambda: session_dir
+        )
+        monkeypatch.setattr(
+            "lorekeep.importer.codex._codex_home", lambda: Path("/nonexistent")
+        )
+        result = _discover_watchable_sessions()
+        assert len(result) == 1
+        assert result[0][0] == "claude"
+        assert result[0][2] == session_dir / "memory"
+
+    def test_finds_codex_session(self, tmp_path, monkeypatch):
+        codex_home = tmp_path / "codex"
+        (codex_home / "memories").mkdir(parents=True)
+        (codex_home / "memories" / "note.md").write_text("# Note")
+
+        monkeypatch.setattr(
+            "lorekeep.importer.claude.find_current_session", lambda: None
+        )
+        monkeypatch.setattr(
+            "lorekeep.importer.codex._codex_home", lambda: codex_home
+        )
+        result = _discover_watchable_sessions()
+        assert len(result) == 1
+        assert result[0][0] == "codex"
+
+    def test_finds_both_agents(self, tmp_path, monkeypatch):
+        claude_dir = tmp_path / "claude"
+        (claude_dir / "memory").mkdir(parents=True)
+        (claude_dir / "memory" / "note.md").write_text("# Claude")
+
+        codex_home = tmp_path / "codex"
+        (codex_home / "memories").mkdir(parents=True)
+        (codex_home / "memories" / "note.md").write_text("# Codex")
+
+        monkeypatch.setattr(
+            "lorekeep.importer.claude.find_current_session", lambda: claude_dir
+        )
+        monkeypatch.setattr(
+            "lorekeep.importer.codex._codex_home", lambda: codex_home
+        )
+        result = _discover_watchable_sessions()
+        agents = [r[0] for r in result]
+        assert "claude" in agents
+        assert "codex" in agents
+
+    def test_skips_empty_memory_dirs(self, tmp_path, monkeypatch):
+        session_dir = tmp_path / "claude"
+        (session_dir / "memory").mkdir(parents=True)
+        # No .md files in memory/
+
+        monkeypatch.setattr(
+            "lorekeep.importer.claude.find_current_session", lambda: session_dir
+        )
+        monkeypatch.setattr(
+            "lorekeep.importer.codex._codex_home", lambda: Path("/nonexistent")
+        )
+        result = _discover_watchable_sessions()
+        assert result == []
+
+    def test_re_discovers_on_each_call(self, tmp_path, monkeypatch):
+        """Session discovery should find new sessions on subsequent calls."""
+        call_count = [0]
+        sessions = [None, tmp_path / "claude"]
+
+        def mock_find():
+            idx = min(call_count[0], len(sessions) - 1)
+            result = sessions[idx]
+            call_count[0] += 1
+            return result
+
+        monkeypatch.setattr(
+            "lorekeep.importer.claude.find_current_session", mock_find
+        )
+        monkeypatch.setattr(
+            "lorekeep.importer.codex._codex_home", lambda: Path("/nonexistent")
+        )
+
+        first = _discover_watchable_sessions()
+        assert first == []
+
+        (tmp_path / "claude" / "memory").mkdir(parents=True)
+        (tmp_path / "claude" / "memory" / "note.md").write_text("# New")
+        second = _discover_watchable_sessions()
+        assert len(second) == 1
+        assert second[0][0] == "claude"
+
+
+class TestQuickImportSession:
+    def test_claude_import(self, tmp_path):
+        from lorekeep.cli import _quick_import_session
+
+        session_dir = tmp_path / "session"
+        mem_dir = session_dir / "memory"
+        mem_dir.mkdir(parents=True)
+        (mem_dir / "note.md").write_text("# Claude Note")
+
+        raw_dir = tmp_path / "raw"
+        raw_dir.mkdir()
+
+        count = _quick_import_session("claude", session_dir, mem_dir, raw_dir)
+        assert count == 1
+        assert (raw_dir / "claude-memory" / "note.md").exists()
+
+    def test_codex_import(self, tmp_path):
+        from lorekeep.cli import _quick_import_session
+
+        mem_dir = tmp_path / "memories"
+        mem_dir.mkdir(parents=True)
+        (mem_dir / "codex-note.md").write_text("# Codex Note")
+
+        raw_dir = tmp_path / "raw"
+        raw_dir.mkdir()
+
+        codex_home = tmp_path / "codex"
+        codex_home.mkdir()
+
+        with patch("lorekeep.importer.codex._codex_home", return_value=codex_home):
+            # Move memories under codex_home for the import to find
+            (codex_home / "memories").mkdir()
+            (codex_home / "memories" / "codex-note.md").write_text("# Codex Note")
+            count = _quick_import_session("codex", codex_home, codex_home / "memories", raw_dir)
+        assert count == 1
+        assert (raw_dir / "codex-memory" / "codex-note.md").exists()
+
+    def test_unknown_agent_returns_zero(self, tmp_path):
+        count = _quick_import_session("unknown", tmp_path, tmp_path, tmp_path)
+        assert count == 0
+
+
+class TestRawFileCountTracking:
+    """Test that new files in raw/ trigger compile (not just mtime)."""
+
+    def test_new_file_detected_on_second_cycle(self, tmp_path, monkeypatch):
+        """Simulate the daemon logic: add a file → detect change via count."""
+        raw_dir = tmp_path / "raw"
+        raw_dir.mkdir()
+        (raw_dir / "a.md").write_text("# A")
+
+        # Simulate first cycle: snapshot state
+        files = sorted(raw_dir.rglob("*.md"))
+        last_count = len(files)
+        last_mtime = max(f.stat().st_mtime for f in files)
+        assert last_count == 1
+
+        # Add new file (same mtime tick possible on fast FS)
+        time.sleep(0.01)
+        (raw_dir / "b.md").write_text("# B")
+
+        # Second cycle: detect change
+        files = sorted(raw_dir.rglob("*.md"))
+        new_count = len(files)
+        new_mtime = max(f.stat().st_mtime for f in files)
+
+        should_compile = False
+        if last_count >= 0:
+            if new_count != last_count:
+                should_compile = True
+            elif new_mtime > last_mtime:
+                should_compile = True
+
+        assert should_compile is True
+
+    def test_no_change_no_compile(self, tmp_path):
+        raw_dir = tmp_path / "raw"
+        raw_dir.mkdir()
+        (raw_dir / "a.md").write_text("# A")
+
+        files = sorted(raw_dir.rglob("*.md"))
+        last_count = len(files)
+        last_mtime = max(f.stat().st_mtime for f in files)
+
+        # No changes
+        files2 = sorted(raw_dir.rglob("*.md"))
+        new_count = len(files2)
+        new_mtime = max(f.stat().st_mtime for f in files2)
+
+        should_compile = new_count != last_count or new_mtime > last_mtime
+        assert should_compile is False
+
+    def test_file_modified_detected(self, tmp_path):
+        raw_dir = tmp_path / "raw"
+        raw_dir.mkdir()
+        (raw_dir / "a.md").write_text("# A")
+
+        files = sorted(raw_dir.rglob("*.md"))
+        last_count = len(files)
+        last_mtime = max(f.stat().st_mtime for f in files)
+
+        # Modify file (same count, different mtime)
+        time.sleep(0.01)
+        (raw_dir / "a.md").write_text("# A updated")
+
+        files2 = sorted(raw_dir.rglob("*.md"))
+        new_count = len(files2)
+        new_mtime = max(f.stat().st_mtime for f in files2)
+
+        should_compile = new_count != last_count or new_mtime > last_mtime
+        assert should_compile is True
+
+
+class TestInitProducesGraph:
+    """Test that init produces a graph when API key is provided."""
+
+    def test_init_compiles_about_md(self, tmp_path, monkeypatch, patch_make_provider):
+        """Init with API key should compile about.md → facts.jsonl + wiki."""
+        from lorekeep.cli import app
+        from lorekeep.providers import ModelInfo
+
+        home = tmp_path / "home"
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        monkeypatch.setattr("lorekeep.cli._is_interactive", lambda: True)
+        monkeypatch.setattr(
+            "lorekeep.providers.list_models",
+            lambda p: [ModelInfo("gpt-4o-mini", p, "chat", 0.15e-6, 0.6e-6, 128000, True)]
+        )
+        monkeypatch.setattr("lorekeep.cli._start_daemon", lambda p: None)
+
+        # provider=1 (openai), model=1, key=sk-test, ns=myteam, name=Alice, bio=builder
+        result = runner.invoke(app, ["init"], input="1\n1\nsk-testKEY\nmyteam\nAlice\nBuilds backend\n")
+        assert result.exit_code == 0, result.stdout
+
+        facts = home / "graph" / "facts.jsonl"
+        assert facts.exists(), "facts.jsonl should exist after init compile"
+
+        wiki = home / "wiki" / "index.md"
+        assert wiki.exists(), "wiki/index.md should exist after init compile"
+
+        about = home / "raw" / "myteam" / "about.md"
+        assert about.exists()
+        assert "Alice" in about.read_text()

--- a/tests/test_daemon_service.py
+++ b/tests/test_daemon_service.py
@@ -1,0 +1,173 @@
+"""Tests for daemon service installation (systemd, launchd, Windows startup)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from lorekeep.daemon_service import (
+    _find_lorekeep_command,
+    _service_label,
+    _systemd_unit,
+    _launchd_plist,
+    _windows_script,
+    _systemd_unit_path,
+    _launchd_plist_path,
+    _windows_startup_path,
+    install,
+    uninstall,
+    status,
+)
+
+
+class TestFindCommand:
+    def test_finds_direct_binary(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/local/bin/lorekeep" if cmd == "lorekeep" else None)
+        cmd, args = _find_lorekeep_command()
+        assert cmd == "/usr/local/bin/lorekeep"
+        assert args == []
+
+    def test_falls_back_to_uvx(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda cmd: "/home/user/.local/bin/uvx" if cmd == "uvx" else None)
+        cmd, args = _find_lorekeep_command()
+        assert cmd == "/home/user/.local/bin/uvx"
+        assert args == ["lorekeep"]
+
+    def test_falls_back_to_bare_name(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda cmd: None)
+        cmd, args = _find_lorekeep_command()
+        assert cmd == "lorekeep"
+        assert args == []
+
+
+class TestSystemdUnit:
+    def test_unit_contains_execstart(self, tmp_path):
+        with patch("lorekeep.daemon_service._find_lorekeep_command",
+                   return_value=("/usr/local/bin/lorekeep", [])):
+            unit = _systemd_unit(tmp_path)
+        assert "ExecStart=/usr/local/bin/lorekeep agent watch" in unit
+        assert "Restart=on-failure" in unit
+        assert f"LOREKEEP_HOME={tmp_path}" in unit
+
+    def test_unit_with_uvx(self, tmp_path):
+        with patch("lorekeep.daemon_service._find_lorekeep_command",
+                   return_value=("/home/user/.local/bin/uvx", ["lorekeep"])):
+            unit = _systemd_unit(tmp_path)
+        assert "ExecStart=/home/user/.local/bin/uvx lorekeep agent watch" in unit
+
+    def test_unit_path_in_config(self):
+        path = _systemd_unit_path()
+        assert ".config/systemd/user" in str(path)
+        assert path.name == "lorekeep.service"
+
+    def test_install_writes_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
+        with patch("lorekeep.daemon_service._find_lorekeep_command",
+                   return_value=("/usr/local/bin/lorekeep", [])):
+            from lorekeep.daemon_service import install_systemd
+            unit_path = install_systemd(tmp_path / "data")
+        assert unit_path.exists()
+        content = unit_path.read_text()
+        assert "lorekeep agent watch" in content
+
+
+class TestLaunchdPlist:
+    def test_plist_contains_label(self, tmp_path):
+        plist = _launchd_plist(tmp_path)
+        assert "com.lorekeep.daemon" in plist
+        assert "RunAtLoad" in plist
+        assert "KeepAlive" in plist
+
+    def test_plist_contains_command(self, tmp_path):
+        with patch("lorekeep.daemon_service._find_lorekeep_command",
+                   return_value=("/usr/local/bin/lorekeep", [])):
+            plist = _launchd_plist(tmp_path)
+        assert "/usr/local/bin/lorekeep" in plist
+        assert "agent" in plist
+        assert "watch" in plist
+
+    def test_plist_contains_env(self, tmp_path):
+        plist = _launchd_plist(tmp_path)
+        assert f"LOREKEEP_HOME" in plist
+        assert str(tmp_path) in plist
+
+    def test_plist_path_in_library(self):
+        path = _launchd_plist_path()
+        assert "Library/LaunchAgents" in str(path)
+        assert path.name == "com.lorekeep.daemon.plist"
+
+    def test_install_writes_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
+        with patch("lorekeep.daemon_service._find_lorekeep_command",
+                   return_value=("/usr/local/bin/lorekeep", [])):
+            from lorekeep.daemon_service import install_launchd
+            plist_path = install_launchd(tmp_path / "data")
+        assert plist_path.exists()
+
+
+class TestWindowsScript:
+    def test_script_contains_command(self, tmp_path):
+        with patch("lorekeep.daemon_service._find_lorekeep_command",
+                   return_value=("C:\\lorekeep\\lorekeep.exe", [])):
+            script = _windows_script(tmp_path)
+        assert "lorekeep.exe" in script
+        assert "agent" in script
+        assert "watch" in script
+
+    def test_script_sets_env(self, tmp_path):
+        script = _windows_script(tmp_path)
+        assert "LOREKEEP_HOME" in script
+
+    def test_install_writes_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("APPDATA", str(tmp_path / "AppData" / "Roaming"))
+        with patch("lorekeep.daemon_service._find_lorekeep_command",
+                   return_value=("lorekeep", [])):
+            from lorekeep.daemon_service import install_windows
+            script_path = install_windows(tmp_path / "data")
+        assert script_path.exists()
+        assert script_path.suffix == ".vbs"
+
+
+class TestPlatformDispatch:
+    def test_install_dispatches_correctly(self, monkeypatch, tmp_path):
+        for platform, func_name in [("linux", "install_systemd"),
+                                     ("darwin", "install_launchd"),
+                                     ("win32", "install_windows")]:
+            monkeypatch.setattr(sys, "platform", platform)
+            with patch(f"lorekeep.daemon_service.{func_name}",
+                       return_value=Path("/fake/path")) as mock_fn:
+                name, path = install(tmp_path / "data")
+                assert mock_fn.called
+
+    def test_uninstall_dispatches_correctly(self, monkeypatch):
+        for platform, func_name in [("linux", "uninstall_systemd"),
+                                     ("darwin", "uninstall_launchd"),
+                                     ("win32", "uninstall_windows")]:
+            monkeypatch.setattr(sys, "platform", platform)
+            with patch(f"lorekeep.daemon_service.{func_name}", return_value=True) as mock_fn:
+                result = uninstall()
+                assert mock_fn.called
+                assert result is True
+
+    def test_status_dispatches(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch("lorekeep.daemon_service.status_systemd", return_value="active"):
+            s = status()
+            assert "systemd" in s
+
+    def test_unsupported_platform(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "freebsd")
+        with pytest.raises(RuntimeError, match="Unsupported"):
+            install(Path("/tmp"))
+
+
+class TestUninstall:
+    def test_uninstall_returns_false_when_not_installed(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = uninstall()
+        assert result is False

--- a/tests/test_enhancements.py
+++ b/tests/test_enhancements.py
@@ -1,0 +1,199 @@
+"""Tests for enhancements: prefix cache prompt, observability config, config CLI."""
+from __future__ import annotations
+
+import yaml
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+# ── Prefix cache: system prompt structure ─────────────────────────────────
+
+class TestSystemPromptStructure:
+    def test_system_prompt_includes_schema(self):
+        from lorekeep.compile.extract import build_system_prompt
+        from lorekeep.models import Schema
+
+        schema = Schema.load({
+            "version": 1,
+            "node_types": {"service": {"props": {"name": "string"}}},
+            "edge_types": {"depends_on": {"from": "service", "to": "service"}},
+        })
+        prompt = build_system_prompt(schema)
+        assert "service" in prompt
+        assert "depends_on" in prompt
+        assert "knowledge-graph extractor" in prompt
+
+    def test_user_prompt_is_chunk_text_only(self):
+        from lorekeep.compile.extract import build_prompt
+        from lorekeep.models import DocChunk
+
+        chunk = DocChunk(
+            path="raw/test.md", start_line=1, end_line=5,
+            text="The payments-api is a Go service.", namespace="backend",
+        )
+        prompt = build_prompt(chunk, None)
+        assert prompt == "The payments-api is a Go service."
+
+    def test_system_prompt_constant_across_chunks(self):
+        """System prompt should be identical for different chunks (same schema)."""
+        from lorekeep.compile.extract import build_system_prompt
+        from lorekeep.models import DocChunk, Schema
+
+        schema = Schema.load({"version": 1, "node_types": {"x": {}}, "edge_types": {}})
+        c1 = DocChunk(path="a.md", start_line=1, end_line=1, text="chunk1", namespace="ns")
+        c2 = DocChunk(path="b.md", start_line=1, end_line=1, text="chunk2", namespace="ns")
+
+        sys1 = build_system_prompt(schema)
+        sys2 = build_system_prompt(schema)
+        assert sys1 == sys2
+
+
+# ── Observability config ──────────────────────────────────────────────────
+
+class TestObservabilityConfig:
+    def test_default_no_observability(self):
+        from lorekeep.config import Config
+        c = Config()
+        assert c.observability.provider is None
+
+    def test_langfuse_config(self):
+        from lorekeep.config import Config
+        data = {
+            "provider": {"model": "gpt-4o"},
+            "observability": {
+                "provider": "langfuse",
+                "api_key_env": "LANGFUSE_PUBLIC_KEY",
+                "api_url": "https://langfuse.example.com",
+            },
+        }
+        c = Config.model_validate(data)
+        assert c.observability.provider == "langfuse"
+        assert c.observability.api_key_env == "LANGFUSE_PUBLIC_KEY"
+
+    def test_langsmith_config(self):
+        from lorekeep.config import Config
+        data = {
+            "provider": {"model": "gpt-4o"},
+            "observability": {
+                "provider": "langsmith",
+                "project": "lorekeep-prod",
+            },
+        }
+        c = Config.model_validate(data)
+        assert c.observability.provider == "langsmith"
+        assert c.observability.project == "lorekeep-prod"
+
+    def test_setup_observability_noop_when_no_provider(self):
+        from lorekeep.compile.providers import setup_observability
+        setup_observability(provider=None)
+        # Should not raise
+
+    def test_setup_observability_langfuse(self, monkeypatch):
+        import litellm
+        from lorekeep.compile.providers import setup_observability
+
+        monkeypatch.delenv("LANGFUSE_HOST", raising=False)
+        setup_observability(
+            provider="langfuse",
+            api_url="https://lf.example.com",
+        )
+        import os
+        assert os.environ.get("LANGFUSE_HOST") == "https://lf.example.com"
+        assert "langfuse" in litellm.success_callback
+
+    def test_setup_observability_langsmith(self, monkeypatch):
+        import litellm
+        from lorekeep.compile.providers import setup_observability
+
+        monkeypatch.delenv("LANGCHAIN_PROJECT", raising=False)
+        setup_observability(
+            provider="langsmith",
+            project="test-project",
+        )
+        import os
+        assert os.environ.get("LANGCHAIN_PROJECT") == "test-project"
+        assert "langsmith" in litellm.success_callback
+
+
+# ── Config CLI ────────────────────────────────────────────────────────────
+
+class TestConfigCLI:
+    def test_config_show(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        config = home / "config.yaml"
+        config.write_text("provider:\n  model: gpt-4o\n")
+
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        from lorekeep.cli import app
+        result = runner.invoke(app, ["config", "show"])
+        assert result.exit_code == 0
+        assert "gpt-4o" in result.stdout
+
+    def test_config_set_string(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        config = home / "config.yaml"
+        config.write_text("provider:\n  model: gpt-4o\n")
+
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        from lorekeep.cli import app
+        result = runner.invoke(app, ["config", "set", "provider.model", "deepseek/deepseek-chat"])
+        assert result.exit_code == 0
+
+        data = yaml.safe_load(config.read_text())
+        assert data["provider"]["model"] == "deepseek/deepseek-chat"
+
+    def test_config_set_nested_new_key(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        config = home / "config.yaml"
+        config.write_text("provider:\n  model: gpt-4o\n")
+
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        from lorekeep.cli import app
+        result = runner.invoke(app, ["config", "set", "observability.provider", "langfuse"])
+        assert result.exit_code == 0
+
+        data = yaml.safe_load(config.read_text())
+        assert data["observability"]["provider"] == "langfuse"
+
+    def test_config_set_list(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        config = home / "config.yaml"
+        config.write_text("ns:\n  default: [public]\n")
+
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        from lorekeep.cli import app
+        result = runner.invoke(app, ["config", "set", "ns.default", "backend,frontend"])
+        assert result.exit_code == 0
+
+        data = yaml.safe_load(config.read_text())
+        assert data["ns"]["default"] == ["backend", "frontend"]
+
+    def test_config_set_int(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        config = home / "config.yaml"
+        config.write_text("compile:\n  chunk_lines: 60\n")
+
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        from lorekeep.cli import app
+        result = runner.invoke(app, ["config", "set", "compile.chunk_lines", "30"])
+        assert result.exit_code == 0
+
+        data = yaml.safe_load(config.read_text())
+        assert data["compile"]["chunk_lines"] == 30
+
+    def test_config_show_no_config(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        from lorekeep.cli import app
+        result = runner.invoke(app, ["config", "show"])
+        assert result.exit_code == 1

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,7 +1,7 @@
 from datetime import date
 import json
 from lorekeep.models import DocChunk, Schema
-from lorekeep.compile.extract import build_prompt, parse_response, SYSTEM_PROMPT
+from lorekeep.compile.extract import build_prompt, build_system_prompt, parse_response, SYSTEM_PROMPT_BASE
 
 
 SCHEMA = Schema.load({
@@ -19,12 +19,16 @@ def make_chunk(text="x"):
                     text=text, namespace="teams/backend")
 
 
-def test_prompt_contains_schema_and_chunk():
+def test_system_prompt_contains_schema():
+    s = build_system_prompt(SCHEMA)
+    assert "service" in s and "depends_on" in s
+    assert "knowledge-graph extractor" in s
+
+
+def test_user_prompt_is_chunk_text_only():
     c = make_chunk("The payments-api is a Go service.")
     p = build_prompt(c, SCHEMA)
-    assert "service" in p and "depends_on" in p
-    assert "payments-api" in p
-    assert "raw/backend/a.md:3" in p
+    assert p == "The payments-api is a Go service."
 
 
 def test_parse_response_maps_nodes_and_edges():


### PR DESCRIPTION
4 fixes to daemon + init:

## 1. Multi-agent session watch (Claude + Codex)

```python
_discover_watchable_sessions()
  → [("claude", session_dir, memory_dir), ("codex", codex_home, memories_dir)]
```

Daemon watches **both** Claude  and Codex  for delta quick-import (zero LLM cost). Previously only Claude.

Cursor/opencode: no quick-import path (deep-only) → handled by session-end hooks ().

## 2. Session re-discovery every cycle

 called every 60s polling cycle (cheap directory scan). Detects new sessions opened after daemon start. Previously: discovered once at startup.

## 3. File count tracking for raw/ watch

Track both mtime AND file count. New files detected even if mtime is same tick (fast filesystem). Previously: mtime only → could miss new files.

## 4. Init always produces graph + wiki

 now calls  after compile (same pattern as  CLI command). Previously: wiki not generated during init compile.

## Tests

13 new tests: session discovery (Claude/Codex/both/empty/re-discovery), quick import per agent, file count tracking, init→graph end-to-end. 396 total.

## Docs

-  — updated daemon diagram + status
-  — daemon watch description
-  — new Daemon section