### PR TITLE
fix: treat api_base as advanced — native providers need none

### DIFF
--- a/.lorekeep/config.yaml.example
+++ b/.lorekeep/config.yaml.example
@@ -2,16 +2,18 @@
 #
 # The model string MUST be '{provider}/{model}' — litellm routes by the prefix:
 #   openai/gpt-4o-mini, anthropic/claude-sonnet-4-20250514, deepseek/deepseek-chat,
-#   ollama/llama3. Native providers (openai, anthropic, deepseek) need NO api_base.
-#   OpenAI-compatible endpoints (DashScope, Ollama) set api_base AND use the openai/ prefix.
+#   dashscope/qwen-plus, ollama/llama3.
+# Native providers (openai, anthropic, deepseek, dashscope, gemini, ...) need NO
+# api_base — litellm already knows the endpoint. Set api_base ONLY for a custom
+# OpenAI-compatible endpoint (vllm, lm_studio, a proxy/gateway, or Ollama on a
+# non-default host); see Option E.
 #
 # API keys: prefer api_key_env (name of an env var you export). An inline api_key is
 # also accepted since this file is gitignored — but never commit it.
 #
-# Option A: Alibaba ModelStudio / DashScope (international, OpenAI-compatible)
+# Option A: Alibaba ModelStudio / DashScope (native litellm provider — no api_base)
 provider:
-  model: openai/qwen-plus                          # qwen-max | qwen-plus | qwen-turbo
-  api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+  model: dashscope/qwen-plus                        # qwen-max | qwen-plus | qwen-turbo
   api_key_env: DASHSCOPE_API_KEY                   # export DASHSCOPE_API_KEY=...
   temperature: 0.0
 #
@@ -28,10 +30,18 @@ provider:
 #   api_key_env: DEEPSEEK_API_KEY
 #   temperature: 0.0
 #
-# Option D: Ollama (local, strict privacy)
+# Option D: Ollama (local, strict privacy — default http://localhost:11434)
+#   set api_base only if your Ollama runs on a different host/port
 # provider:
 #   model: ollama/llama3
-#   api_base: http://localhost:11434
+#   temperature: 0.0
+#
+# Option E: custom OpenAI-compatible endpoint (vllm / lm_studio / proxy / gateway)
+#   this is the one case api_base is required
+# provider:
+#   model: openai/your-model
+#   api_base: https://your-gateway.example.com/v1
+#   api_key_env: YOUR_GATEWAY_KEY
 #   temperature: 0.0
 compile:
   chunk_lines: 60

--- a/README.md
+++ b/README.md
@@ -198,14 +198,17 @@ Every result is filtered to the caller's namespace. Write tools append to `pendi
 dev marker > XDG):
 ```yaml
 provider:
-  model: openai/qwen-plus                              # {provider}/{model} — litellm routes by prefix
-  api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+  model: dashscope/qwen-plus                           # {provider}/{model} — litellm routes by prefix
   api_key_env: DASHSCOPE_API_KEY                       # env var name (preferred)
   api_key: null                                        # or inline (gitignored config only)
 ns:
   default: [public]
 install_source: pypi                                   # pypi = portable .mcp.json
 ```
+Native providers (`openai`, `anthropic`, `deepseek`, `dashscope`, `gemini`, …)
+need **no** `api_base` — litellm knows their endpoint. Set `api_base` only for a
+custom OpenAI-compatible endpoint (vllm, lm_studio, a proxy/gateway, or Ollama on
+a non-default host).
 API keys never live in committed files — use `api_key_env` (env) or inline
 `api_key` in the gitignored config only. Examples (DashScope / OpenAI / Ollama)
 in [`.lorekeep/config.yaml.example`](.lorekeep/config.yaml.example).

--- a/docs/guides/compile.md
+++ b/docs/guides/compile.md
@@ -17,15 +17,14 @@ The first directory under `raw/` becomes the fact's `ns` (e.g. `backend`, `front
 
 ```bash
 cp .lorekeep/config.yaml.example .lorekeep/config.yaml
-# edit model / api_base as needed
+# edit model as needed (native providers need no api_base)
 ```
 
 For strict privacy, use a local model:
 
 ```yaml
 provider:
-  model: ollama/llama3
-  api_base: http://localhost:11434
+  model: ollama/llama3                      # default http://localhost:11434; set api_base only for a non-default host
 ```
 
 ## 3. Compile

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -106,9 +106,11 @@ provider:
 
 The model string must be `{provider}/{model}` (e.g. `openai/gpt-4o-mini`,
 `anthropic/claude-sonnet-4-20250514`, `deepseek/deepseek-chat`,
-`ollama/llama3`). Native providers (`openai`, `anthropic`, `deepseek`) need no
-`api_base`; OpenAI-compatible endpoints (DashScope, Ollama) set `api_base` and
-use the `openai/` prefix. A bare name like `deepseek-chat` is rejected with a
+`dashscope/qwen-plus`, `ollama/llama3`). Native providers (`openai`,
+`anthropic`, `deepseek`, `dashscope`, `gemini`, …) need **no** `api_base` —
+litellm already knows their endpoint. Set `api_base` only for a custom
+OpenAI-compatible endpoint (vllm, lm_studio, a proxy/gateway, or Ollama on a
+non-default host). A bare name like `deepseek-chat` is rejected with a
 suggestion — `lorekeep doctor` will tell you exactly what's wrong.
 
 Prefer an env var instead? Set `api_key_env: DEEPSEEK_API_KEY` (and

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -15,7 +15,7 @@ from lorekeep.models import now_iso
 from lorekeep.pipeline import compile_graph
 from lorekeep.paths import resolve_paths
 from lorekeep.defaults import DEFAULT_CONFIG_YAML, DEFAULT_SCHEMA
-from lorekeep.providers import validate_model_prefix
+from lorekeep.providers import NATIVE_PROVIDERS, model_provider, validate_model_prefix
 from lorekeep.schema_io import load_schema
 
 log = logging.getLogger("lorekeep")
@@ -550,6 +550,18 @@ def doctor() -> None:
     except Exception as exc:
         problems.append(f"mcp configure/tool failed: {exc}")
         ns = []
+
+    # Hint: api_base is redundant for native providers — litellm already knows
+    # their endpoint. Surfaced as a non-fatal note (a user may intentionally
+    # point a native provider at a mirror/proxy).
+    if config.provider.api_base:
+        prefix = model_provider(config.provider.model)
+        if prefix in NATIVE_PROVIDERS:
+            notes.append(
+                f"provider: hint — api_base set for {prefix}/, but litellm "
+                "already knows this endpoint; usually unnecessary (only "
+                "vllm/lm_studio/proxies/non-default-ollama need api_base)."
+            )
 
     # Provider connectivity probe — catches the most common breakage (bad
     # model/api_base/api_key) that a graph/schema check alone misses.

--- a/src/lorekeep/providers.py
+++ b/src/lorekeep/providers.py
@@ -82,10 +82,7 @@ def _normalize_model_name(name: str, provider: str) -> str:
 
 
 # Bare model names mapped to their canonical ``{provider}/{model}`` form, used
-# only to *suggest* a fix when a user writes an unambiguous bare name. Kept
-# conservative: ``qwen-*`` is intentionally absent (DashScope uses ``openai/`` +
-# ``api_base`` while native litellm uses ``dashscope/`` — ambiguous, so we emit
-# the rule instead of guessing).
+# only to *suggest* a fix when a user writes an unambiguous bare name.
 _BARE_ALIASES: dict[str, str] = {
     "deepseek-chat": "deepseek/deepseek-chat",
     "deepseek-reasoner": "deepseek/deepseek-reasoner",
@@ -98,6 +95,10 @@ _BARE_ALIASES: dict[str, str] = {
     "claude-3-5-sonnet-20241022": "anthropic/claude-3-5-sonnet-20241022",
     "claude-3-haiku-20240307": "anthropic/claude-3-haiku-20240307",
     "claude-3-opus-20240229": "anthropic/claude-3-opus-20240229",
+    # qwen-* → native dashscope/ (litellm knows the endpoint; no api_base)
+    "qwen-plus": "dashscope/qwen-plus",
+    "qwen-max": "dashscope/qwen-max",
+    "qwen-turbo": "dashscope/qwen-turbo",
 }
 
 
@@ -134,6 +135,25 @@ def validate_model_prefix(model: str) -> None:
         "'anthropic/claude-sonnet-4-20250514', 'deepseek/deepseek-chat', "
         "'ollama/llama3'."
     )
+
+
+def model_provider(model: str) -> str:
+    """Return the ``{provider}`` prefix of a litellm model string.
+
+    ``"dashscope/qwen-plus"`` → ``"dashscope"``. Splits on the first ``/`` only,
+    so model names containing a later ``/`` are handled.
+    """
+    return model.split("/", 1)[0]
+
+
+# Providers litellm knows the endpoint for — no ``api_base`` needed. Everything
+# in :data:`DYNAMIC_PROVIDERS` (ollama, vllm, lm_studio, …) and custom
+# OpenAI-compatible gateways legitimately takes an ``api_base``.
+NATIVE_PROVIDERS: set[str] = {
+    "openai", "anthropic", "deepseek", "dashscope", "gemini",
+    "mistral", "groq", "openrouter", "together_ai", "xai",
+    "perplexity", "cohere", "ai21",
+}
 
 
 

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -152,3 +152,40 @@ class TestProviderPing:
     def test_litellm_provider_has_ping(self):
         from lorekeep.compile.providers import LiteLLMProvider
         assert callable(getattr(LiteLLMProvider, "ping", None))
+
+
+class TestDoctorApiBaseHint:
+    """api_base is redundant for native providers — doctor warns (non-fatal)."""
+
+    def test_warns_api_base_on_native_provider(self, tmp_path: Path, fixtures: Path, monkeypatch):
+        out = _seed_graph(tmp_path, fixtures)
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "provider:\n"
+            "  model: dashscope/qwen-plus\n"
+            "  api_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1\n"
+        )
+        monkeypatch.setenv("LOREKEEP_OUT", str(out))
+        monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+        monkeypatch.setenv("LOREKEEP_CONFIG", str(cfg))
+        monkeypatch.setattr("lorekeep.cli._has_provider", lambda c: False)  # skip ping
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0, result.stdout
+        assert "api_base" in result.stdout.lower()
+        assert "dashscope" in result.stdout
+
+    def test_no_api_base_hint_for_dynamic_ollama(self, tmp_path: Path, fixtures: Path, monkeypatch):
+        out = _seed_graph(tmp_path, fixtures)
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "provider:\n"
+            "  model: ollama/llama3\n"
+            "  api_base: http://localhost:11434\n"
+        )
+        monkeypatch.setenv("LOREKEEP_OUT", str(out))
+        monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+        monkeypatch.setenv("LOREKEEP_CONFIG", str(cfg))
+        monkeypatch.setattr("lorekeep.cli._has_provider", lambda c: False)
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0, result.stdout
+        assert "api_base" not in result.stdout.lower()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -7,9 +7,11 @@ import pytest
 
 from lorekeep.providers import (
     ModelInfo,
+    NATIVE_PROVIDERS,
     _normalize_model_name,
     format_cost,
     is_dynamic,
+    model_provider,
     search_providers,
     suggest_model_prefix,
     validate_model_prefix,
@@ -238,9 +240,12 @@ class TestSuggestModelPrefix:
     def test_unknown_returns_none(self):
         assert suggest_model_prefix("some-custom-model") is None
 
-    def test_qwen_ambiguous_returns_none(self):
-        # qwen-* is ambiguous (DashScope openai/ + api_base vs native dashscope/)
-        assert suggest_model_prefix("qwen-plus") is None
+    def test_qwen_plus_suggests_dashscope(self):
+        # native dashscope/ is the recommended form → qwen-* is unambiguous now
+        assert suggest_model_prefix("qwen-plus") == "dashscope/qwen-plus"
+
+    def test_qwen_max_suggests_dashscope(self):
+        assert suggest_model_prefix("qwen-max") == "dashscope/qwen-max"
 
 
 class TestValidateModelPrefix:
@@ -268,10 +273,36 @@ class TestValidateModelPrefix:
         assert "totally-unknown-model" in msg
         assert "{provider}/{model}" in msg  # rule explained with template
 
-    def test_qwen_bare_raises_without_guessing_prefix(self):
-        # ambiguous: must NOT silently suggest a wrong prefix
+    def test_qwen_bare_raises_with_dashscope_suggestion(self):
+        # native dashscope/ recommended → suggest it
         with pytest.raises(ValueError) as ei:
             validate_model_prefix("qwen-plus")
-        msg = str(ei.value)
-        assert "dashscope/qwen-plus" not in msg
-        assert "openai/qwen-plus" not in msg
+        assert "dashscope/qwen-plus" in str(ei.value)
+
+
+class TestModelProvider:
+    """``model_provider`` extracts the ``{provider}`` prefix."""
+
+    def test_dashscope(self):
+        assert model_provider("dashscope/qwen-plus") == "dashscope"
+
+    def test_openai(self):
+        assert model_provider("openai/gpt-4o-mini") == "openai"
+
+    def test_only_first_slash(self):
+        # model names can contain '/' after the provider (rare) — only split once
+        assert model_provider("openai/org/model") == "openai"
+
+
+class TestNativeProviders:
+    """NATIVE_PROVIDERS = providers litellm knows the endpoint for (no api_base).
+    Dynamic providers (free-text endpoints) must be excluded."""
+
+    def test_native_includes_common(self):
+        for p in ("openai", "anthropic", "deepseek", "dashscope", "gemini"):
+            assert p in NATIVE_PROVIDERS, p
+
+    def test_native_excludes_dynamic(self):
+        # these legitimately take an api_base
+        for p in ("ollama", "vllm", "lm_studio", "openai_compat"):
+            assert p not in NATIVE_PROVIDERS, p


### PR DESCRIPTION
## Why

Follow-up to #118. `api_base` is **redundant** for every native provider — litellm already knows their endpoint. It's only needed for custom/dynamic endpoints litellm doesn't know. But the shipped example showed `openai/qwen-plus` + `api_base` for DashScope (unnecessary — `dashscope/` is native with 34 models) and set `api_base` for default-local Ollama (litellm bakes in `http://localhost:11434`).

Confirmed against litellm (catalog):
- **Native (no `api_base`):** `openai`, `anthropic`, `deepseek`, **`dashscope`**, `gemini`, `mistral`, `groq`, `ollama` (default host), `openrouter`, `together_ai`.
- **Needs `api_base`:** `vllm`, `lm_studio`, `openai_compat`, custom proxies/gateways, Ollama on a non-default host.

## Changes

- **`providers.py`** — `NATIVE_PROVIDERS` (curated set; excludes `DYNAMIC_PROVIDERS`), `model_provider(model)` (prefix helper), and `qwen-plus/max/turbo` → `dashscope/<name>` aliases (now unambiguous since native `dashscope/` is recommended).
- **`cli.py`** — `doctor` emits a **non-fatal hint** when `api_base` is set and the model prefix is native: *"api_base set for {prefix}/, but litellm already knows this endpoint; usually unnecessary"*. Dynamic providers and custom gateways are unaffected. Exit 0 (guidance, not a block).
- **Docs/example** — `config.yaml.example` Option A is now native `dashscope/qwen-plus` (no `api_base`); Ollama option drops `api_base`; new **Option E** documents the one case `api_base` is required (custom OpenAI-compatible endpoint). README config block + getting-started + compile.md updated to the native form.

## Tests (offline, FakeProvider-only)
- `test_providers.py` — `TestModelProvider`, `TestNativeProviders`, qwen → dashscope suggestions.
- `test_doctor_cli.py` — `TestDoctorApiBaseHint`: hint fires for `dashscope/`+api_base; **no** hint for `ollama/`+api_base (dynamic).

## Verification
- `test_providers` + `test_doctor_cli` + `test_config` + `test_core_regression` + `test_determinism`: **89 passed**.
- Manual smoke: `LOREKEEP_DOCTOR_NO_PING=1 lorekeep doctor` on the repo config (`openai/deepseek-v4-flash` + `api_base`) → hint fires correctly. (That config could itself simplify to native `deepseek/deepseek-v4-flash` — the hint nudges toward it.)
- Optional: `dashscope/qwen-plus` + `DASHSCOPE_API_KEY` end-to-end (catalog confirms 34 models).

## Risk
A user may intentionally point a native provider at a mirror/proxy (e.g. `openai/` at a gateway). The hint is non-fatal (exit 0) — guidance, not a block. Ollama is excluded from the native set since `api_base` is commonly set for it; a wrong-host is still caught by the existing ENDPOINT UNREACHABLE classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)