### PR TITLE
ci: merge-commit for release + uv.lock PRs (--squash -> --merge)

### DIFF
--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -22,6 +22,6 @@ jobs:
     steps:
       - name: Enable auto-merge for Release PR
         run: |
-          gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+          gh pr merge --auto --merge "${{ github.event.pull_request.html_url }}"
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -99,7 +99,7 @@ jobs:
             --base main \
             --head chore/sync-uv-lock-${{ needs.release-please.outputs.tag_name }}
           sleep 3
-          gh pr merge --squash --auto --delete-branch \
+          gh pr merge --merge --auto --delete-branch \
             chore/sync-uv-lock-${{ needs.release-please.outputs.tag_name }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Part 2 of the merge-commit switch. Aligns the two automated-merge sites with the policy set in #131:

- `release-please.yml`: post-release uv.lock sync PR → `--merge`
- `auto-merge-release-please.yml`: release-please Release PR → `--merge`

Repo settings already disable squash + rebase (#131 work). After this, no path uses squash.

Needs `workflow` scope to push (hence separate from the docs PR).