### PR TITLE
chore: hide eval commands from production CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,7 @@ uv run lorekeep <command>                    # run the CLI in dev mode
 | `init` | Bootstrap data home (config + schema + raw/graph dirs) |
 | `compile` | `raw/*.md` → `graph/facts.jsonl` + `manifest.json` + `wiki/` (runs the LLM pipeline, auto-generates wiki) |
 | `check` | Validate compiled graph loads, no dangling edges (exit 1 on failure) |
-| `eval` | Tier-1 construction P/R/F1 vs gold corpus + structure metrics |
-| `eval-locomo` | Tier-2 LoCoMo retrieval/temporal/abstention eval |
+| `check` | Validate compiled graph loads, no dangling edges (exit 1 on failure) |
 | `wiki` | Regenerate `wiki/` from `facts.jsonl` (Obsidian-compatible markdown) |
 | `serve [--transport stdio\|http]` | Run the MCP server (9 read + 5 write tools) |
 | `mcp add --agent claude\|cursor\|codex\|opencode --ns NS` | Write agent MCP config |

--- a/README.md
+++ b/README.md
@@ -225,10 +225,10 @@ For usage, see the [`docs/`](docs/README.md) index.
 ## Evaluation
 
 **Tier-1** (CI): extraction P/R/F1 vs a gold corpus, entity-resolution pairwise F1,
-graph-structure metrics, determinism. Run: `uvx lorekeep eval`.
+graph-structure metrics, determinism. *Dev-only command: `lorekeep eval`.*
 
 **Tier-2 LoCoMo** (per-release): long-term conversation → graph → retrieval QA.
-Run: `uvx lorekeep eval-locomo --data locomo10.json --compile`.
+*Dev-only command: `lorekeep eval-locomo`.*
 
 | Category | Recall | Description |
 |---|---|---|

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -143,7 +143,7 @@ def wiki() -> None:
     typer.echo(f"wiki: {result['pages']} pages written to {p['wiki']}")
 
 
-@app.command(name="eval")
+@app.command(name="eval", hidden=True)
 def eval_cmd() -> None:
     """Run Tier-1 construction-quality evaluation vs the gold corpus."""
     p = resolve_paths()
@@ -160,7 +160,7 @@ def eval_cmd() -> None:
     typer.echo(json.dumps(report, indent=2, sort_keys=True))
 
 
-@app.command(name="eval-locomo")
+@app.command(name="eval-locomo", hidden=True)
 def eval_locomo_cmd(
     data: str = typer.Option("", "--data", help="Path to locomo10.json"),
     compile_first: bool = typer.Option(


### PR DESCRIPTION
Hidden from `--help` but still functional for development.

- `lorekeep eval` → hidden=True
- `lorekeep eval-locomo` → hidden=True
- Removed from AGENTS.md CLI table
- README: marked as 'Dev-only command'

Commands still work when called directly — just not advertised to end users.