### PR TITLE
chore: sync uv.lock to v0.11.3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1024,7 +1024,7 @@ wheels = [
 
 [[package]]
 name = "lorekeep"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Auto-synced after release.