### PR TITLE
chore: sync uv.lock to v0.11.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1030,7 +1030,7 @@ wheels = [
 
 [[package]]
 name = "lorekeep"
-version = "0.11.3"
+version = "0.11.4"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Auto-synced after release.