### PR TITLE
fix: about.md not written when raw/ has existing files

### DIFF
--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -527,17 +527,19 @@ def init(
     else:
         typer.echo("  (existing config/schema preserved)")
 
-    # First file: the user's about.md (profile from onboarding) — replaces the
-    # generic welcome sample. Written only on first init (fresh config + empty raw/).
-    if not config_existed and not any(p["raw"].rglob("*.md")):
+    # First file: the user's about.md (profile from onboarding).
+    # Written on first init — always, even if raw/ has other files.
+    if not config_existed:
         ns_dir = p["raw"] / ns
         ns_dir.mkdir(parents=True, exist_ok=True)
-        about_md = (
-            f"# {name or '(your name)'}\n\n"
-            f"{bio or '(your bio — a one-line intro about you)'}\n"
-        )
-        (ns_dir / "about.md").write_text(about_md)
-        typer.echo(f"  wrote: {ns_dir / 'about.md'}")
+        about_path = ns_dir / "about.md"
+        if not about_path.exists():
+            about_md = (
+                f"# {name or '(your name)'}\n\n"
+                f"{bio or '(your bio — a one-line intro about you)'}\n"
+            )
+            about_path.write_text(about_md)
+            typer.echo(f"  wrote: {about_path}")
 
     # --- One-click chain: wire → import → compile → daemon -----------------
     if not config_existed:

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -132,15 +132,32 @@ def test_init_preserves_existing_config(tmp_path: Path, monkeypatch):
     assert (home / "raw").is_dir()
 
 
-def test_init_no_about_when_raw_has_files(tmp_path: Path, monkeypatch):
-    """If raw/ already has .md files, don't write about.md."""
+def test_init_writes_about_even_with_existing_raw_files(tmp_path: Path, monkeypatch):
+    """about.md is written on first init even if raw/ has other .md files."""
     home = tmp_path / "home"
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
     (home / "raw" / "existing").mkdir(parents=True)
     (home / "raw" / "existing" / "doc.md").write_text("# existing")
     result = runner.invoke(app, ["init"])
     assert result.exit_code == 0, result.stdout
-    assert not (home / "raw" / "public" / "about.md").exists()
+    # about.md written to default ns (public) alongside existing files
+    assert (home / "raw" / "public" / "about.md").exists()
+
+
+def test_init_no_about_on_second_run(tmp_path: Path, monkeypatch):
+    """Second init (config exists) doesn't overwrite about.md."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
+    about = home / "raw" / "public" / "about.md"
+    assert about.exists()
+    about.write_text("# Custom Bio\n\nDon't overwrite me.\n")
+
+    # Second init
+    result2 = runner.invoke(app, ["init"])
+    assert result2.exit_code == 0
+    assert "Don't overwrite me" in about.read_text()
 
 
 def test_init_auto_wires_detected_agent(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
Bug: init checked `not any(raw/*.md exists)` before writing about.md. If raw/ had files (locomo eval data, welcome.md, imports), the user's name/bio were silently discarded → empty graph after compile.

Fix: always write about.md on first init if it doesn't exist yet.

433 tests pass.