### PR TITLE
fix: add explicit permissions to lint-commits workflow

### DIFF
--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   pr-title:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes [code scanning alert #1](https://github.com/manhhailua/lorekeep/security/code-scanning/1).

Adds  to . Follows least-privilege principle.