### PR TITLE
fix: simplify provider config, validate model prefix, ping provider in doctor

### DIFF
--- a/.lorekeep/config.yaml.example
+++ b/.lorekeep/config.yaml.example
@@ -1,28 +1,37 @@
-# Copy to .lorekeep/config.yaml (gitignored). Provider used at compile time only.
-# API keys NEVER go in this file - set them as env vars (api_key_env names which).
+# Copy to .lorekeep/config.yaml (gitignored). Provider is used at compile time only.
+#
+# The model string MUST be '{provider}/{model}' — litellm routes by the prefix:
+#   openai/gpt-4o-mini, anthropic/claude-sonnet-4-20250514, deepseek/deepseek-chat,
+#   ollama/llama3. Native providers (openai, anthropic, deepseek) need NO api_base.
+#   OpenAI-compatible endpoints (DashScope, Ollama) set api_base AND use the openai/ prefix.
+#
+# API keys: prefer api_key_env (name of an env var you export). An inline api_key is
+# also accepted since this file is gitignored — but never commit it.
 #
 # Option A: Alibaba ModelStudio / DashScope (international, OpenAI-compatible)
 provider:
-  backend: openai
   model: openai/qwen-plus                          # qwen-max | qwen-plus | qwen-turbo
   api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
   api_key_env: DASHSCOPE_API_KEY                   # export DASHSCOPE_API_KEY=...
   temperature: 0.0
 #
-# Option B: OpenAI
+# Option B: OpenAI (native — no api_base)
 # provider:
-#   backend: openai
 #   model: openai/gpt-4o-mini
-#   api_base: null
 #   api_key_env: OPENAI_API_KEY
 #   temperature: 0.0
 #
-# Option C: Ollama (local, strict privacy)
+# Option C: DeepSeek (native litellm provider — no api_base)
+#   real models: deepseek-chat (V3) | deepseek-reasoner (R1)
 # provider:
-#   backend: ollama
+#   model: deepseek/deepseek-chat
+#   api_key_env: DEEPSEEK_API_KEY
+#   temperature: 0.0
+#
+# Option D: Ollama (local, strict privacy)
+# provider:
 #   model: ollama/llama3
 #   api_base: http://localhost:11434
-#   api_key_env: null
 #   temperature: 0.0
 compile:
   chunk_lines: 60

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Every result is filtered to the caller's namespace. Write tools append to `pendi
 dev marker > XDG):
 ```yaml
 provider:
-  model: openai/qwen-plus                              # litellm model string
+  model: openai/qwen-plus                              # {provider}/{model} — litellm routes by prefix
   api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
   api_key_env: DASHSCOPE_API_KEY                       # env var name (preferred)
   api_key: null                                        # or inline (gitignored config only)

--- a/docs/guides/compile.md
+++ b/docs/guides/compile.md
@@ -24,7 +24,6 @@ For strict privacy, use a local model:
 
 ```yaml
 provider:
-  backend: ollama
   model: ollama/llama3
   api_base: http://localhost:11434
 ```

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -98,12 +98,18 @@ key inline. Edit it here if you want a different one. The key lives in
 
 ```yaml
 provider:
-  backend: openai
-  model: openai/deepseek-v4-flash          # any litellm model string
-  api_base: https://api.deepseek.com/v1
+  model: deepseek/deepseek-chat            # {provider}/{model} — litellm routes by the prefix
+  api_base: null                           # native deepseek provider — no api_base needed
   api_key: sk-...                          # inline; config.yaml is gitignored
   temperature: 0.0
 ```
+
+The model string must be `{provider}/{model}` (e.g. `openai/gpt-4o-mini`,
+`anthropic/claude-sonnet-4-20250514`, `deepseek/deepseek-chat`,
+`ollama/llama3`). Native providers (`openai`, `anthropic`, `deepseek`) need no
+`api_base`; OpenAI-compatible endpoints (DashScope, Ollama) set `api_base` and
+use the `openai/` prefix. A bare name like `deepseek-chat` is rejected with a
+suggestion — `lorekeep doctor` will tell you exactly what's wrong.
 
 Prefer an env var instead? Set `api_key_env: DEEPSEEK_API_KEY` (and
 `api_key: null`), then `export DEEPSEEK_API_KEY=sk-...`. Both work.
@@ -189,10 +195,12 @@ recovery — is in [Backing up the data home](backup.md).
 - **`lorekeep serve` hangs** — it blocks on stdio waiting for an MCP client.
   To just confirm it boots, run it under a timeout with stdin closed:
   `timeout 3 uvx lorekeep serve --transport stdio </dev/null`.
-- **Compile gave 0 nodes** — the provider wasn't reached. Check
-  `api_key_env` / `api_base` in `config.yaml`. If you switched provider or
-  model after a first compile, delete `<data-home>/cache.json` (the cache key
-  doesn't include the model) and recompile.
+- **Compile gave 0 nodes** — the provider wasn't reached. Run
+  `lorekeep doctor` first: it pings the provider and reports auth / model /
+  endpoint failures directly. Then check `model` (must be
+  `{provider}/{model}`), `api_base`, and `api_key` / `api_key_env` in
+  `config.yaml`. (The cache key includes the model, so switching it
+  re-extracts automatically — no need to delete `cache.json`.)
 - **`check` reports dangling edges** — an edge points at a node that isn't in
   the graph. Re-open the source doc at the `path:line` in the edge's `src` and
   fix the reference, then recompile.

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 
@@ -14,7 +15,10 @@ from lorekeep.models import now_iso
 from lorekeep.pipeline import compile_graph
 from lorekeep.paths import resolve_paths
 from lorekeep.defaults import DEFAULT_CONFIG_YAML, DEFAULT_SCHEMA
+from lorekeep.providers import validate_model_prefix
 from lorekeep.schema_io import load_schema
+
+log = logging.getLogger("lorekeep")
 
 app = typer.Typer(help="Lorekeep — compile team docs into a temporal knowledge graph.")
 
@@ -43,6 +47,7 @@ def _build_provider(config: Config) -> LiteLLMProvider:
         api_key = os.environ.get(config.provider.api_key_env)
     if not api_key:
         api_key = config.provider.api_key
+    validate_model_prefix(config.provider.model)  # defense-in-depth (load_config already gates)
     return LiteLLMProvider(
         model=config.provider.model,
         api_base=config.provider.api_base,
@@ -127,6 +132,8 @@ def _report_compile_errors(manifest, *, exit_on_total_failure: bool = True) -> N
     errs = manifest.errors or []
     if not errs:
         return
+    for e in errs:
+        log.error("compile error %s:%s: %s", e.path, e.line, e.message)
     total_fail = manifest.node_count == 0 and manifest.chunk_count > 0
     if total_fail:
         typer.echo(
@@ -142,11 +149,32 @@ def _report_compile_errors(manifest, *, exit_on_total_failure: bool = True) -> N
         if exit_on_total_failure:
             raise typer.Exit(code=1)
     else:
-        typer.echo(
-            f"compile: {len(errs)} chunk(s) failed (partial — "
-            f"{manifest.node_count} nodes still produced). See manifest.json.",
-            err=True,
-        )
+        # Systemic-error heuristic: if most chunks failed with the SAME message,
+        # it's almost always a provider config issue (bad model/api_base/api_key)
+        # rather than per-doc content. Surface every identical error + a hint so
+        # the user isn't left with a one-line summary and an empty-looking graph.
+        messages = [e.message for e in errs]
+        distinct = set(messages)
+        systemic = len(errs) >= 3 and (len(distinct) == 1 or max(messages.count(m) for m in distinct) >= 0.8 * len(errs))
+        if systemic:
+            typer.echo(
+                f"compile: {len(errs)} of {manifest.chunk_count} chunk(s) failed "
+                f"with the same error ({manifest.node_count} nodes still produced).",
+                err=True,
+            )
+            for e in errs:
+                typer.echo(f"  {e.path}:{e.line}: {e.message}", err=True)
+            typer.echo(
+                "  hint: identical errors across chunks usually mean a provider "
+                "config issue (model/api_base/api_key). Run 'lorekeep doctor'.",
+                err=True,
+            )
+        else:
+            typer.echo(
+                f"compile: {len(errs)} chunk(s) failed (partial — "
+                f"{manifest.node_count} nodes still produced). See manifest.json.",
+                err=True,
+            )
 
 
 @app.command()
@@ -436,6 +464,13 @@ def config_set(
     else:
         target[final_key] = value
 
+    if key == "provider.model":
+        try:
+            validate_model_prefix(target[final_key])
+        except ValueError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=1)
+
     p["config"].write_text(
         yaml.dump(data, default_flow_style=False, sort_keys=False),
         encoding="utf-8",
@@ -472,9 +507,11 @@ def mcp_add(
 
 @app.command()
 def doctor() -> None:
-    """Verify install: graph loads, schema valid, ns resolves, a tool responds."""
+    """Verify install: graph loads, schema valid, ns resolves, a tool responds,
+    and the configured LLM provider is reachable."""
     p = resolve_paths()
     problems = []
+    notes = []
 
     facts_path = p["out"] / "facts.jsonl"
     if not facts_path.exists():
@@ -496,8 +533,15 @@ def doctor() -> None:
         except Exception as exc:
             problems.append(f"schema invalid: {exc}")
 
+    # Load config once; a bare model fails fast here (reported, not crashed).
+    try:
+        config = load_config(p["config"])
+    except ValueError as exc:
+        typer.echo(f"FAIL: provider config: {exc}")
+        raise typer.Exit(code=1)
+
     raw_ns = os.environ.get("LOREKEEP_NS")
-    allowed = [x.strip() for x in raw_ns.split(",")] if raw_ns else load_config(p["config"]).ns.default
+    allowed = [x.strip() for x in raw_ns.split(",")] if raw_ns else config.ns.default
 
     try:
         from lorekeep.mcp_server import configure, list_namespaces
@@ -507,6 +551,27 @@ def doctor() -> None:
         problems.append(f"mcp configure/tool failed: {exc}")
         ns = []
 
+    # Provider connectivity probe — catches the most common breakage (bad
+    # model/api_base/api_key) that a graph/schema check alone misses.
+    if os.environ.get("LOREKEEP_DOCTOR_NO_PING") == "1":
+        notes.append("provider: ping skipped (LOREKEEP_DOCTOR_NO_PING=1)")
+    elif not _has_provider(config):
+        notes.append("provider: skipped (no API key set — compile will skip until you add one)")
+    else:
+        try:
+            _make_provider(config).ping()
+            notes.append(f"provider: ok ({config.provider.model})")
+        except Exception as exc:
+            msg = str(exc).lower()
+            if "401" in msg or "authentication" in msg or "unauthorized" in msg:
+                problems.append("provider: AUTH FAILED (bad API key)")
+            elif "404" in msg or "not found" in msg or "model" in msg and "exist" in msg:
+                problems.append(f"provider: MODEL NOT FOUND ({config.provider.model}) — check the model string")
+            elif "connection" in msg or "timeout" in msg or "unreachable" in msg or "refused" in msg:
+                problems.append("provider: ENDPOINT UNREACHABLE (check api_base / network)")
+            else:
+                problems.append(f"provider: FAILED — {exc}")
+
     if problems:
         typer.echo("FAIL: " + "; ".join(problems))
         raise typer.Exit(code=1)
@@ -515,6 +580,8 @@ def doctor() -> None:
         f"all checks passed: {len(store.node_ids())} nodes, "
         f"{len(store.all_edges())} edges, namespaces={ns}"
     )
+    for note in notes:
+        typer.echo(note)
 
 
 def _is_interactive() -> bool:
@@ -664,7 +731,7 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
         ns = typer.prompt("Default namespace", default="private")
         name = typer.prompt("Your name", default="")
         bio = typer.prompt("Bio (one-line intro)", default="")
-        _write_config(p, backend="openai", model="gpt-4o-mini",
+        _write_config(p, model="openai/gpt-4o-mini",
                        api_base=None, api_key_env=None, api_key=None, ns=ns)
         return ns, name, bio
 
@@ -722,6 +789,13 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
             model = typer.prompt("Model name (litellm string)", default="")
         api_base = None
 
+    # Prefix a bare model name with the explicitly-selected provider so the
+    # written config is always a valid litellm string. (Not a guess — the user
+    # picked this provider; only bare names get prefixed.)
+    if "/" not in model:
+        from lorekeep.providers import _normalize_model_name
+        model = _normalize_model_name(model, provider_name)
+
     typer.echo(f"  → {model}\n")
 
     # ── API key (skip for local providers) ─────────────────────────────
@@ -755,20 +829,19 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
     bio = typer.prompt("Bio (one-line intro)", default="")
 
     _write_config(
-        p, backend="openai", model=model, api_base=api_base,
+        p, model=model, api_base=api_base,
         api_key_env=env_var if not api_key else None,
         api_key=api_key, ns=ns,
     )
     return ns, name, bio
 
 
-def _write_config(p, backend, model, api_base, api_key_env, api_key, ns):
+def _write_config(p, model, api_base, api_key_env, api_key, ns):
     """Write config.yaml from provider selection."""
     import yaml
     install_source = "local" if (Path.cwd() / ".lorekeep").exists() else "pypi"
     config = {
         "provider": {
-            "backend": backend,
             "model": model,
             "api_base": api_base,
             "api_key_env": api_key_env,

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -13,7 +13,7 @@ from lorekeep.config import Config, load_config
 from lorekeep.models import now_iso
 from lorekeep.pipeline import compile_graph
 from lorekeep.paths import resolve_paths
-from lorekeep.defaults import DEFAULT_CONFIG_YAML, DEFAULT_SCHEMA, PROVIDER_PRESETS
+from lorekeep.defaults import DEFAULT_CONFIG_YAML, DEFAULT_SCHEMA
 from lorekeep.schema_io import load_schema
 
 app = typer.Typer(help="Lorekeep — compile team docs into a temporal knowledge graph.")

--- a/src/lorekeep/compile/providers.py
+++ b/src/lorekeep/compile/providers.py
@@ -8,6 +8,7 @@ from typing import Protocol, runtime_checkable
 class LLMProvider(Protocol):
     def extract_json(self, system: str, user: str) -> str: ...
     def complete(self, system: str, user: str) -> str: ...
+    def ping(self) -> str: ...
 
 
 class FakeProvider:
@@ -28,6 +29,12 @@ class FakeProvider:
         if not self._responses:
             raise RuntimeError("FakeProvider: no canned response left")
         return self._responses.pop(0)
+
+    def ping(self) -> str:
+        """Offline connectivity probe. Returns 'OK' without consuming the
+        response queue (so compile tests' canned-response counts stay exact)."""
+        self.calls.append(("ping", "", ""))
+        return "OK"
 
 
 class LiteLLMProvider:
@@ -84,6 +91,17 @@ class LiteLLMProvider:
             ],
         )
         return resp.choices[0].message.content
+
+    def ping(self) -> str:
+        """One-token connectivity probe used by ``lorekeep doctor``.
+
+        Surfaces auth / model / endpoint failures immediately rather than
+        letting them surface as a silent 0-node compile.
+        """
+        return self.complete(
+            system="You are a connectivity probe.",
+            user="Reply with exactly: OK",
+        )
 
 
 def setup_observability(

--- a/src/lorekeep/config.py
+++ b/src/lorekeep/config.py
@@ -8,8 +8,7 @@ from pydantic import BaseModel, Field
 
 
 class ProviderConfig(BaseModel):
-    backend: str = "openai"          # openai | anthropic | ollama | <litellm prefix>
-    model: str = "gpt-4o-mini"
+    model: str = "openai/gpt-4o-mini"   # must be {provider}/{model} — litellm routes by prefix
     api_base: str | None = None      # set for ollama or openai-compatible endpoints
     api_key_env: str | None = None   # env var holding the api key (else litellm default)
     api_key: str | None = None       # inline key (gitignored config only; env is safer)
@@ -41,8 +40,23 @@ class Config(BaseModel):
     install_source: str | None = None      # pypi | local | git+URL | path
 
 
+def _validate_provider(cfg: Config) -> None:
+    """Fail fast on a bare model name.
+
+    A bare name (no ``/``) fails deep inside litellm with the opaque
+    ``LLM Provider NOT provided`` error. ``validate_model_prefix`` raises
+    ``ValueError`` with an actionable suggestion instead.
+    """
+    from lorekeep.providers import validate_model_prefix
+
+    if cfg.provider.model:
+        validate_model_prefix(cfg.provider.model)
+
+
 def load_config(path: Path) -> Config:
     if not path.exists():
         return Config()
     data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    return Config.model_validate(data)
+    cfg = Config.model_validate(data)
+    _validate_provider(cfg)
+    return cfg

--- a/src/lorekeep/defaults.py
+++ b/src/lorekeep/defaults.py
@@ -30,7 +30,6 @@ DEFAULT_SCHEMA = {
 
 DEFAULT_CONFIG_YAML = """\
 provider:
-  backend: openai
   model: openai/gpt-4o-mini
   api_base: null
   api_key_env: OPENAI_API_KEY
@@ -42,44 +41,6 @@ ns:
   default: [public]
 install_source: pypi
 """
-
-PROVIDER_PRESETS: dict[str, dict] = {
-    "1": {
-        "label": "OpenAI (gpt-4o-mini)",
-        "backend": "openai",
-        "model": "openai/gpt-4o-mini",
-        "api_base": None,
-        "api_key_env": "OPENAI_API_KEY",
-    },
-    "2": {
-        "label": "Anthropic (claude-sonnet-4-20250514)",
-        "backend": "anthropic",
-        "model": "anthropic/claude-sonnet-4-20250514",
-        "api_base": None,
-        "api_key_env": "ANTHROPIC_API_KEY",
-    },
-    "3": {
-        "label": "DashScope/Qwen (qwen-plus)",
-        "backend": "openai",
-        "model": "openai/qwen-plus",
-        "api_base": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-        "api_key_env": "DASHSCOPE_API_KEY",
-    },
-    "4": {
-        "label": "Ollama (local, no API key needed)",
-        "backend": "openai",
-        "model": "ollama/llama3.2",
-        "api_base": "http://localhost:11434",
-        "api_key_env": None,
-    },
-    "5": {
-        "label": "Skip — configure provider later (edit config.yaml)",
-        "backend": "openai",
-        "model": "openai/gpt-4o-mini",
-        "api_base": None,
-        "api_key_env": None,
-    },
-}
 
 SAMPLE_DOC = """\
 # Lorekeep sample

--- a/src/lorekeep/pipeline.py
+++ b/src/lorekeep/pipeline.py
@@ -1,6 +1,7 @@
 """Pipeline: ingest -> extract -> resolve -> writer."""
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from lorekeep.compile.extract import ExtractionCache, extract_chunk
@@ -9,6 +10,8 @@ from lorekeep.compile.providers import LLMProvider
 from lorekeep.compile.resolve import resolve
 from lorekeep.compile.writer import facts_hash, run_id, write_graph
 from lorekeep.models import Edge, Manifest, Node, Schema, now_iso
+
+log = logging.getLogger("lorekeep")
 
 
 def compile_graph(
@@ -34,6 +37,7 @@ def compile_graph(
             for ak, av in aliases.items():       # union variants, last-writer-wins drops aliases
                 all_aliases[ak] = list(dict.fromkeys(all_aliases.get(ak, []) + av))
         except Exception as exc:               # skip-and-log; partial compile is valid
+            log.exception("compile: chunk failed path=%s line=%s", chunk.path, chunk.start_line)
             errors.append({"path": chunk.path, "line": chunk.start_line,
                            "message": str(exc)})
     cache.save()

--- a/src/lorekeep/providers.py
+++ b/src/lorekeep/providers.py
@@ -71,11 +71,70 @@ def _normalize_model_name(name: str, provider: str) -> str:
     names fail at runtime for providers that litellm cannot auto-detect by pattern
     (e.g. deepseek, gemini).  Always storing the prefixed form produces a valid
     litellm model string regardless of provider.
+
+    For runtime validation of a user-supplied model string (no known provider),
+    see :func:`validate_model_prefix`.
     """
     prefix = f"{provider}/"
     if name.startswith(prefix):
         return name
     return f"{provider}/{name}"
+
+
+# Bare model names mapped to their canonical ``{provider}/{model}`` form, used
+# only to *suggest* a fix when a user writes an unambiguous bare name. Kept
+# conservative: ``qwen-*`` is intentionally absent (DashScope uses ``openai/`` +
+# ``api_base`` while native litellm uses ``dashscope/`` — ambiguous, so we emit
+# the rule instead of guessing).
+_BARE_ALIASES: dict[str, str] = {
+    "deepseek-chat": "deepseek/deepseek-chat",
+    "deepseek-reasoner": "deepseek/deepseek-reasoner",
+    "gpt-4o-mini": "openai/gpt-4o-mini",
+    "gpt-4o": "openai/gpt-4o",
+    "gpt-4-turbo": "openai/gpt-4-turbo",
+    "gpt-3.5-turbo": "openai/gpt-3.5-turbo",
+    "claude-sonnet-4-20250514": "anthropic/claude-sonnet-4-20250514",
+    "claude-3-5-sonnet-latest": "anthropic/claude-3-5-sonnet-latest",
+    "claude-3-5-sonnet-20241022": "anthropic/claude-3-5-sonnet-20241022",
+    "claude-3-haiku-20240307": "anthropic/claude-3-haiku-20240307",
+    "claude-3-opus-20240229": "anthropic/claude-3-opus-20240229",
+}
+
+
+def suggest_model_prefix(model: str) -> str | None:
+    """Return the canonical ``{provider}/{model}`` form for a known bare name.
+
+    Returns ``None`` for already-prefixed or unknown names so callers never
+    silently rewrite the user's config — they surface this as a *suggestion*.
+    """
+    if "/" in model:
+        return None
+    return _BARE_ALIASES.get(model)
+
+
+def validate_model_prefix(model: str) -> None:
+    """Raise ``ValueError`` unless *model* is a ``{provider}/{model}`` litellm string.
+
+    litellm routes by the prefix (``openai/``, ``deepseek/``, ``anthropic/`` …);
+    a bare name like ``deepseek-chat`` fails deep inside litellm with the opaque
+    ``LLM Provider NOT provided`` error. We fail fast here with an actionable
+    message, including a suggestion when the bare name is a known alias.
+    """
+    if "/" in model:
+        return
+    suggestion = suggest_model_prefix(model)
+    if suggestion:
+        raise ValueError(
+            f"provider model must be '{{provider}}/{{model}}' (got {model!r}). "
+            f"litellm routes by the prefix. Did you mean {suggestion!r}?"
+        )
+    raise ValueError(
+        f"provider model must be '{{provider}}/{{model}}' (got {model!r}). "
+        "litellm routes by the prefix — e.g. 'openai/gpt-4o-mini', "
+        "'anthropic/claude-sonnet-4-20250514', 'deepseek/deepseek-chat', "
+        "'ollama/llama3'."
+    )
+
 
 
 def list_models(provider: str) -> list[ModelInfo]:

--- a/tests/test_compile_cli.py
+++ b/tests/test_compile_cli.py
@@ -50,6 +50,26 @@ def test_compile_total_failure_exits_nonzero(monkeypatch, tmp_path: Path, fixtur
     assert "canned response left" in result.output  # the actual error message
 
 
+def test_compile_total_failure_logs_errors(monkeypatch, tmp_path: Path, fixtures: Path, caplog):
+    """Every compile error must reach the 'lorekeep' logger so daemon agent.log
+    surfaces it (regression: daemon path was silent)."""
+    import logging as _logging
+    monkeypatch.setenv("LOREKEEP_RAW", str(tmp_path / "raw"))
+    monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "graph"))
+    monkeypatch.setenv("LOREKEEP_CACHE", str(tmp_path / "cache.json"))
+    monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+    raw = tmp_path / "raw/test/doc.md"
+    raw.parent.mkdir(parents=True)
+    raw.write_text("# Doc\ncontent\n")
+    monkeypatch.setattr("lorekeep.cli._make_provider", lambda c: FakeProvider(responses=[]))
+    monkeypatch.setattr("lorekeep.cli._has_provider", lambda c: True)
+
+    with caplog.at_level(_logging.ERROR, logger="lorekeep"):
+        result = runner.invoke(app, ["compile"])
+    assert result.exit_code == 1
+    assert any("compile error" in r.message for r in caplog.records)
+
+
 def test_compile_partial_failure_exits_zero(monkeypatch, tmp_path: Path, fixtures: Path, fake_extraction):
     """When some chunks succeed but others fail, compile warns but exits 0
     (partial compile is valid)."""

--- a/tests/test_compile_cli.py
+++ b/tests/test_compile_cli.py
@@ -82,6 +82,62 @@ def test_compile_partial_failure_exits_zero(monkeypatch, tmp_path: Path, fixture
     assert "partial" in result.output
 
 
+def test_compile_rejects_bare_model_before_litellm(monkeypatch, tmp_path: Path, fixtures: Path):
+    """Regression for the 2026-07-18 incident: a bare model name must fail fast
+    with a suggestion at compile, not silently produce 0 nodes via litellm."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("provider:\n  model: deepseek-chat\napi_key: sk-test\n")
+    monkeypatch.setenv("LOREKEEP_CONFIG", str(cfg))
+    monkeypatch.setenv("LOREKEEP_RAW", str(tmp_path / "raw"))
+    monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "graph"))
+    monkeypatch.setenv("LOREKEEP_CACHE", str(tmp_path / "cache.json"))
+    monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+    raw = tmp_path / "raw/test/doc.md"
+    raw.parent.mkdir(parents=True)
+    raw.write_text("# Doc\nSome content.\n")
+
+    result = runner.invoke(app, ["compile"])
+    assert result.exit_code != 0
+    # load_config raises ValueError with the suggestion; surface it clearly
+    assert result.exception is not None
+    assert "deepseek/deepseek-chat" in str(result.exception)
+
+
+def test_compile_partial_systemic_errors_surface_all(monkeypatch, tmp_path: Path, fixtures: Path, fake_extraction):
+    """≥3 chunks failing with the SAME error (partial — some nodes produced)
+    must surface every error + a provider-config hint, not a one-line summary."""
+    monkeypatch.setenv("LOREKEEP_RAW", str(tmp_path / "raw"))
+    monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "graph"))
+    monkeypatch.setenv("LOREKEEP_CACHE", str(tmp_path / "cache.json"))
+    monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+
+    # 4 chunks: first succeeds (produces nodes), next 3 fail identically.
+    for name in ("ok.md", "bad1.md", "bad2.md", "bad3.md"):
+        (tmp_path / "raw/test" / name).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "raw/test" / name).write_text(f"# {name}\ncontent.\n")
+
+    class _Systematic(FakeProvider):
+        def __init__(self):
+            super().__init__(responses=[])
+            self._n = 0
+
+        def extract_json(self, system, user):
+            self._n += 1
+            if self._n == 1:
+                return fake_extraction
+            raise RuntimeError("LLM Provider NOT provided")
+
+    monkeypatch.setattr("lorekeep.cli._make_provider", lambda config: _Systematic())
+    monkeypatch.setattr("lorekeep.cli._has_provider", lambda config: True)
+
+    result = runner.invoke(app, ["compile"])
+    assert result.exit_code == 0, result.output  # partial compile is valid
+    out = result.output.lower()
+    assert "same error" in out
+    assert "lorekeep doctor" in out
+    assert out.count("llm provider not provided") >= 3  # every error echoed
+
+
 def test_compile_success_no_error_output(patch_make_provider, monkeypatch, tmp_path: Path, fixtures: Path):
     """When all chunks succeed, no error warning is printed."""
     monkeypatch.setenv("LOREKEEP_RAW", str(tmp_path / "raw"))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+
+import pytest
+
 from lorekeep.config import Config, load_config
 
 
@@ -6,19 +9,46 @@ def test_load_config(tmp_path: Path):
     cfg = tmp_path / "config.yaml"
     cfg.write_text(
         "provider:\n"
-        "  backend: openai\n"
-        "  model: gpt-4o-mini\n"
+        "  model: openai/gpt-4o-mini\n"
         "  api_base: null\n"
         "compile:\n"
         "  chunk_lines: 40\n"
     )
     c = load_config(cfg)
     assert isinstance(c, Config)
-    assert c.provider.model == "gpt-4o-mini"
+    assert c.provider.model == "openai/gpt-4o-mini"
     assert c.compile.chunk_lines == 40
 
 
 def test_default_config_when_missing(tmp_path: Path):
     c = load_config(tmp_path / "missing.yaml")
-    assert c.provider.backend == "openai"
+    assert c.provider.model == "openai/gpt-4o-mini"
     assert c.compile.chunk_lines == 60
+
+
+def test_load_config_rejects_bare_model(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("provider:\n  model: deepseek-chat\n")
+    with pytest.raises(ValueError) as ei:
+        load_config(cfg)
+    assert "deepseek/deepseek-chat" in str(ei.value)
+
+
+def test_load_config_accepts_prefixed_model(tmp_path: Path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("provider:\n  model: deepseek/deepseek-chat\n")
+    c = load_config(cfg)  # no raise
+    assert c.provider.model == "deepseek/deepseek-chat"
+
+
+def test_load_config_drops_legacy_backend_silently(tmp_path: Path):
+    """Old configs with `backend:` must still load (pydantic extra=ignore)."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "provider:\n"
+        "  backend: openai\n"
+        "  model: openai/gpt-4o-mini\n"
+    )
+    c = load_config(cfg)  # no raise, backend silently dropped
+    assert c.provider.model == "openai/gpt-4o-mini"
+    assert not hasattr(c.provider, "backend")

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -19,3 +19,8 @@ def test_default_config_yaml_loads_into_config():
     assert c.provider.model.startswith("openai/")
     assert c.install_source == "pypi"
     assert c.ns.default == ["public"]
+
+
+def test_default_config_yaml_has_no_backend():
+    """backend is a removed dead field — must not appear in the template."""
+    assert "backend" not in DEFAULT_CONFIG_YAML

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -99,3 +99,56 @@ def test_doctor_reports_bare_model_as_problem(tmp_path: Path, fixtures: Path, mo
     assert result.exit_code == 1
     assert "provider config" in result.stdout.lower()
     assert "deepseek/deepseek-chat" in result.stdout
+
+
+def test_doctor_no_ping_env_escape_hatch(tmp_path: Path, fixtures: Path, monkeypatch):
+    """LOREKEEP_DOCTOR_NO_PING=1 skips the ping even when a key is present."""
+    out = _seed_graph(tmp_path, fixtures)
+    monkeypatch.setenv("LOREKEEP_OUT", str(out))
+    monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+    monkeypatch.setenv("LOREKEEP_DOCTOR_NO_PING", "1")
+    monkeypatch.setattr("lorekeep.cli._has_provider", lambda c: True)
+    # If the ping ran, this would explode (network). It must NOT be called.
+    def _boom(c):
+        raise AssertionError("provider built despite LOREKEEP_DOCTOR_NO_PING=1")
+    monkeypatch.setattr("lorekeep.cli._make_provider", _boom)
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0, result.stdout
+    assert "ping skipped" in result.stdout.lower()
+
+
+def test_doctor_reports_endpoint_unreachable(tmp_path: Path, fixtures: Path, monkeypatch):
+    out = _seed_graph(tmp_path, fixtures)
+    monkeypatch.setenv("LOREKEEP_OUT", str(out))
+    monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+
+    class _Unreachable:
+        def ping(self):
+            raise Exception("ConnectionError: Connection refused")
+
+    monkeypatch.setattr("lorekeep.cli._has_provider", lambda c: True)
+    monkeypatch.setattr("lorekeep.cli._make_provider", lambda c: _Unreachable())
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 1
+    assert "endpoint unreachable" in result.stdout.lower()
+
+
+class TestProviderPing:
+    """ping() contract: FakeProvider returns OK without consuming the response
+    queue (so compile tests' canned-response counts stay exact)."""
+
+    def test_fake_ping_returns_ok(self):
+        f = FakeProvider(["canned"])
+        assert f.ping() == "OK"
+
+    def test_fake_ping_does_not_consume_queue(self):
+        f = FakeProvider(["canned"])
+        assert f.ping() == "OK"
+        assert f.extract_json("s", "u") == "canned"  # still there
+
+    def test_fake_ping_works_with_empty_queue(self):
+        assert FakeProvider([]).ping() == "OK"
+
+    def test_litellm_provider_has_ping(self):
+        from lorekeep.compile.providers import LiteLLMProvider
+        assert callable(getattr(LiteLLMProvider, "ping", None))

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -1,18 +1,27 @@
 import shutil
 from pathlib import Path
 from typer.testing import CliRunner
+
 from lorekeep.cli import app
+from lorekeep.compile.providers import FakeProvider
 
 runner = CliRunner()
 
 
-def test_doctor_ok(tmp_path: Path, fixtures: Path, monkeypatch):
+def _seed_graph(tmp_path: Path, fixtures: Path) -> Path:
     out = tmp_path / "graph"
-    out.mkdir()
+    out.mkdir(exist_ok=True)
     shutil.copy(fixtures / "gold/payments.facts.jsonl", out / "facts.jsonl")
+    return out
+
+
+def test_doctor_ok(tmp_path: Path, fixtures: Path, monkeypatch):
+    out = _seed_graph(tmp_path, fixtures)
     monkeypatch.setenv("LOREKEEP_OUT", str(out))
     monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
     monkeypatch.setenv("LOREKEEP_NS", "teams/backend")
+    # Keep the provider ping offline — this test is about graph/schema/MCP only.
+    monkeypatch.setattr("lorekeep.cli._has_provider", lambda c: False)
     result = runner.invoke(app, ["doctor"])
     assert result.exit_code == 0, result.stdout
     assert "all checks passed" in result.stdout.lower()
@@ -23,3 +32,70 @@ def test_doctor_missing_graph(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["doctor"])
     assert result.exit_code == 1
     assert "facts.jsonl not found" in result.stdout.lower()
+
+
+def test_doctor_pings_provider_when_key_present(tmp_path: Path, fixtures: Path, monkeypatch):
+    out = _seed_graph(tmp_path, fixtures)
+    monkeypatch.setenv("LOREKEEP_OUT", str(out))
+    monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+    monkeypatch.setattr("lorekeep.cli._has_provider", lambda c: True)
+    monkeypatch.setattr("lorekeep.cli._make_provider", lambda c: FakeProvider([]))
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0, result.stdout
+    assert "provider: ok" in result.stdout.lower()
+
+
+def test_doctor_reports_auth_failure(tmp_path: Path, fixtures: Path, monkeypatch):
+    out = _seed_graph(tmp_path, fixtures)
+    monkeypatch.setenv("LOREKEEP_OUT", str(out))
+    monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+
+    class _BadAuth:
+        def ping(self):
+            raise Exception("401 Authentication Error")
+
+    monkeypatch.setattr("lorekeep.cli._has_provider", lambda c: True)
+    monkeypatch.setattr("lorekeep.cli._make_provider", lambda c: _BadAuth())
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 1
+    assert "auth failed" in result.stdout.lower()
+
+
+def test_doctor_reports_model_not_found(tmp_path: Path, fixtures: Path, monkeypatch):
+    out = _seed_graph(tmp_path, fixtures)
+    monkeypatch.setenv("LOREKEEP_OUT", str(out))
+    monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+
+    class _BadModel:
+        def ping(self):
+            raise Exception("NotFoundError: model not found")
+
+    monkeypatch.setattr("lorekeep.cli._has_provider", lambda c: True)
+    monkeypatch.setattr("lorekeep.cli._make_provider", lambda c: _BadModel())
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 1
+    assert "model not found" in result.stdout.lower()
+
+
+def test_doctor_skips_ping_when_no_key(tmp_path: Path, fixtures: Path, monkeypatch):
+    out = _seed_graph(tmp_path, fixtures)
+    monkeypatch.setenv("LOREKEEP_OUT", str(out))
+    monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+    monkeypatch.setattr("lorekeep.cli._has_provider", lambda c: False)
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0, result.stdout
+    assert "provider: skipped" in result.stdout.lower()
+
+
+def test_doctor_reports_bare_model_as_problem(tmp_path: Path, fixtures: Path, monkeypatch):
+    """A bare model name is reported as a problem, not a crash."""
+    out = _seed_graph(tmp_path, fixtures)
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("provider:\n  model: deepseek-chat\n")
+    monkeypatch.setenv("LOREKEEP_OUT", str(out))
+    monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+    monkeypatch.setenv("LOREKEEP_CONFIG", str(cfg))
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 1
+    assert "provider config" in result.stdout.lower()
+    assert "deepseek/deepseek-chat" in result.stdout

--- a/tests/test_enhancements.py
+++ b/tests/test_enhancements.py
@@ -148,6 +148,21 @@ class TestConfigCLI:
         data = yaml.safe_load(config.read_text())
         assert data["provider"]["model"] == "deepseek/deepseek-chat"
 
+    def test_config_set_rejects_bare_model(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        config = home / "config.yaml"
+        config.write_text("provider:\n  model: openai/gpt-4o\n")
+
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        from lorekeep.cli import app
+        result = runner.invoke(app, ["config", "set", "provider.model", "deepseek-chat"])
+        assert result.exit_code == 1
+        assert "deepseek/deepseek-chat" in result.output  # suggestion surfaced
+        # config not clobbered with the invalid value
+        data = yaml.safe_load(config.read_text())
+        assert data["provider"]["model"] == "openai/gpt-4o"
+
     def test_config_set_nested_new_key(self, tmp_path, monkeypatch):
         home = tmp_path / "home"
         home.mkdir()

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -59,7 +59,7 @@ def test_init_interactive(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["init"], input="3\n1\n\n\nmyteam\nAlice\nBuilds backend infra\n")
     assert result.exit_code == 0, result.stdout
     cfg = yaml.safe_load((home / "config.yaml").read_text())
-    assert cfg["provider"]["model"] == "deepseek-chat"
+    assert cfg["provider"]["model"] == "deepseek/deepseek-chat"
     assert cfg["provider"]["api_key"] is None
     assert cfg["provider"]["api_key_env"] == "DEEPSEEK_API_KEY"
     assert cfg["ns"]["default"] == ["myteam"]
@@ -86,7 +86,7 @@ def test_init_interactive_stores_inline_key(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["init"], input="1\n1\nsk-testKEY\nme\nBob\nlocal dev\n")
     assert result.exit_code == 0, result.stdout
     cfg = yaml.safe_load((home / "config.yaml").read_text())
-    assert cfg["provider"]["model"] == "gpt-4o-mini"
+    assert cfg["provider"]["model"] == "openai/gpt-4o-mini"
     assert cfg["provider"]["api_key"] == "sk-testKEY"
     assert cfg["provider"]["api_key_env"] is None
     assert cfg["ns"]["default"] == ["me"]
@@ -115,7 +115,7 @@ def test_init_interactive_ollama_no_key(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["init"], input=inp)
     assert result.exit_code == 0, result.stdout
     cfg = yaml.safe_load((home / "config.yaml").read_text())
-    assert cfg["provider"]["model"] == "llama3.2"
+    assert cfg["provider"]["model"] == "ollama/llama3.2"
     assert cfg["provider"]["api_key"] is None
     assert cfg["ns"]["default"] == ["myproject"]
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -43,3 +43,26 @@ def test_compile_pipeline_produces_facts(tmp_path: Path, fixtures: Path):
     assert (out / "manifest.json").exists()
     assert manifest.node_count == 4
     assert manifest.edge_count == 2
+
+
+def test_pipeline_per_chunk_failure_logs_exception(tmp_path: Path, fixtures: Path, caplog):
+    """A per-chunk failure must be logged (full traceback) for daemon/verbose
+    debugging, while the manifest still records the short message."""
+    import logging as _logging
+    raw = tmp_path / "raw"
+    copy_fixture(fixtures / "raw/backend/payments.md",
+                 raw / "teams/backend/payments.md")
+    schema = Schema.load(json.loads((fixtures / "schema.json").read_text()))
+
+    class _Boom(FakeProvider):
+        def extract_json(self, system, user):
+            raise RuntimeError("LLM Provider NOT provided")
+
+    with caplog.at_level(_logging.ERROR, logger="lorekeep"):
+        manifest = compile_graph(raw_root=raw, out_dir=tmp_path / "graph",
+                                 schema=schema, provider=_Boom(responses=[]),
+                                 cache_path=tmp_path / "cache.json", chunk_lines=60)
+    assert manifest.node_count == 0
+    assert manifest.errors                      # short message preserved
+    assert any("compile: chunk failed" in r.message for r in caplog.records)
+    assert any(r.exc_info for r in caplog.records)  # traceback attached

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -11,6 +11,8 @@ from lorekeep.providers import (
     format_cost,
     is_dynamic,
     search_providers,
+    suggest_model_prefix,
+    validate_model_prefix,
     DYNAMIC_PROVIDERS,
 )
 
@@ -212,3 +214,64 @@ class TestListModelsNormalization:
         assert all("/" in m for m in ids), f"non-prefixed model: {ids}"
         assert "deepseek/deepseek-v4-flash" in ids
         assert "deepseek/deepseek-chat" in ids
+
+
+class TestSuggestModelPrefix:
+    """``suggest_model_prefix`` returns the canonical prefixed form for known
+    unambiguous bare names, else None (don't guess)."""
+
+    def test_deepseek_chat(self):
+        assert suggest_model_prefix("deepseek-chat") == "deepseek/deepseek-chat"
+
+    def test_deepseek_reasoner(self):
+        assert suggest_model_prefix("deepseek-reasoner") == "deepseek/deepseek-reasoner"
+
+    def test_gpt_4o_mini(self):
+        assert suggest_model_prefix("gpt-4o-mini") == "openai/gpt-4o-mini"
+
+    def test_claude_sonnet_4(self):
+        assert suggest_model_prefix("claude-sonnet-4-20250514") == "anthropic/claude-sonnet-4-20250514"
+
+    def test_already_prefixed_returns_none(self):
+        assert suggest_model_prefix("openai/gpt-4o-mini") is None
+
+    def test_unknown_returns_none(self):
+        assert suggest_model_prefix("some-custom-model") is None
+
+    def test_qwen_ambiguous_returns_none(self):
+        # qwen-* is ambiguous (DashScope openai/ + api_base vs native dashscope/)
+        assert suggest_model_prefix("qwen-plus") is None
+
+
+class TestValidateModelPrefix:
+    """``validate_model_prefix`` enforces ``{provider}/{model}`` with a suggestion."""
+
+    def test_prefixed_passes(self):
+        validate_model_prefix("deepseek/deepseek-chat")  # no raise
+        validate_model_prefix("openai/gpt-4o-mini")
+        validate_model_prefix("anthropic/claude-sonnet-4-20250514")
+
+    def test_bare_deepseek_raises_with_suggestion(self):
+        with pytest.raises(ValueError) as ei:
+            validate_model_prefix("deepseek-chat")
+        assert "deepseek/deepseek-chat" in str(ei.value)
+
+    def test_bare_gpt_suggests_openai(self):
+        with pytest.raises(ValueError) as ei:
+            validate_model_prefix("gpt-4o-mini")
+        assert "openai/gpt-4o-mini" in str(ei.value)
+
+    def test_unknown_bare_raises_with_rule(self):
+        with pytest.raises(ValueError) as ei:
+            validate_model_prefix("totally-unknown-model")
+        msg = str(ei.value)
+        assert "totally-unknown-model" in msg
+        assert "{provider}/{model}" in msg  # rule explained with template
+
+    def test_qwen_bare_raises_without_guessing_prefix(self):
+        # ambiguous: must NOT silently suggest a wrong prefix
+        with pytest.raises(ValueError) as ei:
+            validate_model_prefix("qwen-plus")
+        msg = str(ei.value)
+        assert "dashscope/qwen-plus" not in msg
+        assert "openai/qwen-plus" not in msg


### PR DESCRIPTION
## Why

A real incident (2026-07-18): a `config.yaml` with a bare model name (`deepseek-chat`, no `provider/` prefix), `null` `api_base`, and a fictional model produced **0 facts** with no clear error. `lorekeep doctor` reported green (it never tested the provider); the user found the cause only by reading `manifest.json` by hand.

Root causes:
1. `provider.backend` is a **dead field** (0 runtime reads — litellm routes by the `model` prefix). Source of the "what is `backend=openai` for?" confusion.
2. **No model-prefix validation** at any load/build/set point — a bare name fails deep inside litellm as `LLM Provider NOT provided` with no config context.
3. Default `model="gpt-4o-mini"` had no prefix (broken-by-default).
4. **Errors swallowed silently** — `pipeline.py` bare-except → manifest only; `_report_compile_errors` loud only on total failure; daemon path silent.
5. `doctor` never tested the LLM.
6. Docs contradicted on DeepSeek (`openai/deepseek-v4-flash`+api_base vs `deepseek/deepseek-chat`).
7. `PROVIDER_PRESETS` was dead code.

## Changes

- **`validate_model_prefix` + `suggest_model_prefix`** (`providers.py`) — single source of truth. Bare names fail fast with a `Did you mean …?` suggestion. `qwen-*` intentionally not aliased (ambiguous).
- **`config.py`** — drop `backend`; default model `openai/gpt-4o-mini`; `load_config` **eagerly** validates the prefix (every command fails fast with a suggestion; `config show` stays safe — reads raw text; `doctor` catches + reports, never crashes). Legacy `backend:` lines silently ignored (pydantic extra=ignore) — no migration.
- **`compile/providers.py`** — `ping()` on the protocol + `LiteLLMProvider` (one ~5-token `complete`) + `FakeProvider` (returns `OK` without consuming the response queue, so compile tests stay exact).
- **`cli.py`** — `doctor` pings the provider when a key is present (classifies AUTH FAILED / MODEL NOT FOUND / ENDPOINT UNREACHABLE; `LOREKEEP_DOCTOR_NO_PING=1` opt-out; skipped-with-note when no key); `config set provider.model` validates before writing; `_interactive_init` prefixes a bare model with the selected provider; `_write_config` drops `backend`; `_report_compile_errors` logs every error + surfaces all when ≥3 chunks fail identically.
- **`pipeline.py`** — `log.exception` at the catch site (full traceback to `agent.log`); manifest keeps the short message. No change to skip-and-log semantics or determinism.
- **`defaults.py`** — delete dead `PROVIDER_PRESETS`; drop `backend` from `DEFAULT_CONFIG_YAML`.
- **Docs** — `config.yaml.example` (explain the prefix rule, correct native DeepSeek option, soften stale key header); `getting-started.md` (native `deepseek/deepseek-chat`, fix the wrong cache-key note, point 0-node compiles at `doctor`); `compile.md` (drop `backend: ollama`); `README.md` (annotate prefix rule).

## Determinism / cache note

Cache key (`extract.py`) = `sha256(schema_version + model + chunk_hash)`. Already-valid prefixed configs: stored `model` unchanged → cache keys identical → zero re-extraction (`test_determinism.py` holds). The default-model fix only affects the no-config fallback. Bare→prefixed changes the key, but a bare model had no successful cache entries anyway.

## Tests

New (all offline, FakeProvider-only):
- `test_providers.py` — `TestSuggestModelPrefix`, `TestValidateModelPrefix`
- `test_config.py` — bare-model rejection, prefixed acceptance, legacy-backend silently dropped
- `test_doctor_cli.py` — ping OK / AUTH FAILED / MODEL NOT FOUND / skipped-no-key / bare-model-as-problem
- `test_compile_cli.py` — bare-model rejection before litellm (incident regression); systemic partial-error surfacing
- `test_enhancements.py` — `config set` rejects bare model
- `test_pipeline.py` — per-chunk failure logs traceback (caplog)

## Verification

- `test_core_regression.py` + `test_determinism.py` — 28 green (unchanged).
- Full suite: 493 passed. 7 failures are **pre-existing / environment**, confirmed on the baseline branch: 6 `test_init_cli.py` (agent-detection assertions fail because Claude Code/Cursor are installed on this machine) + 1 `test_watch_sessions.py` (`timeout` binary absent on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)