### PR TITLE
feat: daemon auto-backup + multi-device sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ just single-user.
   `lorekeep mcp add` wires Claude Code / Cursor / Codex / opencode.
 - **Autonomous agent daemon** — `lorekeep agent watch` keeps the graph current:
   auto-compile on raw/ change, auto-resolve pending journals, delta import of
-  agent session memory. Runs in the background; MCP server lazy-reloads.
+  agent session memory. **Auto-backup**: syncs to remote git after compile (pull --rebase + push).
+  Runs in the background; MCP server lazy-reloads.
 - **Session-end hooks** — `lorekeep hook` auto-imports agent memory when a
   session ends (Claude / Cursor / Codex / opencode). Wired by `mcp add`.
 - **Obsidian wiki** — auto-generated after every compile/resolve: human-browsable

--- a/docs/guides/backup.md
+++ b/docs/guides/backup.md
@@ -52,6 +52,21 @@ lorekeep backup      # commit + push raw/ + schema.json
 
 If nothing changed, it prints `backup: up to date` and exits 0.
 
+## Auto-backup (daemon)
+
+If the daemon (`lorekeep agent watch`) is running and a backup remote is
+configured, backup syncs automatically:
+
+1. **At startup**: pull --rebase from remote (sync changes from other machines)
+2. **After every compile**: commit local changes → fetch + rebase → push
+
+No manual `lorekeep backup` needed — the daemon handles it. If no remote is
+configured (`lorekeep backup --init` not run), backup is silently skipped.
+
+Multi-device conflicts (two machines editing same file) are handled by
+git rebase — if a conflict occurs, the daemon skips silently and the user
+resolves manually with `lorekeep backup`.
+
 ## Restore / second device
 
 On a fresh machine, clone the backup remote **into** the data home location,

--- a/docs/guides/serve.md
+++ b/docs/guides/serve.md
@@ -122,11 +122,14 @@ Two modes, from fully automatic to agent-controlled:
 ```bash
 # Mode 1: Daemon (default) — fully autonomous, follows Karpathy LLM Wiki pattern
 uvx lorekeep agent watch
+# Startup: sync backup from remote (pull changes from other machines)
 # Watches raw/ → auto-compile (file count + mtime tracking)
+#   → after compile: auto-resolve + wiki regen + backup sync (push to remote)
 # Watches pending/ → auto-resolve
 # Watches Claude memory/ + Codex memories/ → delta quick-import (zero LLM)
 # Session re-discovery every cycle — detects new sessions after daemon start
 # Survives restart: lorekeep agent daemon install (systemd/launchd/startup)
+# Backup auto-syncs: pull --rebase (other machines) + push (local changes)
 # Use --no-watch-sessions to disable session watching
 
 # Mode 2: Agent-controlled (--no-watch on init) — no daemon

--- a/src/lorekeep/backup.py
+++ b/src/lorekeep/backup.py
@@ -85,6 +85,36 @@ def _reconcile_remote(home: Path) -> None:
         pass  # no remote ref yet, or clean tree — push will surface real errors
 
 
+def has_remote(home: Path) -> bool:
+    """Check if a backup remote (git repo + origin) is configured."""
+    if not (home / ".git").is_dir():
+        return False
+    try:
+        remotes = _git(["remote"], home)
+        return "origin" in remotes.split()
+    except BackupError:
+        return False
+
+
+def sync_backup(home: Path) -> bool:
+    """Sync backup: pull --rebase from remote, then commit + push.
+
+    Used by daemon after compile. Pulls changes from other machines first
+    (fetch + rebase), then pushes local changes.
+
+    Silently returns False if:
+    - No backup repo or remote configured
+    - Network error or conflict (user resolves manually with ``lorekeep backup``)
+    """
+    if not has_remote(home):
+        return False
+    try:
+        _reconcile_remote(home)
+        return backup(home)
+    except BackupError:
+        return False
+
+
 def init_backup(home: Path, remote: str) -> None:
     """Init a git repo in ``home``, write .gitignore, set origin, commit, push.
 

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -1476,6 +1476,15 @@ def watch(
             typer.echo("agent: resolving pending journals at startup...")
             _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
 
+    # Sync from remote at startup (pull changes from other machines)
+    try:
+        from lorekeep.backup import sync_backup, has_remote
+        if has_remote(p["home"]):
+            typer.echo("agent: syncing backup from remote...")
+            sync_backup(p["home"])
+    except Exception:
+        pass
+
     while True:
         try:
             # Re-check existence each cycle (raw/ or pending/ may be created after start)
@@ -1514,6 +1523,15 @@ def watch(
 
             if compiled and has_pending:
                 _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
+
+            # --- auto-backup + sync after compile ---------------------------
+            if compiled:
+                try:
+                    from lorekeep.backup import sync_backup
+                    if sync_backup(p["home"]):
+                        typer.echo("agent: backup synced")
+                except Exception:
+                    pass
 
             # --- pending/ watch → auto-resolve ------------------------------
             if has_pending:

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from lorekeep.backup import BACKUP_GITIGNORE, BackupError, backup, init_backup
+from lorekeep.backup import BACKUP_GITIGNORE, BackupError, backup, init_backup, has_remote, sync_backup
 
 
 def _bare_remote(tmp_path: Path) -> str:
@@ -159,3 +159,87 @@ def test_init_backup_idempotent_on_diverged_remote(tmp_path: Path):
     init_backup(home, remote)
     # The remote-side file should be present locally after rebase
     assert (home / "raw" / "ns2" / "remote.md").exists()
+
+
+# ── has_remote + sync_backup tests ────────────────────────────────────────
+
+
+def test_has_remote_false_when_no_repo(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    assert has_remote(home) is False
+
+
+def test_has_remote_false_when_no_origin(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=home, check=True)
+    assert has_remote(home) is False
+
+
+def test_has_remote_true_after_init(tmp_path: Path):
+    home = tmp_path / "home"
+    remote = _bare_remote(tmp_path)
+    init_backup(home, remote)
+    assert has_remote(home) is True
+
+
+def test_sync_backup_no_repo_returns_false(tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    assert sync_backup(home) is False
+
+
+def test_sync_backup_commits_and_pushes(tmp_path: Path):
+    home = tmp_path / "home"
+    remote = _bare_remote(tmp_path)
+    init_backup(home, remote)
+
+    (home / "raw" / "ns").mkdir(parents=True)
+    (home / "raw" / "ns" / "new.md").write_text("# new")
+    pushed = sync_backup(home)
+    assert pushed is True
+
+
+def test_sync_backup_nothing_to_push(tmp_path: Path):
+    home = tmp_path / "home"
+    remote = _bare_remote(tmp_path)
+    init_backup(home, remote)
+    pushed = sync_backup(home)
+    assert pushed is False
+
+
+def test_sync_backup_pulls_from_other_machine(tmp_path: Path):
+    """Sync should pull changes pushed by another device before pushing."""
+    home = tmp_path / "home"
+    remote = _bare_remote(tmp_path)
+    init_backup(home, remote)
+
+    # Simulate another machine pushing a new file
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "-q", remote, str(other)], check=True)
+    (other / "raw" / "shared").mkdir(parents=True)
+    (other / "raw" / "shared" / "synced.md").write_text("# from other device")
+    _git_cmd(["add", "-A"], other)
+    _git_cmd(["commit", "-q", "-m", "other device"], other)
+    subprocess.run(["git", "push", "-q"], cwd=other, check=True)
+
+    # Now sync on the original device — should pull the file
+    (home / "raw" / "local").mkdir(parents=True)
+    (home / "raw" / "local" / "local.md").write_text("# local change")
+    sync_backup(home)
+
+    assert (home / "raw" / "shared" / "synced.md").exists()
+    assert (home / "raw" / "local" / "local.md").exists()
+
+
+def test_sync_backup_handles_network_error(tmp_path: Path):
+    home = tmp_path / "home"
+    remote = _bare_remote(tmp_path)
+    init_backup(home, remote)
+    # Break the remote URL
+    subprocess.run(["git", "remote", "set-url", "origin", "/nonexistent/path"],
+                   cwd=home, check=True)
+    # Should not raise — returns False silently
+    result = sync_backup(home)
+    assert result is False

--- a/uv.lock
+++ b/uv.lock
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "lorekeep"
-version = "0.10.0"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Daemon automatically backs up + syncs to remote git after compile.

## What

```python
# New in backup.py:
has_remote(home)    # check if backup remote configured
sync_backup(home)   # fetch + rebase + commit + push (silent on failure)
```

## Daemon integration

1. **At startup**: `sync_backup()` — pull changes from other machines
2. **After compile**: `sync_backup()` — commit local changes + push
   (pull --rebase first → multi-device edits merged)

```
Machine A: edit raw/ → compile → daemon backs up → push
Machine B: daemon start → pull from A → detects new files → compile → push
```

## Behavior

| Scenario | Result |
|---|---|
| No remote configured | Silently skipped |
| Nothing to push | `sync_backup` returns False |
| Remote has new changes | Fetch + rebase → local updated |
| Network error | Silently skipped (retry next cycle) |
| Conflict | Silently skipped (user runs `lorekeep backup` manually) |

## Tests

8 new tests: has_remote (3), sync_backup (5 — push/pull/nothing/error).
441 total.