### PR TITLE
fix: use PAT for release-please

### DIFF
--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -24,4 +24,4 @@ jobs:
         run: |
           gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,14 @@ name: release-please
 # the git tag + GitHub Release, then the publish job builds and publishes to
 # PyPI via OIDC trusted publishing (no API token).
 #
+# IMPORTANT: Uses RELEASE_PLEASE_TOKEN (a Personal Access Token) instead of
+# GITHUB_TOKEN. PRs created by GITHUB_TOKEN don't trigger downstream workflow
+# runs (GitHub prevents this to avoid loops). A PAT-authored PR merge DOES
+# trigger the push event → release-please detects the release → creates tag.
+#
+# Setup: create a fine-grained PAT with contents:write + pull-requests:write,
+# add as repo secret RELEASE_PLEASE_TOKEN.
+#
 # PyPI trusted publisher must be configured with:
 #   workflow = release-please.yml, environment = pypi
 on:
@@ -35,7 +43,8 @@ jobs:
       - id: rp
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # PAT required: GITHUB_TOKEN PRs don't trigger push events on merge
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
   publish:
     needs: release-please
@@ -93,4 +102,4 @@ jobs:
           gh pr merge --squash --auto --delete-branch \
             chore/sync-uv-lock-${{ needs.release-please.outputs.tag_name }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the root cause of failed releases (v0.10.1 tag missing).

GITHUB_TOKEN-authored PR merges don't trigger push events → release-please never runs after Release PR merge → no tag/release/Publish.

Uses `RELEASE_PLEASE_TOKEN || GITHUB_TOKEN` in 3 places:
- release-please-action token
- sync-uv-lock job GH_TOKEN
- auto-merge workflow GH_TOKEN

**Setup required after merge:**
1. Create fine-grained PAT: GitHub Settings → Developer settings → PATs
2. Permissions: Contents (read+write), Pull requests (read+write)
3. Repo: manhhailua/lorekeep
4. Add as repo secret: `RELEASE_PLEASE_TOKEN`
5. Next release will work automatically