### PR TITLE
feat: ontology v2 — subject-aware knowledge graph (personal + team)

### DIFF
--- a/.lorekeep/config.yaml.example
+++ b/.lorekeep/config.yaml.example
@@ -46,5 +46,6 @@ provider:
 compile:
   chunk_lines: 60
 ns:
-  default: [public]
+  default: [me]
+  personal: me
 install_source: pypi                              # pypi (portable .mcp.json) | local | git+URL | path

--- a/.lorekeep/schema.json
+++ b/.lorekeep/schema.json
@@ -1,26 +1,42 @@
 {
-  "version": 2,
+  "version": 3,
   "node_types": {
-    "service": {"props": {"name": "string", "lang": "string"}},
-    "team": {"props": {"name": "string"}},
-    "decision": {"props": {"title": "string"}},
-    "project": {"props": {"name": "string", "status": "string"}},
-    "person": {"props": {"name": "string", "role": "string"}},
-    "tool": {"props": {"name": "string", "category": "string"}},
-    "command": {"props": {"name": "string", "platform": "string"}},
-    "concept": {"props": {"name": "string", "domain": "string"}},
-    "note": {"props": {"title": "string", "topic": "string"}},
+    "person": {"props": {"name": "string", "handle": "string", "org": "string"}},
+    "role": {"props": {"name": "string", "domain": "string"}},
+    "skill": {"props": {"name": "string", "domain": "string", "level": "string"}},
+    "domain": {"props": {"name": "string", "description": "string"}},
+    "preference": {"props": {"name": "string", "description": "string"}},
+    "value": {"props": {"name": "string", "description": "string"}},
+    "goal": {"props": {"title": "string", "timeframe": "string", "status": "string"}},
+    "service": {"props": {"name": "string", "lang": "string", "status": "string"}},
+    "project": {"props": {"name": "string", "status": "string", "start_date": "string"}},
+    "decision": {"props": {"title": "string", "status": "string", "decided_on": "string"}},
+    "team": {"props": {"name": "string", "org": "string"}},
     "document": {"props": {"title": "string", "kind": "string"}}
   },
   "edge_types": {
     "depends_on": {"from": "service", "to": "service"},
-    "decided_by": {"from": "decision", "to": "team"},
-    "owns": {"from": "team", "to": "service"},
     "part_of": {"from": "service", "to": "project"},
-    "uses": {"from": "service", "to": "tool"},
-    "mentions": {"from": "note", "to": "concept"},
-    "documents": {"from": "document", "to": "concept"},
-    "describes": {"from": "note", "to": "service"},
-    "relates_to": {"from": "concept", "to": "concept"}
+    "decided_by": {"from": "decision", "to": ["person", "team"]},
+    "owns": {"from": ["person", "team"], "to": "service"},
+    "contributes_to": {"from": "person", "to": "project"},
+    "works_on": {"from": "person", "to": "project"},
+    "has_role": {"from": "person", "to": "role"},
+    "has_skill": {"from": "person", "to": "skill"},
+    "in_domain": {"from": ["role", "skill"], "to": "domain"},
+    "pursues": {"from": "person", "to": "goal"},
+    "holds_value": {"from": "person", "to": "value"},
+    "member_of": {"from": "person", "to": "team"},
+    "is_a": {"from": "service", "to": "domain"},
+    "collaborates_with": {"from": "person", "to": "person"},
+    "prefers": {"from": "person", "to": "preference"},
+    "relates_to": {
+      "from": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"],
+      "to": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"]
+    },
+    "documents": {
+      "from": "document",
+      "to": ["service", "project", "decision", "domain"]
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -2,28 +2,33 @@
 
 <p align="center"><img src="cover.jpeg" alt="Lorekeep" /></p>
 
-**A temporal knowledge graph for AI agents, over MCP — agents read at query time and propose facts at runtime through journal-based write tools.**
+**A second brain for code — a temporal knowledge graph that aggregates what you and your agents learn across devices, the services you build, and your team, over MCP. Agents read at query time and propose facts at runtime through journal-based write tools.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Lorekeep compiles a team's raw docs into a temporal knowledge graph (`facts.jsonl`),
-serves it to coding agents (Claude Code, Cursor, Codex, opencode) over MCP, and
-lets agents propose new facts at zero LLM cost. Knowledge is processed once at
-compile time, not re-RAG'd per query.
+Lorekeep is a **second brain**: every coding agent you run (Claude Code, Cursor,
+Codex, opencode) reads from and contributes to one knowledge graph; every device
+stays in sync; the software you build and operate feeds back in; and your team
+shares the parts that matter. Under the hood it compiles raw docs + agent
+contributions into a temporal knowledge graph (`facts.jsonl`) served over MCP.
+Knowledge is processed once, not re-RAG'd per query.
 
 ---
 
 ## Why
 
-| | file-based | temporal KG | compile step | team permission | MCP |
-|---|---|---|---|---|---|
-| Obsidian + MCP | ✅ | ❌ | ❌ | ❌ | ✅ |
-| mcp-knowledge-graph | ✅ | ❌ | ❌ | ❌ (local) | ✅ |
-| mem0 / cognee | ❌ (DB) | partial | ❌ | partial (DB) | ✅ |
+A second brain for code has to pull from many sources — your coding agents, your
+devices, the services you operate, your team — and stay coherent as it grows.
+Most tools cover one slice:
 
-No tool combines all five. Lorekeep does: **file-based + temporal graph +
-compile-once + namespace permission + MCP** — for team-level knowledge, not
-just single-user.
+| | file-based | temporal KG | compile step | team permission | agent + device + software sources | MCP |
+|---|---|---|---|---|---|---|
+| Obsidian + MCP | ✅ | ❌ | ❌ | ❌ | ❌ (manual) | ✅ |
+| mcp-knowledge-graph | ✅ | ❌ | ❌ | ❌ (local) | ❌ | ✅ |
+| mem0 / cognee | ❌ (DB) | partial | ❌ | partial (DB) | partial | ✅ |
+
+No tool combines all six. Lorekeep does: **file-based + temporal graph +
+compile-once + namespace permission + multi-source (agents/devices/software/team) + MCP**.
 
 ## Features
 
@@ -328,9 +333,9 @@ docs/                  README.md index, architecture/, guides/
 
 ## Status
 
-**v1 (implemented)** — compile pipeline + serve (store/permission/MCP 9 read+5 write/4-agent integrations) + import (Claude/Cursor/Codex/opencode) + session-end hooks + agent daemon (watch/ingest/lint/suggest/status) + journal + resolve + data-home + dev mode + lazy-reload + backup + eval + scope awareness (`meta` tool) + **wiki** (Obsidian-compatible markdown output). Published to PyPI as `lorekeep`.
+**v1 (implemented)** — the second-brain foundation: compile pipeline + serve (store/permission/MCP 9 read+5 write/4-agent integrations) + import (Claude/Cursor/Codex/opencode) + session-end hooks + agent daemon (watch/ingest/lint/suggest/status) + journal + resolve + data-home + dev mode + lazy-reload + backup + eval + scope awareness (`meta` tool) + **subject-aware ontology v2** (personal `me` ns + team ns + cross-ns edges) + **Obsidian/Tolaria wiki** + profile/contribution commands. Published to PyPI as `lorekeep`.
 
-**Phase 2 (planned)** — streamable-HTTP team server, OIDC/SSO, embeddings/hybrid search, scheduled nightly lint/suggest in daemon, schema evolve, HotpotQA/CronQuestions/LongMemEval benchmark datasets and the bespoke Tier-3 Lorekeep-Reason eval.
+**Next** — the second-brain direction is multi-faceted: multi-agent concurrency, multi-device sync, software-source connectors, a proactive agent, a team server, better retrieval. See the full **[Roadmap](docs/ROADMAP.md)**.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ just single-user.
 - **Obsidian + Tolaria wiki** — auto-generated after every compile/resolve: flat
   markdown pages with `[[wikilinks]]`, YAML frontmatter (incl. relationship
   fields), tags. The same `wiki/` folder opens in both Obsidian and Tolaria.
+- **Subject-aware ontology** — work-context node types (person, role, skill,
+  domain, goal, …) + cross-namespace edges (owns, contributes_to, skilled_in)
+  weave your personal knowledge into the team graph. The `me` namespace is
+  subject-centric (altitude rule: tokens → attributes, not nodes).
 - **Lazy-reload** — graph updates visible on next query. Connect once, use forever.
 - **Provider-pluggable extraction** — litellm (OpenAI / Anthropic /
   DashScope/Qwen / Ollama). Strict-privacy → Ollama, fully local.
@@ -121,6 +125,13 @@ The full journey from install to continuous use — see the
 | 7. Keep current | `lorekeep agent watch &` | Daemon: auto-compile, auto-resolve, delta-import sessions |
 | 8. Back up | `lorekeep backup` | Push data home to private git repo (raw/ + schema.json) |
 | 9. Persist daemon | `lorekeep agent daemon install` | Survive restart (systemd/launchd/startup) |
+
+Personal knowledge + team sharing:
+
+| Command | Purpose |
+|---|---|
+| `lorekeep profile [--open]` | Show / open your personal profile source (`raw/<ns>/about.md` + `profile.md`) — edit in Obsidian/Tolaria, then `compile`. |
+| `lorekeep contribution` | Suggest team-knowledge gaps: nodes in your personal ns not yet shared with a team ns. |
 
 Steps 1–6 are one-time setup. Step 7 runs in the background for continuous
 updates. Step 8 syncs across machines.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Lorekeep is a **second brain**: every coding agent you run (Claude Code, Cursor,
-Codex, opencode) reads from and contributes to one knowledge graph; every device
-stays in sync; the software you build and operate feeds back in; and your team
-shares the parts that matter. Under the hood it compiles raw docs + agent
+Codex, opencode) reads from and contributes to one knowledge graph; devices
+rebuild the same graph from Git-synced raw docs, schema, and agent journals; the
+software you build and operate feeds back in; and your team shares the parts
+that matter. Under the hood it compiles raw docs + agent
 contributions into a temporal knowledge graph (`facts.jsonl`) served over MCP.
 Knowledge is processed once, not re-RAG'd per query.
 
@@ -38,8 +39,9 @@ compile-once + namespace permission + multi-source (agents/devices/software/team
 - **Agent-driven knowledge** — agents propose facts at runtime via MCP write
   tools at **zero marginal LLM cost**. Confidence-gated: high-confidence
   auto-merge, low-confidence quarantine.
-- **File-sovereign** — `facts.jsonl` (one fact per line, sorted) is the single
-  source of truth and the sync unit (git or S3). No binary store committed.
+- **File-sovereign** — raw docs + schema + append-only agent journals are the
+  durable, Git-syncable sources. `facts.jsonl` is a deterministic derived store
+  rebuilt on each device; no binary store is committed.
 - **Temporal** — every fact carries `valid_from`/`valid_to` (half-open
   `[from, to)`); query "what was true at *T*", history, diffs.
 - **Namespace permission** — facts are tagged `ns` from the directory tree
@@ -137,6 +139,7 @@ Personal knowledge + team sharing:
 |---|---|
 | `lorekeep profile [--open]` | Show / open your personal profile source (`raw/<ns>/about.md` + `profile.md`) — edit in Obsidian/Tolaria, then `compile`. |
 | `lorekeep contribution` | Suggest team-knowledge gaps: nodes in your personal ns not yet shared with a team ns. |
+| `lorekeep schema upgrade [--dry-run]` | Upgrade the stock ontology v2 schema to v3 with a backup; custom schemas require `--force`. |
 
 Steps 1–6 are one-time setup. Step 7 runs in the background for continuous
 updates. Step 8 syncs across machines.
@@ -219,7 +222,8 @@ provider:
   api_key_env: DASHSCOPE_API_KEY                       # env var name (preferred)
   api_key: null                                        # or inline (gitignored config only)
 ns:
-  default: [public]
+  default: [me]                                      # serve-time default scope
+  personal: me                                       # subject-centric extraction
 install_source: pypi                                   # pypi = portable .mcp.json
 ```
 Native providers (`openai`, `anthropic`, `deepseek`, `dashscope`, `gemini`, …)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,10 @@
 # Lorekeep documentation
 
-Lorekeep builds a **living temporal knowledge graph** that coding agents both **read and contribute to** — served over MCP, with per-namespace permission and zero marginal LLM cost for agent contributions.
+Lorekeep is a **second brain for code**: a living temporal knowledge graph that coding agents both **read and contribute to** — aggregating what you and your agents learn across devices, the services you build, and your team, served over MCP with per-namespace permission and zero marginal LLM cost for agent contributions.
 
 - New here? Start with the **[Getting started guide](guides/getting-started.md)** (install → compile → serve → backup in 10 minutes), or the terse **[Quickstart](../README.md#quickstart)** in the project README.
 - Want the why and how? Read **[Architecture overview](architecture/overview.md)**.
+- Where it's heading? Read the **[Roadmap](ROADMAP.md)** (second-brain direction: multi-agent, multi-device, software connectors, proactive agent, team server, retrieval).
 
 ## Architecture
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,147 @@
+# Roadmap — Lorekeep as a second brain
+
+> Direction, not commitments. No dates. Items move as the product + users learn.
+
+## North star
+
+Lorekeep is a **second brain for code**: one knowledge graph that aggregates what
+you and your coding agents learn, across every device you use, the services you
+build and operate, and your team — and that **grows itself proactively**, not just
+compiles on edit. The payoff: every agent (and you) reasons over the same
+complete, coherent, temporally-correct picture instead of re-reading scattered
+docs or re-deriving context per session.
+
+The second brain has four **touchpoints** that feed it and one **proactive core**
+that keeps it healthy:
+
+| Touchpoint | Feeds the brain from… |
+|---|---|
+| **Many coding agents (parallel)** | Claude Code, Cursor, Codex, opencode — all read + contribute concurrently |
+| **Many devices (simultaneous)** | laptop, desktop, server — same brain, kept in sync |
+| **The software you build/operate** | your microservices' ADRs, runbooks, READMEs, observability, CI |
+| **Team sharing** | personal knowledge shared where it belongs (namespaces + permission) |
+| **Proactive core** | lorekeep reconciles, dedups, fills gaps, surfaces contradictions on its own |
+
+## Shipped (the foundation)
+
+Everything below is implemented today and is what the roadmap builds on:
+
+- **Subject-aware ontology v2** — work-context node types + cross-namespace edges;
+  the `me` namespace is subject-centric (altitude rule: tokens → attributes), team
+  namespaces are entity-centric. ScopedGraph gates visibility per namespace.
+- **MCP, 9 read + 5 write tools** — agents read at query time and propose facts at
+  runtime through journal-based write tools (zero marginal LLM cost).
+- **Three write paths → one resolve** — `raw/` compile, agent propose, session
+  import — converge into a pure-logic resolve step.
+- **4-agent session import + hooks** — Claude / Cursor / Codex / opencode memories
+  → `raw/`; session-end hooks auto-trigger.
+- **Agent daemon** — `agent watch` auto-compiles on raw/ change, auto-resolves
+  pending journals, delta-imports session memory.
+- **Backup + sync unit** — `lorekeep backup` commits `raw/` + schema to a private
+  git repo; `facts.jsonl` is the sync unit (git or S3).
+- **Obsidian/Tolaria wiki** — flat markdown + relationship frontmatter; one vault,
+  both apps.
+- **Profile + contribution** — `profile` (edit your personal source in Obsidian/
+  Tolaria) and `contribution` (what should you share with a team namespace?).
+- **Resolve normalize** — auto-merge duplicate ids (case/separator variants),
+  preserve diacritics.
+
+## Phases
+
+Each phase: **goal**, **why it matters**, **scope**, **non-goals**. Phases are
+directions, not a sequence — several advance in parallel.
+
+### 1. Multi-agent concurrency (hardening)
+
+- **Goal:** many agents proposing facts in parallel never lose or corrupt data.
+- **Why:** you run Claude Code + Cursor + Codex at once; they all write to the same
+  brain.
+- **Scope:** sharper contradiction detection across parallel proposals (beyond the
+  current `flag_contradiction`); agent-identity provenance on every fact; atomic
+  journal appends; deterministic merge under concurrent writes.
+- **Non-goals:** a central server (that's phase 5); real-time co-editing UX.
+- **Builds on:** append-only journal + resolve merge (shipped).
+
+### 2. Multi-device sync
+
+- **Goal:** laptop + desktop edit the same brain simultaneously without clobbering.
+- **Why:** the second brain follows you across machines; sequential pull/push isn't
+  enough when two devices edit concurrently.
+- **Scope:** conflict resolver for simultaneous `facts.jsonl` edits (field-level
+  merge, last-writer-vs-merge policy options); optional central sync server for
+  always-on reconciliation.
+- **Non-goals:** replacing git as the transport (git stays the default).
+- **Builds on:** git backup (`pull --rebase` + push) + facts.jsonl as sync unit.
+- **Honest gap:** today's backup is sequential — concurrent device edits can
+  conflict and need manual resolve.
+
+### 3. Software-source connectors
+
+- **Goal:** lorekeep reads the software you operate, not just docs you hand-write.
+- **Why:** your microservices already hold the truth (ADRs, runbooks, READMEs,
+  service catalog, observability, CI). Ingesting them keeps the brain live.
+- **Scope:** git-repo watch (auto-ingest ADRs/runbooks/READMEs from service repos
+  into the right namespace); observability → facts (e.g. a Signoz MCP feed turning
+  recurring incidents/services into facts); CI status edges. Connectors are
+  read-only ingest, namespace-tagged.
+- **Non-goals:** lorekeep doesn't run your services or own their repos; it mirrors
+  their knowledge into the graph.
+- **Builds on:** `raw/<ns>` ingest + ontology v2 service/project/decision types.
+
+### 4. Proactive agent
+
+- **Goal:** the brain grows and heals itself, not just compiles on edit.
+- **Why:** a second brain that silently drifts is worthless; lorekeep should
+  reconcile, dedup, fill gaps, and surface contradictions on a schedule.
+- **Scope:** scheduled nightly reconcile (dedup, normalize, fill gaps driven by the
+  `contribution` view, surface flagged contradictions for review, auto-enrich from
+  imported sessions). A "what changed + what needs you" digest.
+- **Non-goals:** autonomous fact creation without review (human stays in the loop
+  for low-confidence / contradictory facts).
+- **Builds on:** daemon auto-compile/resolve + `contribution` + `lint`/`suggest`
+  hooks.
+
+### 5. Team server
+
+- **Goal:** share namespaces across an org without each person running their own
+  serve.
+- **Why:** team knowledge needs a shared, authenticated endpoint, not N local MCP
+  servers.
+- **Scope:** streamable-HTTP transport; OIDC/SSO; shared namespace hosting; schema
+  evolution without breaking older clients.
+- **Non-goals:** multi-tenant SaaS (single-org deployment first).
+- **Builds on:** MCP server + ScopedGraph permission (deny-by-default).
+
+### 6. Retrieval quality
+
+- **Goal:** agents query the second brain well — not just keyword `search`.
+- **Why:** as the graph grows, recall + ranking matter for the agent to actually
+  *use* it.
+- **Scope:** embeddings / hybrid (keyword + vector) search; graph-guided retrieval
+  (search → get_node → neighbors); retrieval eval against the existing Tier-1/Tier-2
+  harnesses.
+- **Non-goals:** training models; the graph stays file-based.
+- **Builds on:** FTS5 cache + graph BFS neighbors (shipped).
+
+## How phases relate
+
+```
+touchpoints (feed)            proactive core (heal)         serve (use)
+─────────────────             ────────────────────          ──────────
+1 multi-agent concurrency ─┐
+2 multi-device sync ───────┼──► 4 proactive agent ──► 5 team server ──► 6 retrieval
+3 software connectors ─────┘         (dedup/gap/         (shared ns)      (agents
+                                       contradict)                          query)
+```
+
+Phases 1-3 feed the brain; phase 4 keeps it healthy; phases 5-6 let agents and
+teams use it well. Everything builds on the shipped foundation above.
+
+## References
+
+- [Architecture overview](architecture/overview.md) — compile/serve phases, write
+  paths, the append-and-resolve model.
+- [Agent](architecture/agent.md) — the daemon that phases 3-4 extend.
+- [Permission model](architecture/permission.md) — namespaces + ScopedGraph, the
+  basis for team sharing (phase 5).
+- [Evaluation](architecture/evaluation.md) — the retrieval-quality bar (phase 6).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,8 +37,9 @@ Everything below is implemented today and is what the roadmap builds on:
   → `raw/`; session-end hooks auto-trigger.
 - **Agent daemon** — `agent watch` auto-compiles on raw/ change, auto-resolves
   pending journals, delta-imports session memory.
-- **Backup + sync unit** — `lorekeep backup` commits `raw/` + schema to a private
-  git repo; `facts.jsonl` is the sync unit (git or S3).
+- **Backup + durable sources** — `lorekeep backup` commits `raw/`, schema, and
+  agent journals to a private git repo; each device rebuilds derived
+  `facts.jsonl`.
 - **Obsidian/Tolaria wiki** — flat markdown + relationship frontmatter; one vault,
   both apps.
 - **Profile + contribution** — `profile` (edit your personal source in Obsidian/
@@ -67,11 +68,11 @@ directions, not a sequence — several advance in parallel.
 - **Goal:** laptop + desktop edit the same brain simultaneously without clobbering.
 - **Why:** the second brain follows you across machines; sequential pull/push isn't
   enough when two devices edit concurrently.
-- **Scope:** conflict resolver for simultaneous `facts.jsonl` edits (field-level
-  merge, last-writer-vs-merge policy options); optional central sync server for
-  always-on reconciliation.
+- **Scope:** conflict resolver for simultaneous raw-document edits and journal
+  reconciliation; optional central sync server for always-on reconciliation.
 - **Non-goals:** replacing git as the transport (git stays the default).
-- **Builds on:** git backup (`pull --rebase` + push) + facts.jsonl as sync unit.
+- **Builds on:** git backup (`pull --rebase` + push) + deterministic rebuild
+  from durable sources.
 - **Honest gap:** today's backup is sequential — concurrent device edits can
   conflict and need manual resolve.
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -2,7 +2,9 @@
 
 > Adapted from the original design spec.
 
-The single source of truth is `facts.jsonl`: one fact per line, sorted, byte-stable. Agent-proposed facts accumulate in `pending/` journals and are merged into `facts.jsonl` by a periodic resolve pass. Everything else — `manifest.json`, `schema.json`, the FTS cache — is derived from the store.
+The durable sources of truth are raw docs, `schema.json`, and agent journals.
+`facts.jsonl` is a sorted, byte-stable derived store rebuilt by compile +
+journal replay. `manifest.json`, the wiki, and the FTS cache are also derived.
 
 ## Repository layout
 

--- a/docs/architecture/journal.md
+++ b/docs/architecture/journal.md
@@ -166,9 +166,10 @@ Per-agent write caps prevent journal flooding:
 
 ### Journal storage
 
-`pending/` journals are committed to git for sync, but quarantined entries (confidence < 0.5) have their `fact` content redacted to only `id`, `type`, `agent`, and `proposed_at`. The full fact payload is written to a gitignored `pending/.quarantine/` directory. This prevents quarantined fact content from leaking to anyone with repository access while preserving the audit trail.
-
-Alternatively, `pending/` can be fully gitignored and synced via a separate channel (S3, shared filesystem) — configurable per deployment.
+`pending/` journals are committed to the configured private backup repository
+so accepted agent facts can be replayed on another device. Journal payloads may
+contain sensitive context, including quarantined proposals; the backup remote
+must therefore remain private. Selective redaction/encryption is future work.
 
 ## Related
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -85,7 +85,7 @@ The system has three write paths feeding into a single resolve step, then a read
 | D5 | Python + FastMCP | Richest LLM/markdown/MCP ecosystem; compile-heavy logic favors Python. |
 | D6 | Mid-org target (≈5k facts, 5–15 teams) | Karpathy sweet-spot; FTS/grep sufficient, no embeddings needed yet. |
 | D7 | Temporal knowledge graph | Facts carry `valid_from`/`valid_to`; supports "what was true at T", history, diffs. |
-| D8 | `facts.jsonl` as store + sync unit | Plain text, line-based git diffs, S3-streamable; no binary store committed. |
+| D8 | Durable sources as sync unit | Git syncs raw docs, schema, and agent journals; each device deterministically rebuilds `facts.jsonl`. |
 | D9 | Query via networkx in-memory; optional local FTS cache | Store is the sync unit; no rebuild-on-sync; cache is local-only, derived. |
 | D10 | stdio-first transport | Every coding agent spawns the local server reading the repo's `facts.jsonl`; zero servers, max privacy. |
 | D11 | Extract LLM pluggable, default API, ollama option | Quality by default; data leaves only at compile time; ollama for strict privacy. |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -12,7 +12,7 @@ The system has two phases: **compile** (offline, curator-side) and **serve** (ru
 
 ## North star
 
-Lorekeep exists to let an agent reason about a domain **systematically and with complete information** — not to maximize memory-recall benchmark scores. Memory benchmarks (LoCoMo, LongMemEval) are parity checks, not the objective. The real measures are completeness, coherence, temporal correctness, and reasoning support (see [evaluation](evaluation.md)).
+Lorekeep is a **second brain for code**: one knowledge graph that aggregates what you and your coding agents learn across devices, the services you build and operate, and your team — and that grows itself proactively. The payoff is that an agent (and you) reasons about a domain **systematically and with complete information** — not to maximize memory-recall benchmark scores. Memory benchmarks (LoCoMo, LongMemEval) are parity checks, not the objective. The real measures are completeness, coherence, temporal correctness, and reasoning support (see [evaluation](evaluation.md)). See the [Roadmap](../ROADMAP.md) for the direction.
 
 ## Architecture
 

--- a/docs/architecture/serve-mcp.md
+++ b/docs/architecture/serve-mcp.md
@@ -123,9 +123,15 @@ Verifies: `facts.jsonl` loads, schema is valid, ns mapping resolves, journal dir
 
 ## Sync and multi-device
 
-- **git (primary):** commit `raw/` + `graph/` + `pending/` (`facts.jsonl`, `manifest.json`, `schema.json`, journals). Each device clones/pulls and spawns its local MCP server. No binary store is committed; the FTS cache is gitignored and rebuilt locally.
+- **git (primary):** commit `raw/` + `schema.json` + `pending/` journals. Each
+  device clones/pulls, re-compiles, replays accepted journal entries, and
+  spawns its local MCP server. Derived graph/manifest/wiki/cache files remain
+  gitignored.
 - **S3 (alternative):** `aws s3 sync` the same paths to an object store; devices sync down.
-- **Write conflicts:** journals are append-only, per-namespace or per-agent. No two agents write to the same journal line. Resolve serializes all journals into a single deterministic `facts.jsonl`. Concurrent journal appends from different devices merge cleanly via git.
+- **Write conflicts:** local journal append/status updates are process-locked
+  and entries have collision-resistant IDs. Git sync is currently sequential;
+  simultaneous edits to the same raw file or namespace journal may still need
+  manual conflict resolution.
 - **Future scale (>50k facts):** partition `facts.jsonl` to Parquet on S3; query via DuckDB/Polars directly on objects.
 
 ## Error handling (serve-side)

--- a/src/lorekeep/agent.py
+++ b/src/lorekeep/agent.py
@@ -181,6 +181,7 @@ def ingest_source(
     schema: Schema,
     chunk_lines: int = 60,
     on_progress: Callable[[int, int, DocChunk], None] | None = None,
+    personal_ns: str = "me",
 ) -> IngestResult:
     """Read a source file, chunk it, and extract facts via LLM.
 
@@ -217,7 +218,10 @@ def ingest_source(
         if on_progress is not None:
             on_progress(chunk_count, total, chunk)
         chunk_count += 1
-        raw = provider.extract_json(build_system_prompt(schema, chunk.namespace), build_prompt(chunk, schema))
+        raw = provider.extract_json(
+            build_system_prompt(schema, chunk.namespace, personal_ns),
+            build_prompt(chunk, schema),
+        )
         nodes, edges, _aliases = parse_response(raw, chunk, schema)
         for n in nodes:
             all_nodes.append(n.model_dump(mode="json", by_alias=True))

--- a/src/lorekeep/agent.py
+++ b/src/lorekeep/agent.py
@@ -13,8 +13,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from lorekeep.compile.extract import (
-    SYSTEM_PROMPT,
     build_prompt,
+    build_system_prompt,
     parse_response,
 )
 from lorekeep.compile.providers import LLMProvider
@@ -217,7 +217,7 @@ def ingest_source(
         if on_progress is not None:
             on_progress(chunk_count, total, chunk)
         chunk_count += 1
-        raw = provider.extract_json(SYSTEM_PROMPT, build_prompt(chunk, schema))
+        raw = provider.extract_json(build_system_prompt(schema, chunk.namespace), build_prompt(chunk, schema))
         nodes, edges, _aliases = parse_response(raw, chunk, schema)
         for n in nodes:
             all_nodes.append(n.model_dump(mode="json", by_alias=True))

--- a/src/lorekeep/backup.py
+++ b/src/lorekeep/backup.py
@@ -16,8 +16,8 @@ graph/facts.jsonl
 graph/manifest.json
 wiki/
 cache.json
-pending/
 fts.sqlite
+*.lock
 """
 
 
@@ -109,8 +109,13 @@ def sync_backup(home: Path) -> bool:
     if not has_remote(home):
         return False
     try:
+        before = _remote_sha(home)
+        # Commit first so tracked journal/raw changes do not block rebase.
+        _commit(home, "backup")
         _reconcile_remote(home)
-        return backup(home)
+        _git(["push"], home)
+        after = _remote_sha(home)
+        return after != before
     except BackupError:
         return False
 

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -294,6 +294,54 @@ def profile(
         _open_in_obsidian(ns_dir)
 
 
+@app.command()
+def contribution() -> None:
+    """Suggest team-knowledge gaps: nodes in your personal namespace not yet shared.
+
+    Scans the compiled graph for nodes of shareable types (service, project,
+    decision, domain, skill) that live only in your personal namespace — i.e.
+    things you know but the team graph doesn't. Move the source doc to a team
+    namespace (raw/<team>/) and re-compile to share. Read-only.
+    """
+    from collections import defaultdict
+    from lorekeep.compile.resolve import _normalize_id
+    from lorekeep.output import dim, info, ok, warn
+    from lorekeep.store.graph import GraphStore
+    p = resolve_paths()
+    facts = p["out"] / "facts.jsonl"
+    if not facts.exists():
+        warn(f"no compiled graph at {facts} — run `lorekeep compile` first")
+        raise typer.Exit(code=1)
+    try:
+        personal_ns = (load_config(p["config"]).ns.default or ["me"])[0]
+    except Exception:
+        personal_ns = "me"
+    SHARE_TYPES = {"service", "project", "decision", "domain", "skill"}
+
+    store = GraphStore.from_jsonl(facts)
+    where: dict[str, set[str]] = defaultdict(set)
+    for n in store.all_nodes():
+        where[_normalize_id(n.id)].update(n.ns)
+
+    gaps = [
+        n for n in store.all_nodes()
+        if personal_ns in n.ns
+        and n.type in SHARE_TYPES
+        and not (where[_normalize_id(n.id)] - {personal_ns, "public"})
+    ]
+    gaps.sort(key=lambda n: (n.type, n.id))
+
+    if not gaps:
+        ok(f"no contribution gaps — your '{personal_ns}' knowledge is already shared")
+        return
+    info(f"{len(gaps)} node(s) in '{personal_ns}' not in any team namespace:")
+    for n in gaps:
+        dim(f"  {n.id} ({n.type}) — consider moving its source doc to raw/<team>/")
+
+
+
+
+
 @app.command(name="eval", hidden=True)
 def eval_cmd() -> None:
     """Run Tier-1 construction-quality evaluation vs the gold corpus."""

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -217,6 +217,7 @@ def compile() -> None:
             raw_root=p["raw"], out_dir=p["out"], schema=schema,
             provider=provider, cache_path=p["cache"], chunk_lines=config.compile.chunk_lines,
             on_progress=_progress_cb(handle),
+            personal_ns=config.ns.personal_namespace,
         )
 
     ok(f"compiled: {manifest.node_count} nodes, {manifest.edge_count} edges, "
@@ -227,7 +228,10 @@ def compile() -> None:
     pending_dir = p.get("pending")
     resolved = False
     if pending_dir and pending_dir.exists():
-        resolved = _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
+        resolved = _do_auto_resolve(
+            p["out"], pending_dir, p.get("wiki"), p.get("schema"),
+            replay_accepted=True,
+        )
 
     if not resolved:
         _auto_generate_wiki(p["out"], p["wiki"])
@@ -284,7 +288,7 @@ def profile(
     from lorekeep.output import info
     p = resolve_paths()
     try:
-        ns = (load_config(p["config"]).ns.default or ["me"])[0]
+        ns = load_config(p["config"]).ns.personal_namespace
     except Exception:
         ns = "me"
     ns_dir = p["raw"] / ns
@@ -313,7 +317,7 @@ def contribution() -> None:
         warn(f"no compiled graph at {facts} — run `lorekeep compile` first")
         raise typer.Exit(code=1)
     try:
-        personal_ns = (load_config(p["config"]).ns.default or ["me"])[0]
+        personal_ns = load_config(p["config"]).ns.personal_namespace
     except Exception:
         personal_ns = "me"
     SHARE_TYPES = {"service", "project", "decision", "domain", "skill"}
@@ -388,6 +392,7 @@ def eval_locomo_cmd(
             raw_root=p["raw"], out_dir=p["out"], schema=schema,
             provider=provider, cache_path=p["cache"],
             chunk_lines=config.compile.chunk_lines,
+            personal_ns=config.ns.personal_namespace,
         )
         typer.echo(f"eval-locomo: compiled {manifest.node_count} nodes, {manifest.edge_count} edges")
 
@@ -428,7 +433,24 @@ def check() -> None:
     ok(f"check: ok — {struct['node_count']} nodes, {struct['edge_count']} edges, 0 dangling")
 
 
+def _with_resolve_lock(func):
+    """Typer-safe decorator serializing manual resolve with daemon resolve."""
+    from functools import wraps
+
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        from lorekeep.journal import resolve_lock
+        pending = resolve_paths().get("pending")
+        if pending is None:
+            return func(*args, **kwargs)
+        with resolve_lock(pending):
+            return func(*args, **kwargs)
+
+    return wrapped
+
+
 @app.command()
+@_with_resolve_lock
 def resolve(
     archive: bool = typer.Option(
         False, "--archive",
@@ -468,15 +490,20 @@ def resolve(
             else:
                 existing_edges.append(f)
 
+    schema = load_schema(p["schema"])
     # Merge journals
-    merged = merge_journals(existing_nodes, existing_edges, pending_entries)
+    merged = merge_journals(
+        existing_nodes, existing_edges, pending_entries, schema=schema,
+    )
 
     # Run standard resolve over merged facts
-    resolved = resolve_facts(merged.nodes, merged.edges)
+    resolved = resolve_facts(
+        merged.nodes, merged.edges, schema=schema,
+    )
 
     # Build manifest
     manifest = Manifest(
-        schema_version=0,
+        schema_version=schema.version,
         chunk_count=0,
         node_count=len(resolved.nodes),
         edge_count=len(resolved.edges),
@@ -497,11 +524,17 @@ def resolve(
     ns_to_flagged: dict[str, set[str]] = {}
     ns_to_quarantined: dict[str, set[str]] = {}
     for entry, _ in merged.merged:
-        ns_to_merged.setdefault(entry.ns, set()).add(entry.proposed_at)
+        ns_to_merged.setdefault(entry.ns, set()).add(
+            entry.entry_id or entry.proposed_at
+        )
     for entry, _ in merged.flagged:
-        ns_to_flagged.setdefault(entry.ns, set()).add(entry.proposed_at)
+        ns_to_flagged.setdefault(entry.ns, set()).add(
+            entry.entry_id or entry.proposed_at
+        )
     for entry, _ in merged.quarantined:
-        ns_to_quarantined.setdefault(entry.ns, set()).add(entry.proposed_at)
+        ns_to_quarantined.setdefault(entry.ns, set()).add(
+            entry.entry_id or entry.proposed_at
+        )
 
     # Flagged entries are still merged into the graph (just flagged for review)
     for ns, timestamps in ns_to_flagged.items():
@@ -548,6 +581,35 @@ app.add_typer(mcp_app, name="mcp")
 
 config_app = typer.Typer(help="View and edit lorekeep config.")
 app.add_typer(config_app, name="config")
+schema_app = typer.Typer(help="Inspect and upgrade the graph schema.")
+app.add_typer(schema_app, name="schema")
+
+
+@schema_app.command("upgrade")
+def schema_upgrade(
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show the upgrade without writing."),
+    force: bool = typer.Option(False, "--force", help="Replace a custom older schema after backing it up."),
+) -> None:
+    """Upgrade the stock v2 ontology to v3, preserving a backup."""
+    from lorekeep.output import info, ok, warn
+    from lorekeep.schema_io import upgrade_schema
+
+    p = resolve_paths()
+    result = upgrade_schema(p["schema"], dry_run=dry_run, force=force)
+    if result["custom"] and not result["changed"]:
+        warn(
+            "custom schema detected; re-run with --force only after reviewing "
+            "the v2→v3 ontology changes"
+        )
+        raise typer.Exit(code=2)
+    if not result["changed"]:
+        ok(f"schema already at version {result['to']}")
+        return
+    action = "would upgrade" if dry_run else "upgraded"
+    info(f"{action} schema v{result['from']} → v{result['to']}")
+    if not dry_run:
+        ok(f"backup: {result['backup']}")
+        info("next: run `lorekeep compile` to rebuild the derived graph")
 
 
 @config_app.command("show")
@@ -757,6 +819,7 @@ def init(
             ns, name, bio = _interactive_init(p)
         else:
             p["config"].write_text(DEFAULT_CONFIG_YAML)
+            ns = load_config(p["config"]).ns.personal_namespace
         created.append(str(p["config"]))
     elif p["config"].exists():
         try:
@@ -884,7 +947,7 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
     idx = int(choice) if choice.isdigit() else 0
     if idx == len(POPULAR) + 2 or choice.lower() == "skip":
         typer.echo("  → Skipped (edit config.yaml to add a provider later)\n")
-        ns = typer.prompt("Default namespace", default="private")
+        ns = typer.prompt("Default namespace", default="me")
         name = typer.prompt("Your name", default="")
         bio = typer.prompt("Bio (one-line intro)", default="")
         _write_config(p, model="openai/gpt-4o-mini",
@@ -979,7 +1042,7 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
                 typer.echo("  → skipped (add key to config.yaml later)\n")
 
     # ── Namespace + profile ────────────────────────────────────────────
-    ns = typer.prompt("Default namespace", default="private")
+    ns = typer.prompt("Default namespace", default="me")
     name = typer.prompt("Your name", default="")
     typer.echo("  (your bio → raw/<ns>/about.md → compiled into the graph)")
     bio = typer.prompt("Bio (one-line intro)", default="")
@@ -1005,7 +1068,7 @@ def _write_config(p, model, api_base, api_key_env, api_key, ns):
             "temperature": 0.0,
         },
         "compile": {"chunk_lines": 60},
-        "ns": {"default": [ns]},
+        "ns": {"default": [ns], "personal": ns},
         "install_source": install_source,
     }
     p["config"].write_text(yaml.dump(config, default_flow_style=False, sort_keys=False))
@@ -1102,12 +1165,16 @@ def _auto_import_and_compile(p: dict) -> None:
                 provider=provider, cache_path=p["cache"],
                 chunk_lines=config.compile.chunk_lines,
                 on_progress=_progress_cb(handle),
+                personal_ns=config.ns.personal_namespace,
             )
         _report_compile_errors(manifest, exit_on_total_failure=False)
         pending_dir = p.get("pending")
         resolved = False
         if pending_dir and pending_dir.exists():
-            resolved = _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
+            resolved = _do_auto_resolve(
+                p["out"], pending_dir, p.get("wiki"), p.get("schema"),
+                replay_accepted=True,
+            )
         if not resolved:
             _auto_generate_wiki(p["out"], p["wiki"])
         typer.echo(f"  compiled: {manifest.node_count} nodes, {manifest.edge_count} edges")
@@ -1465,6 +1532,7 @@ def ingest(
                 schema=schema,
                 chunk_lines=config.compile.chunk_lines,
                 on_progress=on_progress,
+                personal_ns=config.ns.personal_namespace,
             )
         except Exception as exc:
             typer.echo(f"ingest: extraction failed: {exc}")
@@ -1529,7 +1597,10 @@ def ingest(
     from lorekeep.journal import append_journal
     from lorekeep.models import JournalEntry
 
-    now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    import socket
+    import uuid
+    now = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+    device = os.environ.get("LOREKEEP_DEVICE", socket.gethostname())
     entry_count = 0
 
     for n in approved_nodes:
@@ -1539,6 +1610,8 @@ def ingest(
         entry = JournalEntry(
             fact=n,
             agent="cli-ingest",
+            device=device,
+            entry_id=uuid.uuid4().hex,
             ns=result.ns,
             confidence=1.0,           # human-approved → max confidence
             proposed_at=now,
@@ -1554,6 +1627,8 @@ def ingest(
         entry = JournalEntry(
             fact=e,
             agent="cli-ingest",
+            device=device,
+            entry_id=uuid.uuid4().hex,
             ns=result.ns,
             confidence=1.0,
             proposed_at=now,
@@ -1761,14 +1836,6 @@ def watch(
     session_state: dict[str, float] = {}
     session_import_time: dict[str, float] = {}
 
-    # One-time resolve of pending journals present at startup
-    if pending_dir and pending_dir.exists():
-        from lorekeep.journal import load_journals
-        journals = load_journals(pending_dir)
-        if any(j.status == "pending" for j in journals):
-            typer.echo("agent: resolving pending journals at startup...")
-            _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
-
     # Sync from remote at startup (pull changes from other machines)
     try:
         from lorekeep.backup import sync_backup, has_remote
@@ -1777,6 +1844,17 @@ def watch(
             sync_backup(p["home"])
     except Exception:
         pass
+
+    # Resolve/replay only after startup sync so remote journal events are visible.
+    if pending_dir and pending_dir.exists():
+        from lorekeep.journal import load_journals
+        journals = load_journals(pending_dir)
+        if any(j.status in {"pending", "merged", "flagged"} for j in journals):
+            typer.echo("agent: replaying journals at startup...")
+            _do_auto_resolve(
+                p["out"], pending_dir, p.get("wiki"), p.get("schema"),
+                replay_accepted=True,
+            )
 
     while True:
         try:
@@ -1808,6 +1886,7 @@ def watch(
                             provider=provider, cache_path=p["cache"],
                             chunk_lines=config.compile.chunk_lines,
                             on_progress=_progress_cb(handle),
+                            personal_ns=config.ns.personal_namespace,
                         )
                     _report_compile_errors(dm, exit_on_total_failure=False)
                     typer.echo("agent: compile done")
@@ -1817,9 +1896,6 @@ def watch(
             last_raw_mtime = raw_mtime
             last_raw_count = raw_count
 
-            if compiled and has_pending:
-                _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
-
             # --- auto-backup + sync after compile ---------------------------
             if compiled:
                 try:
@@ -1828,6 +1904,11 @@ def watch(
                         typer.echo("agent: backup synced")
                 except Exception:
                     pass
+                if has_pending:
+                    _do_auto_resolve(
+                        p["out"], pending_dir, p.get("wiki"), p.get("schema"),
+                        replay_accepted=True,
+                    )
 
             # --- pending/ watch → auto-resolve ------------------------------
             if has_pending:
@@ -1835,7 +1916,9 @@ def watch(
                 pending_mtime = max((f.stat().st_mtime for f in journal_files), default=0.0)
                 if pending_mtime > last_pending_mtime and last_pending_mtime > 0:
                     typer.echo("agent: pending/ changed — resolving...")
-                    _do_auto_resolve(p["out"], pending_dir, p.get("wiki"))
+                    _do_auto_resolve(
+                        p["out"], pending_dir, p.get("wiki"), p.get("schema"),
+                    )
                 last_pending_mtime = pending_mtime
 
             # --- session watch → delta quick import → raw/ ------------------
@@ -1873,7 +1956,32 @@ def watch(
     pid_file.unlink(missing_ok=True)
 
 
-def _do_auto_resolve(out_dir: Path, pending_dir: Path, wiki_dir: Path | None = None) -> bool:
+def _do_auto_resolve(
+    out_dir: Path,
+    pending_dir: Path,
+    wiki_dir: Path | None = None,
+    schema_path: Path | None = None,
+    replay_accepted: bool = False,
+) -> bool:
+    from lorekeep.journal import resolve_lock
+
+    with resolve_lock(pending_dir):
+        return _do_auto_resolve_unlocked(
+            out_dir,
+            pending_dir,
+            wiki_dir,
+            schema_path,
+            replay_accepted,
+        )
+
+
+def _do_auto_resolve_unlocked(
+    out_dir: Path,
+    pending_dir: Path,
+    wiki_dir: Path | None = None,
+    schema_path: Path | None = None,
+    replay_accepted: bool = False,
+) -> bool:
     """Merge pending journal entries into facts.jsonl.
 
     Extracted as a helper so both the pending/ watch loop and the
@@ -1899,12 +2007,23 @@ def _do_auto_resolve(out_dir: Path, pending_dir: Path, wiki_dir: Path | None = N
                     existing_edges.append(f)
 
         journals = load_journals(pending_dir)
-        pending_entries = [j for j in journals if j.status == "pending"]
-        if pending_entries:
-            merged = merge_journals(existing_nodes, existing_edges, pending_entries)
-            resolved = resolve_facts(merged.nodes, merged.edges)
+        candidate_entries = [
+            j for j in journals
+            if j.status == "pending"
+            or (replay_accepted and j.status in {"merged", "flagged"})
+        ]
+        if candidate_entries:
+            schema = load_schema(schema_path) if schema_path else None
+            merged = merge_journals(
+                existing_nodes,
+                existing_edges,
+                candidate_entries,
+                replay_accepted=replay_accepted,
+                schema=schema,
+            )
+            resolved = resolve_facts(merged.nodes, merged.edges, schema=schema)
             manifest = Manifest(
-                schema_version=0, chunk_count=0,
+                schema_version=schema.version if schema else 0, chunk_count=0,
                 node_count=len(resolved.nodes),
                 edge_count=len(resolved.edges),
                 run_id="auto-resolve", facts_hash="",
@@ -1916,13 +2035,22 @@ def _do_auto_resolve(out_dir: Path, pending_dir: Path, wiki_dir: Path | None = N
             write_graph(out_dir, resolved.nodes, resolved.edges, manifest)
 
             for ns in set(entry.ns for entry, _ in merged.merged):
-                timestamps = {e.proposed_at for e, _ in merged.merged if e.ns == ns}
-                if timestamps:
-                    update_journal_status(pending_dir, ns, timestamps, "merged")
+                entry_keys = {
+                    e.entry_id or e.proposed_at
+                    for e, _ in merged.merged if e.ns == ns
+                }
+                if entry_keys:
+                    update_journal_status(pending_dir, ns, entry_keys, "merged")
             for ns in set(entry.ns for entry, _ in merged.flagged):
-                timestamps = {e.proposed_at for e, _ in merged.flagged if e.ns == ns}
-                existing = {e.proposed_at for e, _ in merged.merged if e.ns == ns}
-                to_flag = timestamps - existing
+                entry_keys = {
+                    e.entry_id or e.proposed_at
+                    for e, _ in merged.flagged if e.ns == ns
+                }
+                existing = {
+                    e.entry_id or e.proposed_at
+                    for e, _ in merged.merged if e.ns == ns
+                }
+                to_flag = entry_keys - existing
                 if to_flag:
                     update_journal_status(pending_dir, ns, to_flag, "flagged")
 

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -272,6 +272,28 @@ def wiki(
         _open_in_obsidian(p["wiki"])
 
 
+@app.command()
+def profile(
+    open: bool = typer.Option(False, "--open", help="Open your raw profile dir in Obsidian/Tolaria."),
+) -> None:
+    """Show / open your personal profile source (raw/<ns>/).
+
+    The wiki is a derived view; the editable source is raw/<ns>/about.md +
+    profile.md. Edit those (in Obsidian/Tolaria), then `lorekeep compile`.
+    """
+    from lorekeep.output import info
+    p = resolve_paths()
+    try:
+        ns = (load_config(p["config"]).ns.default or ["me"])[0]
+    except Exception:
+        ns = "me"
+    ns_dir = p["raw"] / ns
+    info(f"profile source: {ns_dir}")
+    info("edit about.md / profile.md here, then `lorekeep compile` — the wiki reflects you")
+    if open:
+        _open_in_obsidian(ns_dir)
+
+
 @app.command(name="eval", hidden=True)
 def eval_cmd() -> None:
     """Run Tier-1 construction-quality evaluation vs the gold corpus."""
@@ -724,6 +746,19 @@ def init(
             )
             about_path.write_text(about_md)
             typer.echo(f"  wrote: {about_path}")
+
+            # Optional profile scaffold — the editable source for the personal
+            # (subject-centric) namespace. User fills it via Obsidian/Tolaria;
+            # the wiki is a derived view.
+            profile_path = ns_dir / "profile.md"
+            if not profile_path.exists():
+                from lorekeep.defaults import DEFAULT_PROFILE_TEMPLATE
+                profile_path.write_text(DEFAULT_PROFILE_TEMPLATE)
+                typer.echo(f"  wrote: {profile_path}")
+                typer.echo(
+                    "  hint: edit profile.md (role/domains/skills/goals) in "
+                    "Obsidian/Tolaria, then `lorekeep compile` — the wiki reflects you."
+                )
 
     # --- One-click chain: wire → import → compile → daemon -----------------
     if not config_existed:

--- a/src/lorekeep/compile/extract.py
+++ b/src/lorekeep/compile/extract.py
@@ -30,7 +30,7 @@ ALTITUDE_RULE = (
     "document). Low-altitude tokens — commands, environment variables, "
     "filenames, error strings, tool names, metric names — must NOT become "
     "nodes; attach them as properties of the nearest relevant node. Prefer a "
-    "specific semantic edge (depends_on, contributes_to, skilled_in, decided_by) "
+    "specific semantic edge (depends_on, contributes_to, has_skill, decided_by) "
     "over a generic one (relates_to)."
 )
 
@@ -41,12 +41,20 @@ SUBJECT_PROMPT = (
     "subject-centric facts: anchor on ONE canonical person node for the user and "
     "capture their role, skills, domains, goals, preferences, and values. Link the "
     "subject to any team project/service mentioned via cross-namespace edges "
-    "(owns, contributes_to, works_on, skilled_in, collaborates_with). Do NOT split "
+    "(owns, contributes_to, works_on, has_skill, collaborates_with). Do NOT split "
     "the subject into multiple person nodes — emit a single canonical person id."
 )
 
 
-def build_system_prompt(schema: Schema, ns: str | None = None) -> str:
+def _endpoint_label(value: str | tuple[str, ...]) -> str:
+    return value if isinstance(value, str) else "|".join(value)
+
+
+def build_system_prompt(
+    schema: Schema,
+    ns: str | None = None,
+    personal_ns: str = "me",
+) -> str:
     """Build a constant system prompt including schema + altitude rule.
 
     ns='me' adds subject-centric guidance (personal profile); other namespaces
@@ -55,7 +63,8 @@ def build_system_prompt(schema: Schema, ns: str | None = None) -> str:
     """
     node_types = ", ".join(schema.node_types.keys())
     edge_types = ", ".join(
-        f"{k}({v.from_}->{v.to})" for k, v in schema.edge_types.items()
+        f"{k}({_endpoint_label(v.from_)}->{_endpoint_label(v.to)})"
+        for k, v in schema.edge_types.items()
     )
     parts = [
         SYSTEM_PROMPT_BASE,
@@ -63,8 +72,8 @@ def build_system_prompt(schema: Schema, ns: str | None = None) -> str:
         f"Allowed node_types: {node_types}",
         f"Allowed edge_types: {edge_types}",
     ]
-    if ns == "me":
-        parts.append(SUBJECT_PROMPT)
+    if ns == personal_ns:
+        parts.append(SUBJECT_PROMPT.replace("'me'", repr(personal_ns)))
     return "\n\n".join(parts)
 
 
@@ -170,11 +179,19 @@ class ExtractionCache:
         if self.path.exists():
             self._data = json.loads(self.path.read_text(encoding="utf-8"))
 
-    def key(self, chunk: DocChunk, schema_version: int, model: str = "") -> str:
+    def key(
+        self,
+        chunk: DocChunk,
+        schema_version: int,
+        model: str = "",
+        prompt_variant: str = "",
+    ) -> str:
         h = hashlib.sha256()
         h.update(str(schema_version).encode("utf-8"))
         h.update(b"\n")
         h.update(model.encode("utf-8"))
+        h.update(b"\n")
+        h.update(prompt_variant.encode("utf-8"))
         h.update(b"\n")
         h.update(chunk.hash.encode("utf-8"))
         return h.hexdigest()
@@ -193,13 +210,27 @@ class ExtractionCache:
 
 
 def extract_chunk(
-    chunk: DocChunk, schema: Schema, provider: LLMProvider, cache: ExtractionCache,
+    chunk: DocChunk,
+    schema: Schema,
+    provider: LLMProvider,
+    cache: ExtractionCache,
+    personal_ns: str = "me",
 ) -> tuple[list[Node], list[Edge], dict[str, list[str]]]:
     model = getattr(provider, "model", "")
-    key = cache.key(chunk, schema.version, model)
+    schema_json = json.dumps(
+        schema.model_dump(mode="json", by_alias=True),
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    schema_fingerprint = hashlib.sha256(schema_json.encode("utf-8")).hexdigest()
+    prompt_variant = (
+        f"schema={schema_fingerprint};personal={personal_ns};"
+        f"subject={chunk.namespace == personal_ns}"
+    )
+    key = cache.key(chunk, schema.version, model, prompt_variant)
     raw = cache.get(key)
     if raw is None:
-        system = build_system_prompt(schema, chunk.namespace)
+        system = build_system_prompt(schema, chunk.namespace, personal_ns)
         raw = provider.extract_json(system, chunk.text)
         cache.set(key, raw)
     return parse_response(raw, chunk, schema)

--- a/src/lorekeep/compile/extract.py
+++ b/src/lorekeep/compile/extract.py
@@ -16,7 +16,8 @@ SYSTEM_PROMPT_BASE = (
     'object {"nodes":[...], "edges":[...], "aliases":{...}}. '
     "Only use node_types and edge_types listed in the provided schema. "
     "For every node give id (stable slug prefixed by type, e.g. svc:payments-api), "
-    "type, name, optional props, optional valid_from/valid_to (ISO dates, null = unknown). "
+    "type, optional props using the preferred keys for that type, and optional "
+    "valid_from/valid_to (ISO dates, null = unknown). "
     "For every edge give type, from (node id), to (node id), optional valid_from/valid_to. "
     "aliases maps a canonical name to surface variants. Emit NO text outside the JSON."
 )
@@ -32,6 +33,16 @@ ALTITUDE_RULE = (
     "nodes; attach them as properties of the nearest relevant node. Prefer a "
     "specific semantic edge (depends_on, contributes_to, has_skill, decided_by) "
     "over a generic one (relates_to)."
+)
+
+TEMPORAL_RULE = (
+    "Temporal rule: valid_from/valid_to belong to the exact fact whose lifetime "
+    "the text describes. If a relationship starts or ends, set dates on that "
+    "edge only. Do NOT copy an edge's valid_to to either endpoint node unless "
+    "the text explicitly says the entity itself ceased to exist. Examples: "
+    "'service launched on D' means that service node has valid_from D; "
+    "'dependency removed on D' means that dependency edge has valid_to D while "
+    "both endpoint service nodes remain open."
 )
 
 # Subject-centric extraction for the personal namespace: anchor on the person,
@@ -61,7 +72,12 @@ def build_system_prompt(
     use the default entity-centric extraction. Keeping schema in the system
     prompt (not user message) maximizes prefix cache hits across chunks.
     """
-    node_types = ", ".join(schema.node_types.keys())
+    node_types = ", ".join(
+        f"{name}("
+        + ", ".join(f"{prop}:{kind}" for prop, kind in spec.props.items())
+        + ")"
+        for name, spec in schema.node_types.items()
+    )
     edge_types = ", ".join(
         f"{k}({_endpoint_label(v.from_)}->{_endpoint_label(v.to)})"
         for k, v in schema.edge_types.items()
@@ -69,7 +85,8 @@ def build_system_prompt(
     parts = [
         SYSTEM_PROMPT_BASE,
         ALTITUDE_RULE,
-        f"Allowed node_types: {node_types}",
+        TEMPORAL_RULE,
+        f"Allowed node_types and preferred props: {node_types}",
         f"Allowed edge_types: {edge_types}",
     ]
     if ns == personal_ns:
@@ -217,20 +234,22 @@ def extract_chunk(
     personal_ns: str = "me",
 ) -> tuple[list[Node], list[Edge], dict[str, list[str]]]:
     model = getattr(provider, "model", "")
+    system = build_system_prompt(schema, chunk.namespace, personal_ns)
     schema_json = json.dumps(
         schema.model_dump(mode="json", by_alias=True),
         sort_keys=True,
         ensure_ascii=False,
     )
     schema_fingerprint = hashlib.sha256(schema_json.encode("utf-8")).hexdigest()
+    prompt_fingerprint = hashlib.sha256(system.encode("utf-8")).hexdigest()
     prompt_variant = (
-        f"schema={schema_fingerprint};personal={personal_ns};"
+        f"schema={schema_fingerprint};prompt={prompt_fingerprint};"
+        f"personal={personal_ns};"
         f"subject={chunk.namespace == personal_ns}"
     )
     key = cache.key(chunk, schema.version, model, prompt_variant)
     raw = cache.get(key)
     if raw is None:
-        system = build_system_prompt(schema, chunk.namespace, personal_ns)
         raw = provider.extract_json(system, chunk.text)
         cache.set(key, raw)
     return parse_response(raw, chunk, schema)

--- a/src/lorekeep/compile/extract.py
+++ b/src/lorekeep/compile/extract.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from datetime import date
 from typing import Any
 
 from lorekeep.models import DocChunk, Edge, Node, Schema
+
+log = logging.getLogger("lorekeep")
 
 SYSTEM_PROMPT_BASE = (
     "You are a knowledge-graph extractor. Read the document chunk and emit a JSON "
@@ -18,25 +21,54 @@ SYSTEM_PROMPT_BASE = (
     "aliases maps a canonical name to surface variants. Emit NO text outside the JSON."
 )
 
+# Altitude rule: decides node vs attribute. Prevents low-altitude tokens
+# (commands, env vars, filenames, errors) from becoming nodes — the root cause
+# of the "concept noise" wiki reflection (192 nodes, 98 trash concepts).
+ALTITUDE_RULE = (
+    "Altitude rule: create a node ONLY for a stable semantic entity "
+    "(person, service, project, decision, domain, skill, role, goal, team, "
+    "document). Low-altitude tokens — commands, environment variables, "
+    "filenames, error strings, tool names, metric names — must NOT become "
+    "nodes; attach them as properties of the nearest relevant node. Prefer a "
+    "specific semantic edge (depends_on, contributes_to, skilled_in, decided_by) "
+    "over a generic one (relates_to)."
+)
 
-def build_system_prompt(schema: Schema) -> str:
-    """Build a constant system prompt including schema — cacheable across chunks.
+# Subject-centric extraction for the personal namespace: anchor on the person,
+# capture role/skill/domain/goal/preference, link to team entities cross-ns.
+SUBJECT_PROMPT = (
+    "This chunk is in the 'me' namespace — the user's personal profile. Extract "
+    "subject-centric facts: anchor on ONE canonical person node for the user and "
+    "capture their role, skills, domains, goals, preferences, and values. Link the "
+    "subject to any team project/service mentioned via cross-namespace edges "
+    "(owns, contributes_to, works_on, skilled_in, collaborates_with). Do NOT split "
+    "the subject into multiple person nodes — emit a single canonical person id."
+)
 
-    Keeping schema in the system prompt (not user message) maximizes prefix
-    cache hits: the system message is identical for every chunk in a compile run.
+
+def build_system_prompt(schema: Schema, ns: str | None = None) -> str:
+    """Build a constant system prompt including schema + altitude rule.
+
+    ns='me' adds subject-centric guidance (personal profile); other namespaces
+    use the default entity-centric extraction. Keeping schema in the system
+    prompt (not user message) maximizes prefix cache hits across chunks.
     """
     node_types = ", ".join(schema.node_types.keys())
     edge_types = ", ".join(
         f"{k}({v.from_}->{v.to})" for k, v in schema.edge_types.items()
     )
-    return (
-        f"{SYSTEM_PROMPT_BASE}\n\n"
-        f"Allowed node_types: {node_types}\n"
-        f"Allowed edge_types: {edge_types}"
-    )
+    parts = [
+        SYSTEM_PROMPT_BASE,
+        ALTITUDE_RULE,
+        f"Allowed node_types: {node_types}",
+        f"Allowed edge_types: {edge_types}",
+    ]
+    if ns == "me":
+        parts.append(SUBJECT_PROMPT)
+    return "\n\n".join(parts)
 
 
-# Backward compat
+# Backward compat: base prompt without altitude/ns additions.
 SYSTEM_PROMPT = SYSTEM_PROMPT_BASE
 
 
@@ -89,6 +121,7 @@ def parse_response(
     for n in data.get("nodes", []):
         ntype = n.get("type")
         if schema is not None and not schema.is_valid_node_type(ntype):
+            log.debug("dropping node with unknown type %r in %s", ntype, chunk.src)
             continue
         props = dict(n.get("props", {}))
         if "name" in n and "name" not in props:
@@ -106,6 +139,7 @@ def parse_response(
     for e in data.get("edges", []):
         etype = e.get("type")
         if schema is not None and not schema.is_valid_edge_type(etype):
+            log.debug("dropping edge with unknown type %r in %s", etype, chunk.src)
             continue
         edges.append(Edge(
             id="",                      # assigned deterministically in resolve
@@ -165,7 +199,7 @@ def extract_chunk(
     key = cache.key(chunk, schema.version, model)
     raw = cache.get(key)
     if raw is None:
-        system = build_system_prompt(schema)
+        system = build_system_prompt(schema, chunk.namespace)
         raw = provider.extract_json(system, chunk.text)
         cache.set(key, raw)
     return parse_response(raw, chunk, schema)

--- a/src/lorekeep/compile/resolve.py
+++ b/src/lorekeep/compile/resolve.py
@@ -9,9 +9,11 @@ the existing graph with priority: raw/ > import > agent-propose.
 """
 from __future__ import annotations
 
+import re
+import unicodedata
 from dataclasses import dataclass, field
 
-from lorekeep.models import Edge, JournalEntry, Node
+from lorekeep.models import Edge, JournalEntry, Node, Schema
 
 
 @dataclass
@@ -30,7 +32,8 @@ def _normalize_id(node_id: str) -> str:
     ``concept:context_purity`` == ``concept:Context Purity`` ==
     ``concept:context-purity`` (all merge), but diacritic differences do not.
     """
-    return node_id.lower().replace("_", "-").replace(" ", "-")
+    normalized = unicodedata.normalize("NFC", node_id).lower()
+    return re.sub(r"[-_\s]+", "-", normalized)
 
 
 def _build_alias_map(
@@ -38,7 +41,7 @@ def _build_alias_map(
     name_aliases: dict[str, list[str]] | None,
     explicit_map: dict[str, str] | None,
 ) -> dict[str, str]:
-    """Return alias_id -> canonical_id. Canonical = first node id seen for a name."""
+    """Return alias_id -> canonical_id with deterministic normalized ids."""
     alias_map: dict[str, str] = {}
     # 1) by name: group nodes whose props.name matches an alias group's canonical
     if name_aliases:
@@ -53,10 +56,10 @@ def _build_alias_map(
                     if nd.id != canon:
                         alias_map[nd.id] = canon
     # 2) auto-merge by normalized id (case/separator variants; diacritics kept).
-    #    First node per normalized key wins; don't override a name-alias decision.
-    norm_to_canonical: dict[str, str] = {}
+    #    The normalized key itself is canonical, so source ordering cannot change
+    #    stored ids across devices.
     for nd in nodes:
-        canon = norm_to_canonical.setdefault(_normalize_id(nd.id), nd.id)
+        canon = _normalize_id(nd.id)
         if nd.id != canon and nd.id not in alias_map:
             alias_map[nd.id] = canon
     # 3) explicit id->id overrides win
@@ -79,7 +82,21 @@ def resolve(
     edges: list[Edge],
     name_aliases: dict[str, list[str]] | None = None,
     aliases_map: dict[str, str] | None = None,
+    schema: Schema | None = None,
 ) -> ResolveResult:
+    quarantined: list[tuple[dict, str]] = []
+    if schema is not None:
+        valid_nodes = []
+        for node in nodes:
+            if schema.is_valid_node_type(node.type):
+                valid_nodes.append(node)
+            else:
+                quarantined.append((
+                    node.model_dump(mode="json", by_alias=True),
+                    f"unknown node type ({node.type})",
+                ))
+        nodes = valid_nodes
+
     alias_map = _build_alias_map(nodes, name_aliases, aliases_map)
 
     # collapse nodes
@@ -104,9 +121,8 @@ def resolve(
 
     # rewrite + validate edges
     out_edges: list[Edge] = []
-    quarantined: list[tuple[dict, str]] = []
     counter = 0
-    for ed in edges:
+    for ed in sorted(edges, key=lambda e: (e.type, e.from_, e.to, e.id)):
         f = _canonical(ed.from_, alias_map)
         t = _canonical(ed.to, alias_map)
         if f not in node_ids or t not in node_ids:
@@ -117,6 +133,16 @@ def resolve(
             quarantined.append((ed.model_dump(mode="json", by_alias=True),
                                 "self-loop"))
             continue
+        if schema is not None:
+            from_type = canon_nodes[f].type
+            to_type = canon_nodes[t].type
+            if not schema.is_valid_edge_endpoints(ed.type, from_type, to_type):
+                quarantined.append((
+                    ed.model_dump(mode="json", by_alias=True),
+                    f"invalid edge endpoints for {ed.type} "
+                    f"({from_type}->{to_type})",
+                ))
+                continue
         counter += 1
         out_edges.append(ed.model_copy(update={
             "id": f"e_{ed.type}_{counter:04d}",
@@ -157,6 +183,9 @@ def merge_journals(
     existing_nodes: list[Node],
     existing_edges: list[Edge],
     journal_entries: list[JournalEntry],
+    *,
+    replay_accepted: bool = False,
+    schema: Schema | None = None,
 ) -> JournalMergeResult:
     """Gate journal entries by confidence and add to the graph.
 
@@ -165,10 +194,20 @@ def merge_journals(
     """
     result = JournalMergeResult()
     nodes_by_id: dict[str, Node] = {n.id: n for n in existing_nodes}
-    new_edges: list[Edge] = []
+    new_edges: list[tuple[Edge, bool]] = []
 
-    for entry in journal_entries:
-        if entry.status != "pending":
+    ordered_entries = sorted(
+        journal_entries,
+        key=lambda entry: (
+            entry.fact.get("kind") == "edge",
+            entry.entry_id or entry.proposed_at,
+            entry.agent,
+            entry.fact.get("id", ""),
+        ),
+    )
+    for entry in ordered_entries:
+        replaying = replay_accepted and entry.status in {"merged", "flagged"}
+        if entry.status != "pending" and not replaying:
             continue
         confidence = entry.confidence
         fact_data = entry.fact
@@ -181,14 +220,36 @@ def merge_journals(
             result.quarantined.append((entry, "invalid fact schema"))
             continue
 
-        if confidence < 0.5:
+        if confidence < 0.5 and not replaying:
             result.quarantined.append((entry, "low confidence"))
             continue
+
+        if schema is not None and fact.kind == "node":
+            if not schema.is_valid_node_type(fact.type):
+                result.quarantined.append((entry, f"unknown node type: {fact.type}"))
+                continue
+
+        if schema is not None and fact.kind == "edge":
+            from_node = nodes_by_id.get(fact.from_)
+            to_node = nodes_by_id.get(fact.to)
+            if (
+                from_node is None
+                or to_node is None
+                or not schema.is_valid_edge_endpoints(
+                    fact.type, from_node.type, to_node.type,
+                )
+            ):
+                result.quarantined.append((entry, "invalid edge endpoints"))
+                continue
 
         if fact.kind == "node":
             if fact.id in nodes_by_id:
                 base = nodes_by_id[fact.id]
-                merged_props = {**base.props, **fact.props}
+                merged_props = (
+                    {**fact.props, **base.props}
+                    if replaying
+                    else {**base.props, **fact.props}
+                )
                 merged_src = tuple(dict.fromkeys(base.src + fact.src))
                 merged_ns = tuple(dict.fromkeys(base.ns + fact.ns))
                 nodes_by_id[fact.id] = base.model_copy(
@@ -197,8 +258,10 @@ def merge_journals(
             else:
                 nodes_by_id[fact.id] = fact
         else:
-            new_edges.append(fact)
+            new_edges.append((fact, replaying))
 
+        if replaying:
+            continue
         if confidence >= 0.8:
             result.merged.append((entry, ""))
         else:
@@ -209,12 +272,17 @@ def merge_journals(
     # Deduplicate + ID-regenerate edges (journal edges have empty id)
     edge_by_key: dict[tuple[str, str, str], Edge] = {}
     counter = 0
-    for e in existing_edges + new_edges:
+    edge_inputs = [(edge, False) for edge in existing_edges] + new_edges
+    for e, replaying in edge_inputs:
         key = (e.from_, e.to, e.type)
         if key in edge_by_key:
             # Merge props and src for duplicate edges
             existing = edge_by_key[key]
-            merged_props = {**existing.props, **e.props}
+            merged_props = (
+                {**e.props, **existing.props}
+                if replaying
+                else {**existing.props, **e.props}
+            )
             merged_src = tuple(dict.fromkeys(existing.src + e.src))
             edge_by_key[key] = existing.model_copy(
                 update={"props": merged_props, "src": merged_src}

--- a/src/lorekeep/compile/resolve.py
+++ b/src/lorekeep/compile/resolve.py
@@ -22,6 +22,17 @@ class ResolveResult:
     quarantined: list[tuple[dict, str]] = field(default_factory=list)
 
 
+def _normalize_id(node_id: str) -> str:
+    """Canonical form for duplicate detection.
+
+    Lowercase, ``_`` and space -> ``-``. Diacritics (Vietnamese etc.) are
+    PRESERVED — ``person:nguyễn`` stays distinct from ``person:nguyen``. So
+    ``concept:context_purity`` == ``concept:Context Purity`` ==
+    ``concept:context-purity`` (all merge), but diacritic differences do not.
+    """
+    return node_id.lower().replace("_", "-").replace(" ", "-")
+
+
 def _build_alias_map(
     nodes: list[Node],
     name_aliases: dict[str, list[str]] | None,
@@ -41,7 +52,14 @@ def _build_alias_map(
                     canon = name_to_canonical.setdefault(canonical_name, nd.id)
                     if nd.id != canon:
                         alias_map[nd.id] = canon
-    # 2) explicit id->id overrides win
+    # 2) auto-merge by normalized id (case/separator variants; diacritics kept).
+    #    First node per normalized key wins; don't override a name-alias decision.
+    norm_to_canonical: dict[str, str] = {}
+    for nd in nodes:
+        canon = norm_to_canonical.setdefault(_normalize_id(nd.id), nd.id)
+        if nd.id != canon and nd.id not in alias_map:
+            alias_map[nd.id] = canon
+    # 3) explicit id->id overrides win
     if explicit_map:
         alias_map.update(explicit_map)
     return alias_map

--- a/src/lorekeep/config.py
+++ b/src/lorekeep/config.py
@@ -21,7 +21,15 @@ class CompileConfig(BaseModel):
 
 class NsConfig(BaseModel):
     default: list[str] = Field(default_factory=lambda: ["public"])
+    personal: str | None = None
     token_map: dict[str, list[str]] = Field(default_factory=dict)
+
+    @property
+    def personal_namespace(self) -> str:
+        """Personal/subject namespace, with a safe legacy-config fallback."""
+        if self.personal:
+            return self.personal
+        return next((ns for ns in self.default if ns != "public"), "me")
 
 
 class ObservabilityConfig(BaseModel):

--- a/src/lorekeep/defaults.py
+++ b/src/lorekeep/defaults.py
@@ -1,6 +1,33 @@
 """Default config + schema used by `lorekeep init` to bootstrap a fresh home."""
 from __future__ import annotations
 
+DEFAULT_SCHEMA_V2 = {
+    "version": 2,
+    "node_types": {
+        "service": {"props": {"name": "string", "lang": "string"}},
+        "team": {"props": {"name": "string"}},
+        "decision": {"props": {"title": "string"}},
+        "project": {"props": {"name": "string", "status": "string"}},
+        "person": {"props": {"name": "string", "role": "string"}},
+        "tool": {"props": {"name": "string", "category": "string"}},
+        "command": {"props": {"name": "string", "platform": "string"}},
+        "concept": {"props": {"name": "string", "domain": "string"}},
+        "note": {"props": {"title": "string", "topic": "string"}},
+        "document": {"props": {"title": "string", "kind": "string"}},
+    },
+    "edge_types": {
+        "depends_on": {"from": "service", "to": "service"},
+        "decided_by": {"from": "decision", "to": "team"},
+        "owns": {"from": "team", "to": "service"},
+        "part_of": {"from": "service", "to": "project"},
+        "uses": {"from": "service", "to": "tool"},
+        "mentions": {"from": "note", "to": "concept"},
+        "documents": {"from": "document", "to": "concept"},
+        "describes": {"from": "note", "to": "service"},
+        "relates_to": {"from": "concept", "to": "concept"},
+    },
+}
+
 DEFAULT_SCHEMA = {
     # Ontology v2 (schema_version 3): work-context types bridging personal (me)
     # and team namespaces. Catch-all types (concept/tool/command/note) removed —
@@ -10,7 +37,7 @@ DEFAULT_SCHEMA = {
     "version": 3,
     "node_types": {
         # people / subject
-        "person": {"props": {"name": "string", "handle": "string", "role": "string", "org": "string"}},
+        "person": {"props": {"name": "string", "handle": "string", "org": "string"}},
         "role": {"props": {"name": "string", "domain": "string"}},
         "skill": {"props": {"name": "string", "domain": "string", "level": "string"}},
         # knowledge
@@ -19,7 +46,7 @@ DEFAULT_SCHEMA = {
         "value": {"props": {"name": "string", "description": "string"}},
         "goal": {"props": {"title": "string", "timeframe": "string", "status": "string"}},
         # team / work
-        "service": {"props": {"name": "string", "lang": "string", "owner": "string", "status": "string"}},
+        "service": {"props": {"name": "string", "lang": "string", "status": "string"}},
         "project": {"props": {"name": "string", "status": "string", "start_date": "string"}},
         "decision": {"props": {"title": "string", "status": "string", "decided_on": "string"}},
         "team": {"props": {"name": "string", "org": "string"}},
@@ -29,19 +56,30 @@ DEFAULT_SCHEMA = {
         # entity-centric (team)
         "depends_on": {"from": "service", "to": "service"},
         "part_of": {"from": "service", "to": "project"},
-        "decided_by": {"from": "decision", "to": "person"},
+        "decided_by": {"from": "decision", "to": ["person", "team"]},
         # cross-ns bridge (subject -> team)
-        "owns": {"from": "person", "to": "service"},
+        "owns": {"from": ["person", "team"], "to": "service"},
         "contributes_to": {"from": "person", "to": "project"},
         "works_on": {"from": "person", "to": "project"},
         # subject knowledge
-        "skilled_in": {"from": "person", "to": "domain"},
+        "has_role": {"from": "person", "to": "role"},
+        "has_skill": {"from": "person", "to": "skill"},
+        "in_domain": {"from": ["role", "skill"], "to": "domain"},
+        "pursues": {"from": "person", "to": "goal"},
+        "holds_value": {"from": "person", "to": "value"},
+        "member_of": {"from": "person", "to": "team"},
         "is_a": {"from": "service", "to": "domain"},
         "collaborates_with": {"from": "person", "to": "person"},
         "prefers": {"from": "person", "to": "preference"},
         # generic / doc
-        "relates_to": {"from": "service", "to": "service"},
-        "documents": {"from": "document", "to": "service"},
+        "relates_to": {
+            "from": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"],
+            "to": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"],
+        },
+        "documents": {
+            "from": "document",
+            "to": ["service", "project", "decision", "domain"],
+        },
     },
 }
 
@@ -90,7 +128,8 @@ provider:
 compile:
   chunk_lines: 60
 ns:
-  default: [public]
+  default: [me]
+  personal: me
 install_source: pypi
 """
 

--- a/src/lorekeep/defaults.py
+++ b/src/lorekeep/defaults.py
@@ -45,6 +45,41 @@ DEFAULT_SCHEMA = {
     },
 }
 
+# Optional profile scaffold written to raw/<ns>/profile.md on first init.
+# The user fills it in by hand (in Obsidian/Tolaria) — it is the editable
+# source; the wiki is a derived view. The 'me' namespace is subject-centric,
+# so this anchors extraction on the user and links their skills/domains/goals
+# to team entities via cross-namespace edges.
+DEFAULT_PROFILE_TEMPLATE = """\
+# Profile
+
+<!-- Personal context — fill in to anchor your knowledge graph. The 'me'
+namespace is subject-centric: extraction anchors on you and links your
+skills/domains/goals to team entities. Edit this file (Obsidian/Tolaria),
+then `lorekeep compile` — the wiki reflects you. This raw/ file is the
+source of truth; the wiki is a regenerable view. Delete any section you
+leave blank. -->
+
+## Role
+<!-- e.g. AI/LLM Engineer, evaluation & guardrail -->
+
+## Domains
+<!-- knowledge areas you're strong in, one per line:
+RAG evaluation, GCP IAM, Confluence platform, ... -->
+
+## Skills
+<!-- one per line: name (level: beginner | practitioner | expert) -->
+
+## Goals
+<!-- current objectives / OKRs -->
+
+## Preferences
+<!-- working style, e.g. terse comms, confirm before destructive ops -->
+
+## Values
+<!-- principles that shape your decisions -->
+"""
+
 DEFAULT_CONFIG_YAML = """\
 provider:
   model: openai/gpt-4o-mini

--- a/src/lorekeep/defaults.py
+++ b/src/lorekeep/defaults.py
@@ -2,29 +2,46 @@
 from __future__ import annotations
 
 DEFAULT_SCHEMA = {
-    "version": 2,
+    # Ontology v2 (schema_version 3): work-context types bridging personal (me)
+    # and team namespaces. Catch-all types (concept/tool/command/note) removed —
+    # tokens that used to become those nodes are now attributes (see the altitude
+    # rule in compile/extract.py). Validation is type-name only; from/to below are
+    # guidance for the extractor, not a hard gate.
+    "version": 3,
     "node_types": {
-        "service": {"props": {"name": "string", "lang": "string"}},
-        "team": {"props": {"name": "string"}},
-        "decision": {"props": {"title": "string"}},
-        "project": {"props": {"name": "string", "status": "string"}},
-        "person": {"props": {"name": "string", "role": "string"}},
-        "tool": {"props": {"name": "string", "category": "string"}},
-        "command": {"props": {"name": "string", "platform": "string"}},
-        "concept": {"props": {"name": "string", "domain": "string"}},
-        "note": {"props": {"title": "string", "topic": "string"}},
+        # people / subject
+        "person": {"props": {"name": "string", "handle": "string", "role": "string", "org": "string"}},
+        "role": {"props": {"name": "string", "domain": "string"}},
+        "skill": {"props": {"name": "string", "domain": "string", "level": "string"}},
+        # knowledge
+        "domain": {"props": {"name": "string", "description": "string"}},
+        "preference": {"props": {"name": "string", "description": "string"}},
+        "value": {"props": {"name": "string", "description": "string"}},
+        "goal": {"props": {"title": "string", "timeframe": "string", "status": "string"}},
+        # team / work
+        "service": {"props": {"name": "string", "lang": "string", "owner": "string", "status": "string"}},
+        "project": {"props": {"name": "string", "status": "string", "start_date": "string"}},
+        "decision": {"props": {"title": "string", "status": "string", "decided_on": "string"}},
+        "team": {"props": {"name": "string", "org": "string"}},
         "document": {"props": {"title": "string", "kind": "string"}},
     },
     "edge_types": {
+        # entity-centric (team)
         "depends_on": {"from": "service", "to": "service"},
-        "decided_by": {"from": "decision", "to": "team"},
-        "owns": {"from": "team", "to": "service"},
         "part_of": {"from": "service", "to": "project"},
-        "uses": {"from": "service", "to": "tool"},
-        "mentions": {"from": "note", "to": "concept"},
-        "documents": {"from": "document", "to": "concept"},
-        "describes": {"from": "note", "to": "service"},
-        "relates_to": {"from": "concept", "to": "concept"},
+        "decided_by": {"from": "decision", "to": "person"},
+        # cross-ns bridge (subject -> team)
+        "owns": {"from": "person", "to": "service"},
+        "contributes_to": {"from": "person", "to": "project"},
+        "works_on": {"from": "person", "to": "project"},
+        # subject knowledge
+        "skilled_in": {"from": "person", "to": "domain"},
+        "is_a": {"from": "service", "to": "domain"},
+        "collaborates_with": {"from": "person", "to": "person"},
+        "prefers": {"from": "person", "to": "preference"},
+        # generic / doc
+        "relates_to": {"from": "service", "to": "service"},
+        "documents": {"from": "document", "to": "service"},
     },
 }
 

--- a/src/lorekeep/integrations/claude_code.py
+++ b/src/lorekeep/integrations/claude_code.py
@@ -6,9 +6,9 @@ from pathlib import Path
 
 
 def write_config(target_dir: Path, command: str, args: list[str], ns: str | None) -> Path:
-    entry = {"command": command, "args": args}
+    entry = {"command": command, "args": args, "env": {"LOREKEEP_AGENT": "claude"}}
     if ns:
-        entry["env"] = {"LOREKEEP_NS": ns}
+        entry["env"]["LOREKEEP_NS"] = ns
     path = Path(target_dir) / ".mcp.json"
     existing = {}
     if path.exists():

--- a/src/lorekeep/integrations/codex.py
+++ b/src/lorekeep/integrations/codex.py
@@ -21,8 +21,10 @@ def _lorekeep_block(command: str, args: list[str], ns: str | None) -> str:
         f'command = "{_toml_escape(command)}"',
         f"args = {_toml_quote_list(args)}",
     ]
+    env = ['LOREKEEP_AGENT = "codex"']
     if ns:
-        lines.append(f'env = {{ LOREKEEP_NS = "{_toml_escape(ns)}" }}')
+        env.append(f'LOREKEEP_NS = "{_toml_escape(ns)}"')
+    lines.append("env = { " + ", ".join(env) + " }")
     return "\n".join(lines)
 
 

--- a/src/lorekeep/integrations/cursor.py
+++ b/src/lorekeep/integrations/cursor.py
@@ -6,9 +6,9 @@ from pathlib import Path
 
 
 def write_config(target_dir: Path, command: str, args: list[str], ns: str | None) -> Path:
-    entry = {"command": command, "args": args}
+    entry = {"command": command, "args": args, "env": {"LOREKEEP_AGENT": "cursor"}}
     if ns:
-        entry["env"] = {"LOREKEEP_NS": ns}
+        entry["env"]["LOREKEEP_NS"] = ns
     d = Path(target_dir) / ".cursor"
     d.mkdir(parents=True, exist_ok=True)
     path = d / "mcp.json"

--- a/src/lorekeep/integrations/opencode.py
+++ b/src/lorekeep/integrations/opencode.py
@@ -22,8 +22,9 @@ def write_config(target_dir: Path, command: str, args: list[str], ns: str | None
         "command": [command, *args],
         "enabled": True,
     }
+    entry["environment"] = {"LOREKEEP_AGENT": "opencode"}
     if ns:
-        entry["environment"] = {"LOREKEEP_NS": ns}
+        entry["environment"]["LOREKEEP_NS"] = ns
 
     mcp = existing.get("mcp", {})
     mcp["lorekeep"] = entry

--- a/src/lorekeep/journal.py
+++ b/src/lorekeep/journal.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 
 from lorekeep.models import JournalEntry
@@ -19,13 +20,49 @@ def journal_path(pending_dir: Path, ns: str) -> Path:
     return ns_path / "journal.jsonl"
 
 
+@contextmanager
+def _journal_lock(path: Path):
+    """Cross-process lock shared by append and status-rewrite operations."""
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock_path, "a+b") as lock:
+        if os.name == "nt":
+            import msvcrt
+            lock.seek(0, os.SEEK_END)
+            if lock.tell() == 0:
+                lock.write(b"\0")
+                lock.flush()
+            lock.seek(0)
+            msvcrt.locking(lock.fileno(), msvcrt.LK_LOCK, 1)
+            try:
+                yield
+            finally:
+                lock.seek(0)
+                msvcrt.locking(lock.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def resolve_lock(pending_dir: Path):
+    """Serialize the full graph read→merge→write→status transaction."""
+    with _journal_lock(Path(pending_dir) / ".resolve"):
+        yield
+
+
 def append_journal(pending_dir: Path, entry: JournalEntry, ns: str) -> JournalEntry:
     path = journal_path(pending_dir, ns)
     line = json.dumps(entry.model_dump(mode="json"), sort_keys=True, ensure_ascii=False) + "\n"
-    with open(path, "a", encoding="utf-8") as f:
-        f.write(line)
-        f.flush()
-        os.fsync(f.fileno())
+    with _journal_lock(path):
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(line)
+            f.flush()
+            os.fsync(f.fileno())
     return entry
 
 
@@ -51,35 +88,37 @@ def load_journals(pending_dir: Path) -> list[JournalEntry]:
 
 
 def update_journal_status(pending_dir: Path, ns: str,
-                          proposed_at_set: set[str],
+                          entry_key_set: set[str],
                           new_status: str) -> None:
     path = journal_path(pending_dir, ns)
     if not path.exists():
         return
-    text = path.read_text(encoding="utf-8")
-    lines = text.splitlines()
-    updated: list[str] = []
-    for line_text in lines:
-        line_text = line_text.strip()
-        if not line_text:
-            updated.append("")
-            continue
+    with _journal_lock(path):
+        text = path.read_text(encoding="utf-8")
+        lines = text.splitlines()
+        updated: list[str] = []
+        for line_text in lines:
+            line_text = line_text.strip()
+            if not line_text:
+                updated.append("")
+                continue
+            try:
+                d = json.loads(line_text)
+                key = d.get("entry_id") or d.get("proposed_at")
+                if key in entry_key_set and d.get("status") == "pending":
+                    d["status"] = new_status
+                updated.append(json.dumps(d, sort_keys=True, ensure_ascii=False))
+            except Exception:
+                updated.append(line_text)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
         try:
-            d = json.loads(line_text)
-            if d.get("proposed_at") in proposed_at_set and d.get("status") == "pending":
-                d["status"] = new_status
-            updated.append(json.dumps(d, sort_keys=True, ensure_ascii=False))
-        except Exception:
-            updated.append(line_text)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write("\n".join(updated) + ("\n" if updated else ""))
-        os.replace(tmp, path)
-    except BaseException:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write("\n".join(updated) + ("\n" if updated else ""))
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise

--- a/src/lorekeep/mcp_server.py
+++ b/src/lorekeep/mcp_server.py
@@ -9,6 +9,9 @@ the next resolve pass.
 """
 from __future__ import annotations
 
+import os
+import socket
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -195,10 +198,15 @@ def _write_journal(fact_dict: dict, confidence: float, agent: str = "mcp") -> di
         return {"error": "no pending directory configured"}
     ns = _primary_ns()
     fact_dict["ns"] = list(_active_ns())
-    now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    agent = os.environ.get("LOREKEEP_AGENT", agent)
+    device = os.environ.get("LOREKEEP_DEVICE", socket.gethostname())
+    now = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+    entry_id = uuid.uuid4().hex
     entry = JournalEntry(
         fact=fact_dict,
         agent=agent,
+        device=device,
+        entry_id=entry_id,
         ns=ns,
         confidence=max(0.0, min(1.0, float(confidence))),
         proposed_at=now,
@@ -211,6 +219,7 @@ def _write_journal(fact_dict: dict, confidence: float, agent: str = "mcp") -> di
         "status": "pending",
         "ns": ns,
         "proposed_at": now,
+        "entry_id": entry_id,
     }
 
 
@@ -226,6 +235,18 @@ def propose_fact(fact: dict, confidence: float) -> dict:
     elif fact["kind"] == "edge":
         if not _schema.is_valid_edge_type(fact_type):
             return {"error": f"unknown edge type: {fact_type}"}
+        scoped = _require()
+        from_node = scoped.get_node(fact.get("from", ""))
+        to_node = scoped.get_node(fact.get("to", ""))
+        if from_node is None or to_node is None:
+            return {"error": "edge endpoint not found or out of scope"}
+        if not _schema.is_valid_edge_endpoints(
+            fact_type, from_node.type, to_node.type,
+        ):
+            return {
+                "error": f"invalid endpoints for {fact_type}: "
+                f"{from_node.type}->{to_node.type}"
+            }
     else:
         return {"error": f"unknown fact kind: {fact.get('kind')}"}
     fact.pop("ns", None)
@@ -246,6 +267,15 @@ def link_facts(from_id: str, to_id: str, edge_type: str, confidence: float) -> d
         return {"error": "no schema loaded"}
     if not _schema.is_valid_edge_type(edge_type):
         return {"error": f"unknown edge type: {edge_type}"}
+    from_node = scoped.get_node(from_id)
+    to_node = scoped.get_node(to_id)
+    if not _schema.is_valid_edge_endpoints(
+        edge_type, from_node.type, to_node.type,
+    ):
+        return {
+            "error": f"invalid endpoints for {edge_type}: "
+            f"{from_node.type}->{to_node.type}"
+        }
     fact = {
         "kind": "edge",
         "id": "",
@@ -266,7 +296,7 @@ def flag_contradiction(fact_a_id: str, fact_b_id: str, description: str) -> dict
     if pending is None:
         return {"error": "no pending directory configured"}
     ns = _primary_ns()
-    now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    now = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
     flag_fact = {
         "kind": "node",
         "id": f"contradiction:{fact_a_id}:{fact_b_id}",
@@ -280,7 +310,9 @@ def flag_contradiction(fact_a_id: str, fact_b_id: str, description: str) -> dict
     }
     entry = JournalEntry(
         fact=flag_fact,
-        agent="mcp",
+        agent=os.environ.get("LOREKEEP_AGENT", "mcp"),
+        device=os.environ.get("LOREKEEP_DEVICE", socket.gethostname()),
+        entry_id=uuid.uuid4().hex,
         ns=ns,
         confidence=0.0,
         proposed_at=now,
@@ -299,19 +331,18 @@ def flag_contradiction(fact_a_id: str, fact_b_id: str, description: str) -> dict
 def update_fact(id: str, props: dict, confidence: float) -> dict:
     """Propose updated props for an existing node or edge."""
     scoped = _require()
-    store = scoped._g
-    node = store.get_node(id)
+    node = scoped.get_node(id)
     if node is not None:
         fact = node.model_dump(mode="json", by_alias=True)
         fact["props"] = props
         fact.pop("ns", None)
         return _write_journal(fact, confidence)
-    for e in store.all_edges():
-        if e.id == id:
-            edge_dict = e.model_dump(mode="json", by_alias=True)
-            edge_dict["props"] = props
-            edge_dict.pop("ns", None)
-            return _write_journal(edge_dict, confidence)
+    edge = scoped.get_edge(id)
+    if edge is not None:
+        edge_dict = edge.model_dump(mode="json", by_alias=True)
+        edge_dict["props"] = props
+        edge_dict.pop("ns", None)
+        return _write_journal(edge_dict, confidence)
     return {"error": f"fact not found or out of scope: {id}"}
 
 
@@ -322,7 +353,7 @@ def suggest_improvement(description: str) -> dict:
     if pending is None:
         return {"error": "no pending directory configured"}
     ns = _primary_ns()
-    now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    now = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
     suggestion_fact = {
         "kind": "node",
         "id": f"suggestion:{_primary_ns()}:{now[:19]}",
@@ -336,7 +367,9 @@ def suggest_improvement(description: str) -> dict:
     }
     entry = JournalEntry(
         fact=suggestion_fact,
-        agent="mcp",
+        agent=os.environ.get("LOREKEEP_AGENT", "mcp"),
+        device=os.environ.get("LOREKEEP_DEVICE", socket.gethostname()),
+        entry_id=uuid.uuid4().hex,
         ns=ns,
         confidence=0.0,
         proposed_at=now,

--- a/src/lorekeep/models.py
+++ b/src/lorekeep/models.py
@@ -76,8 +76,18 @@ class TypeSpec(BaseModel):
 
 class EndpointSpec(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
-    from_: str = Field(alias="from")
-    to: str
+    from_: str | tuple[str, ...] = Field(alias="from")
+    to: str | tuple[str, ...]
+
+    @staticmethod
+    def _types(value: str | tuple[str, ...]) -> tuple[str, ...]:
+        return (value,) if isinstance(value, str) else value
+
+    def allows(self, from_type: str, to_type: str) -> bool:
+        return (
+            from_type in self._types(self.from_)
+            and to_type in self._types(self.to)
+        )
 
 
 class Schema(BaseModel):
@@ -95,6 +105,12 @@ class Schema(BaseModel):
 
     def is_valid_edge_type(self, t: str) -> bool:
         return t in self.edge_types
+
+    def is_valid_edge_endpoints(
+        self, edge_type: str, from_type: str, to_type: str,
+    ) -> bool:
+        spec = self.edge_types.get(edge_type)
+        return spec is not None and spec.allows(from_type, to_type)
 
 
 class CompileError(BaseModel):
@@ -114,6 +130,8 @@ class JournalEntry(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
     fact: dict[str, Any]
     agent: str
+    device: str = ""
+    entry_id: str = ""
     ns: str
     confidence: float
     proposed_at: str

--- a/src/lorekeep/perm/ns.py
+++ b/src/lorekeep/perm/ns.py
@@ -50,6 +50,14 @@ class ScopedGraph:
         node = self._g.get_node(id)
         return node if self._node_visible(node) else None
 
+    def get_edge(self, id: str) -> Edge | None:
+        edge = self._g.get_edge(id)
+        if edge is None:
+            return None
+        from_node = self._g.get_node(edge.from_)
+        to_node = self._g.get_node(edge.to)
+        return edge if is_edge_visible(edge, from_node, to_node, self._eff) else None
+
     def neighbors(self, id: str, edge_type: str | None = None, depth: int = 1) -> dict:
         start = self._g.get_node(id)
         if not self._node_visible(start):

--- a/src/lorekeep/pipeline.py
+++ b/src/lorekeep/pipeline.py
@@ -26,6 +26,7 @@ def compile_graph(
     cache_path: Path,
     chunk_lines: int = 60,
     on_progress: ProgressCb | None = None,
+    personal_ns: str = "me",
 ) -> Manifest:
     chunks = ingest(raw_root, chunk_lines=chunk_lines)
     cache = ExtractionCache(cache_path)
@@ -39,7 +40,9 @@ def compile_graph(
         if on_progress is not None:
             on_progress(i, total, chunk)
         try:
-            nodes, edges, aliases = extract_chunk(chunk, schema, provider, cache)
+            nodes, edges, aliases = extract_chunk(
+                chunk, schema, provider, cache, personal_ns=personal_ns,
+            )
             all_nodes.extend(nodes)
             all_edges.extend(edges)
             for ak, av in aliases.items():       # union variants, last-writer-wins drops aliases
@@ -50,7 +53,9 @@ def compile_graph(
                            "message": str(exc)})
     cache.save()
 
-    resolved = resolve(all_nodes, all_edges, name_aliases=all_aliases)
+    resolved = resolve(
+        all_nodes, all_edges, name_aliases=all_aliases, schema=schema,
+    )
 
     rid = run_id(chunks, schema.version)
     provisional = Manifest(schema_version=schema.version, chunk_count=len(chunks),

--- a/src/lorekeep/schema_io.py
+++ b/src/lorekeep/schema_io.py
@@ -4,9 +4,52 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from lorekeep.defaults import DEFAULT_SCHEMA, DEFAULT_SCHEMA_V2
 from lorekeep.models import Schema
 
 
 def load_schema(path: Path) -> Schema:
     data = json.loads(path.read_text(encoding="utf-8"))
     return Schema.load(data)
+
+
+def upgrade_schema(
+    path: Path,
+    *,
+    dry_run: bool = False,
+    force: bool = False,
+) -> dict:
+    """Upgrade the stock v2 schema to v3 without overwriting custom schemas."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    version = int(data.get("version", 0))
+    if version >= DEFAULT_SCHEMA["version"]:
+        return {"changed": False, "from": version, "to": version, "custom": False}
+
+    custom = data != DEFAULT_SCHEMA_V2
+    if custom and not force:
+        return {
+            "changed": False,
+            "from": version,
+            "to": DEFAULT_SCHEMA["version"],
+            "custom": True,
+        }
+
+    backup = path.with_name(f"{path.stem}.v{version}.backup{path.suffix}")
+    if not dry_run:
+        if not backup.exists():
+            backup.write_text(
+                json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+        path.write_text(
+            json.dumps(DEFAULT_SCHEMA, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    return {
+        "changed": True,
+        "from": version,
+        "to": DEFAULT_SCHEMA["version"],
+        "custom": custom,
+        "backup": str(backup),
+        "dry_run": dry_run,
+    }

--- a/src/lorekeep/store/fts.py
+++ b/src/lorekeep/store/fts.py
@@ -33,9 +33,18 @@ class FTSIndex:
         self.conn.commit()
 
     def search(self, query: str, limit: int = 10) -> list[str]:
+        terms = query.split()
+        if not terms:
+            return []
+        # MCP search accepts plain user text, not FTS5 query syntax.  Quote
+        # every whitespace-delimited term so punctuation in common entity IDs
+        # (for example ``payments-api`` or ``svc:payments``) stays literal.
+        literal_query = " AND ".join(
+            '"' + term.replace('"', '""') + '"' for term in terms
+        )
         cur = self.conn.execute(
             "SELECT id FROM nodes WHERE nodes MATCH ? LIMIT ?",
-            (query, limit),
+            (literal_query, limit),
         )
         return [row[0] for row in cur.fetchall()]
 

--- a/src/lorekeep/store/graph.py
+++ b/src/lorekeep/store/graph.py
@@ -42,6 +42,12 @@ class GraphStore:
             return None
         return self._G.nodes[id]["node"]
 
+    def get_edge(self, id: str) -> Edge | None:
+        for edge in self.all_edges():
+            if edge.id == id:
+                return edge
+        return None
+
     def all_nodes(self) -> list[Node]:
         return [d["node"] for _, d in self._G.nodes(data=True)]
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -94,7 +94,7 @@ def test_backup_never_tracks_secret_or_regenerable(tmp_path: Path):
     assert "cache.json" not in tracked
 
 
-def test_backup_never_tracks_pending_journals(tmp_path: Path):
+def test_backup_tracks_journals_for_cross_device_replay(tmp_path: Path):
     home = tmp_path / "home"
     remote = _bare_remote(tmp_path)
     init_backup(home, remote)
@@ -104,7 +104,7 @@ def test_backup_never_tracks_pending_journals(tmp_path: Path):
     )
     backup(home)
     tracked = _tracked(home)
-    assert "pending/public/journal.jsonl" not in tracked
+    assert "pending/public/journal.jsonl" in tracked
 
 
 def test_backup_retries_previously_rejected_push(tmp_path: Path):
@@ -231,6 +231,30 @@ def test_sync_backup_pulls_from_other_machine(tmp_path: Path):
 
     assert (home / "raw" / "shared" / "synced.md").exists()
     assert (home / "raw" / "local" / "local.md").exists()
+
+
+def test_sync_backup_commits_tracked_changes_before_rebase(tmp_path: Path):
+    home = tmp_path / "home"
+    remote = _bare_remote(tmp_path)
+    init_backup(home, remote)
+    tracked = home / "raw" / "shared" / "tracked.md"
+    tracked.parent.mkdir(parents=True)
+    tracked.write_text("# v1")
+    assert sync_backup(home) is True
+
+    other = tmp_path / "other-tracked"
+    subprocess.run(["git", "clone", "-q", remote, str(other)], check=True)
+    remote_only = other / "raw" / "remote" / "remote.md"
+    remote_only.parent.mkdir(parents=True)
+    remote_only.write_text("# remote")
+    _git_cmd(["add", "-A"], other)
+    _git_cmd(["commit", "-q", "-m", "remote change"], other)
+    subprocess.run(["git", "push", "-q"], cwd=other, check=True)
+
+    tracked.write_text("# v2 local")
+    assert sync_backup(home) is True
+    assert tracked.read_text() == "# v2 local"
+    assert (home / "raw" / "remote" / "remote.md").exists()
 
 
 def test_sync_backup_handles_network_error(tmp_path: Path):

--- a/tests/test_contribution_cli.py
+++ b/tests/test_contribution_cli.py
@@ -1,0 +1,56 @@
+"""`lorekeep contribution` — team-knowledge gap suggestions (read-only)."""
+from pathlib import Path
+from typer.testing import CliRunner
+
+from lorekeep.cli import app
+
+runner = CliRunner()
+
+
+def _node_line(id, type, ns):
+    import json
+    return json.dumps({
+        "kind": "node", "id": id, "type": type, "ns": ns,
+        "valid_from": None, "valid_to": None, "props": {"name": id}, "src": [],
+    })
+
+
+def test_contribution_finds_personal_only_gap(tmp_path: Path, monkeypatch):
+    out = tmp_path / "graph"
+    out.mkdir()
+    (out / "facts.jsonl").write_text(
+        _node_line("svc:shared", "service", ["me", "backend"]) + "\n"
+        + _node_line("svc:gap", "service", ["me"]) + "\n"
+    )
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("ns:\n  default: [me]\n")
+    monkeypatch.setenv("LOREKEEP_OUT", str(out))
+    monkeypatch.setenv("LOREKEEP_CONFIG", str(cfg))
+
+    result = runner.invoke(app, ["contribution"])
+    assert result.exit_code == 0, result.output
+    assert "svc:gap" in result.output           # in me only -> gap
+    assert "svc:shared" not in result.output    # also in backend -> not a gap
+
+
+def test_contribution_no_gap_when_shared(tmp_path: Path, monkeypatch):
+    out = tmp_path / "graph"
+    out.mkdir()
+    (out / "facts.jsonl").write_text(
+        _node_line("svc:x", "service", ["me", "backend"]) + "\n"
+    )
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("ns:\n  default: [me]\n")
+    monkeypatch.setenv("LOREKEEP_OUT", str(out))
+    monkeypatch.setenv("LOREKEEP_CONFIG", str(cfg))
+
+    result = runner.invoke(app, ["contribution"])
+    assert result.exit_code == 0, result.output
+    assert "no contribution gaps" in result.output.lower()
+
+
+def test_contribution_no_graph(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "nope"))
+    result = runner.invoke(app, ["contribution"])
+    assert result.exit_code == 1
+    assert "compile" in result.output.lower()

--- a/tests/test_core_regression.py
+++ b/tests/test_core_regression.py
@@ -115,6 +115,7 @@ class TestCompilePipeline:
     def test_compile_produces_nonempty_graph(self, tmp_path, monkeypatch, patch_make_provider):
         from lorekeep.cli import app
 
+        monkeypatch.chdir(tmp_path)
         home = tmp_path / "home"
         home.mkdir()
         (home / "raw" / "backend").mkdir(parents=True)
@@ -141,6 +142,7 @@ class TestCompilePipeline:
     def test_compile_produces_wiki(self, tmp_path, monkeypatch, patch_make_provider):
         from lorekeep.cli import app
 
+        monkeypatch.chdir(tmp_path)
         home = tmp_path / "home"
         home.mkdir()
         (home / "raw" / "backend").mkdir(parents=True)
@@ -163,6 +165,7 @@ class TestCompilePipeline:
         """Recompiling unchanged input produces byte-identical facts.jsonl."""
         from lorekeep.cli import app
 
+        monkeypatch.chdir(tmp_path)
         home = tmp_path / "home"
         home.mkdir()
         (home / "raw" / "ns").mkdir(parents=True)

--- a/tests/test_daemon_multi_agent.py
+++ b/tests/test_daemon_multi_agent.py
@@ -241,6 +241,7 @@ class TestInitProducesGraph:
         from lorekeep.cli import app
         from lorekeep.providers import ModelInfo
 
+        monkeypatch.chdir(tmp_path)
         home = tmp_path / "home"
         monkeypatch.setenv("LOREKEEP_HOME", str(home))
         monkeypatch.setattr("lorekeep.cli._is_interactive", lambda: True)

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -4,12 +4,20 @@ from lorekeep.defaults import DEFAULT_SCHEMA, DEFAULT_CONFIG_YAML
 from lorekeep.config import Config
 
 
-def test_default_schema_is_valid_json_v2():
+def test_default_schema_is_valid_json_v3():
     d = DEFAULT_SCHEMA
-    assert d["version"] == 2
+    assert d["version"] == 3
     assert "service" in d["node_types"]
-    assert "concept" in d["node_types"]
+    assert "person" in d["node_types"]
+    assert "domain" in d["node_types"]          # replaced concept
+    assert "skill" in d["node_types"]           # work-context type
+    assert "concept" not in d["node_types"]     # catch-all removed
+    assert "tool" not in d["node_types"]
+    assert "command" not in d["node_types"]
+    assert "note" not in d["node_types"]
     assert "relates_to" in d["edge_types"]
+    assert "contributes_to" in d["edge_types"]  # cross-ns bridge
+    assert "mentions" not in d["edge_types"]    # weak catch-all removed
     json.dumps(d)  # serializable
 
 

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -21,14 +21,29 @@ def test_default_schema_is_valid_json_v3():
     json.dumps(d)  # serializable
 
 
+def test_every_default_node_type_participates_in_an_edge():
+    endpoints = set()
+    for spec in DEFAULT_SCHEMA["edge_types"].values():
+        for side in ("from", "to"):
+            value = spec[side]
+            endpoints.update([value] if isinstance(value, str) else value)
+    assert set(DEFAULT_SCHEMA["node_types"]) - endpoints == set()
+
+
 def test_default_config_yaml_loads_into_config():
     cfg = yaml.safe_load(DEFAULT_CONFIG_YAML)
     c = Config.model_validate(cfg)
     assert c.provider.model.startswith("openai/")
     assert c.install_source == "pypi"
-    assert c.ns.default == ["public"]
+    assert c.ns.default == ["me"]
+    assert c.ns.personal_namespace == "me"
 
 
 def test_default_config_yaml_has_no_backend():
     """backend is a removed dead field — must not appear in the template."""
     assert "backend" not in DEFAULT_CONFIG_YAML
+
+
+def test_legacy_private_default_is_inferred_as_personal_namespace():
+    config = Config.model_validate({"ns": {"default": ["private"]}})
+    assert config.ns.personal_namespace == "private"

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -22,7 +22,16 @@ def make_chunk(text="x"):
 def test_system_prompt_contains_schema():
     s = build_system_prompt(SCHEMA)
     assert "service" in s and "depends_on" in s
+    assert "name:string" in s and "lang:string" in s
     assert "knowledge-graph extractor" in s
+
+
+def test_system_prompt_scopes_temporal_dates_to_exact_fact():
+    s = build_system_prompt(SCHEMA)
+    assert "set dates on that edge only" in s
+    assert "entity itself ceased to exist" in s
+    assert "service launched on D" in s
+    assert "dependency removed on D" in s
 
 
 def test_system_prompt_has_altitude_rule():
@@ -120,6 +129,27 @@ def test_extract_chunk_caches_and_reuses(tmp_path: Path):
     n2, e2, a2 = extract_chunk(c, SCHEMA, provider, cache)
     assert len(n2) == 1
     assert len(provider.calls) == 1                    # provider called once
+
+
+def test_extract_chunk_cache_invalidates_when_system_prompt_changes(
+    tmp_path: Path, monkeypatch,
+):
+    import lorekeep.compile.extract as extract_module
+
+    cache = ExtractionCache(tmp_path / "cache.json")
+    c = make_chunk("The payments-api is a Go service.")
+    raw = json.dumps({"nodes": [], "edges": [], "aliases": {}})
+    provider = FakeProvider(responses=[raw, raw])
+
+    extract_chunk(c, SCHEMA, provider, cache)
+    monkeypatch.setattr(
+        extract_module,
+        "TEMPORAL_RULE",
+        extract_module.TEMPORAL_RULE + " Updated guidance.",
+    )
+    extract_chunk(c, SCHEMA, provider, cache)
+
+    assert len(provider.calls) == 2
 
 
 def test_cache_persists_to_disk(tmp_path: Path):

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -25,6 +25,27 @@ def test_system_prompt_contains_schema():
     assert "knowledge-graph extractor" in s
 
 
+def test_system_prompt_has_altitude_rule():
+    s = build_system_prompt(SCHEMA)
+    assert "Altitude rule" in s
+    # low-altitude tokens must not become nodes
+    assert "must NOT become nodes" in s
+
+
+def test_me_namespace_adds_subject_prompt():
+    s_me = build_system_prompt(SCHEMA, ns="me")
+    s_team = build_system_prompt(SCHEMA, ns="backend")
+    assert "personal profile" in s_me           # subject-centric guidance
+    assert "ONE canonical person" in s_me
+    assert "personal profile" not in s_team     # team ns stays entity-centric
+
+
+def test_team_namespace_omits_subject_prompt():
+    s = build_system_prompt(SCHEMA, ns="teams/backend")
+    assert "personal profile" not in s
+    assert "Altitude rule" in s                 # altitude applies everywhere
+
+
 def test_user_prompt_is_chunk_text_only():
     c = make_chunk("The payments-api is a Go service.")
     p = build_prompt(c, SCHEMA)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -46,6 +46,13 @@ def test_team_namespace_omits_subject_prompt():
     assert "Altitude rule" in s                 # altitude applies everywhere
 
 
+def test_configured_private_namespace_gets_subject_prompt():
+    s_private = build_system_prompt(SCHEMA, ns="private", personal_ns="private")
+    s_me = build_system_prompt(SCHEMA, ns="me", personal_ns="private")
+    assert "personal profile" in s_private
+    assert "personal profile" not in s_me
+
+
 def test_user_prompt_is_chunk_text_only():
     c = make_chunk("The payments-api is a Go service.")
     p = build_prompt(c, SCHEMA)

--- a/tests/test_fts.py
+++ b/tests/test_fts.py
@@ -24,10 +24,14 @@ def test_scan_search_substring(tmp_path: Path):
 
 def test_fts_index_build_and_match(tmp_path: Path):
     idx = FTSIndex(tmp_path / "fts.sqlite")
-    idx.build([nd("svc:a", "payments"), nd("svc:b", "auth")])
+    idx.build([nd("svc:a", "payments-api"), nd("svc:b", "auth")])
     assert "svc:a" in idx.search("payments")
     assert idx.search("payments") == ["svc:a"]
+    assert idx.search("payments-api") == ["svc:a"]
+    assert idx.search("svc:a") == ["svc:a"]
     assert idx.search("nomatch*") == []
+    assert idx.search("-") == []
+    assert idx.search("") == []
     idx.close()
 
 

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -21,12 +21,12 @@ def test_init_creates_home(tmp_path: Path, monkeypatch):
 
 
 def test_init_creates_about_template(tmp_path: Path, monkeypatch):
-    """Non-TTY mode: uses defaults + writes about.md (profile template) under raw/public/."""
+    """Non-TTY mode writes the personal profile under raw/me/, never public."""
     home = tmp_path / "home"
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
     result = runner.invoke(app, ["init"])
     assert result.exit_code == 0, result.stdout
-    about = home / "raw" / "public" / "about.md"
+    about = home / "raw" / "me" / "about.md"
     assert about.exists()
     assert "(your name)" in about.read_text()
 
@@ -38,7 +38,8 @@ def test_init_yes_flag_skips_prompts(tmp_path: Path, monkeypatch):
     assert result.exit_code == 0, result.stdout
     assert (home / "config.yaml").exists()
     cfg = yaml.safe_load((home / "config.yaml").read_text())
-    assert cfg["ns"]["default"] == ["public"]
+    assert cfg["ns"]["default"] == ["me"]
+    assert cfg["ns"]["personal"] == "me"
     assert cfg["provider"]["model"] == "openai/gpt-4o-mini"
 
 
@@ -140,8 +141,8 @@ def test_init_writes_about_even_with_existing_raw_files(tmp_path: Path, monkeypa
     (home / "raw" / "existing" / "doc.md").write_text("# existing")
     result = runner.invoke(app, ["init"])
     assert result.exit_code == 0, result.stdout
-    # about.md written to default ns (public) alongside existing files
-    assert (home / "raw" / "public" / "about.md").exists()
+    # about.md written to the personal namespace alongside existing files
+    assert (home / "raw" / "me" / "about.md").exists()
 
 
 def test_init_no_about_on_second_run(tmp_path: Path, monkeypatch):
@@ -150,7 +151,7 @@ def test_init_no_about_on_second_run(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
     result = runner.invoke(app, ["init"])
     assert result.exit_code == 0
-    about = home / "raw" / "public" / "about.md"
+    about = home / "raw" / "me" / "about.md"
     assert about.exists()
     about.write_text("# Custom Bio\n\nDon't overwrite me.\n")
 
@@ -231,8 +232,8 @@ def test_init_writes_profile_template(tmp_path: Path, monkeypatch):
     from lorekeep.cli import app
     result = runner.invoke(app, ["init", "--yes"])
     assert result.exit_code == 0, result.stdout
-    # default ns is 'public' in --yes mode; profile written there too
-    profile = home / "raw" / "public" / "profile.md"
+    # Non-interactive init must never put a personal profile in public.
+    profile = home / "raw" / "me" / "profile.md"
     assert profile.exists()
     content = profile.read_text()
     assert "## Role" in content

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -17,7 +17,7 @@ def test_init_creates_home(tmp_path: Path, monkeypatch):
     assert (home / "graph").is_dir()
     import json
     schema = json.loads((home / "schema.json").read_text())
-    assert schema["version"] == 2
+    assert schema["version"] == 3
 
 
 def test_init_creates_about_template(tmp_path: Path, monkeypatch):

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -222,3 +222,30 @@ def test_init_no_agents_detected_message(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["init", "--yes"])
     assert result.exit_code == 0, result.stdout
     assert "no coding agents detected" in result.stdout.lower()
+
+
+def test_init_writes_profile_template(tmp_path: Path, monkeypatch):
+    """First init writes raw/<ns>/profile.md scaffold for the personal namespace."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    from lorekeep.cli import app
+    result = runner.invoke(app, ["init", "--yes"])
+    assert result.exit_code == 0, result.stdout
+    # default ns is 'public' in --yes mode; profile written there too
+    profile = home / "raw" / "public" / "profile.md"
+    assert profile.exists()
+    content = profile.read_text()
+    assert "## Role" in content
+    assert "## Domains" in content
+    assert "## Skills" in content
+    assert "## Goals" in content
+
+
+def test_profile_command_shows_source(tmp_path: Path, monkeypatch):
+    home = tmp_path / "home"
+    (home / "raw" / "public").mkdir(parents=True)
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    result = runner.invoke(app, ["profile"])
+    assert result.exit_code == 0, result.stdout
+    assert "profile source" in result.stdout
+    assert "raw" in result.stdout

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -1,9 +1,16 @@
 from pathlib import Path
+import pytest
 from typer.testing import CliRunner
 from lorekeep.cli import app
 import yaml
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def isolate_project_cwd(tmp_path: Path, monkeypatch):
+    """Never let init wiring touch the developer's real checkout."""
+    monkeypatch.chdir(tmp_path)
 
 
 def test_init_creates_home(tmp_path: Path, monkeypatch):

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -26,6 +26,7 @@ def test_claude_writes_mcp_json(tmp_path: Path):
     data = json.loads((tmp_path / ".mcp.json").read_text())
     assert data["mcpServers"]["lorekeep"]["command"] == "uvx"
     assert data["mcpServers"]["lorekeep"]["env"]["LOREKEEP_NS"] == "teams/backend"
+    assert data["mcpServers"]["lorekeep"]["env"]["LOREKEEP_AGENT"] == "claude"
 
 
 def test_cursor_writes_mcp_json(tmp_path: Path):
@@ -41,6 +42,7 @@ def test_codex_writes_toml(tmp_path: Path):
     assert "[mcp_servers.lorekeep]" in text
     assert 'command = "uvx"' in text
     assert 'LOREKEEP_NS = "teams/backend"' in text
+    assert 'LOREKEEP_AGENT = "codex"' in text
 
 
 def test_agent_memory_snippet_mentions_provenance():
@@ -83,7 +85,7 @@ def test_opencode_no_ns(tmp_path: Path):
     opencode.write_config(tmp_path, "uvx", ["lorekeep", "serve", "--transport", "stdio"], ns=None)
     data = json.loads((tmp_path / "opencode.json").read_text())
     entry = data["mcp"]["lorekeep"]
-    assert "environment" not in entry
+    assert entry["environment"] == {"LOREKEEP_AGENT": "opencode"}
 
 
 def test_opencode_idempotent(tmp_path: Path):

--- a/tests/test_journal_concurrency.py
+++ b/tests/test_journal_concurrency.py
@@ -1,0 +1,47 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from lorekeep.journal import append_journal, load_journals, update_journal_status
+from lorekeep.models import JournalEntry
+
+
+def _entry(index: int, proposed_at: str = "2026-07-29T00:00:00Z") -> JournalEntry:
+    return JournalEntry(
+        entry_id=f"entry-{index}",
+        fact={
+            "kind": "node",
+            "id": f"svc:{index}",
+            "type": "service",
+            "ns": ["backend"],
+            "props": {},
+            "src": [],
+        },
+        agent="test",
+        device="test-device",
+        ns="backend",
+        confidence=0.9,
+        proposed_at=proposed_at,
+        status="pending",
+    )
+
+
+def test_concurrent_appends_do_not_lose_or_corrupt_lines(tmp_path):
+    entries = [_entry(i) for i in range(50)]
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda entry: append_journal(
+            tmp_path, entry, "backend",
+        ), entries))
+
+    loaded = load_journals(tmp_path)
+    assert {entry.entry_id for entry in loaded} == {
+        f"entry-{i}" for i in range(50)
+    }
+
+
+def test_status_update_uses_entry_id_not_second_precision_timestamp(tmp_path):
+    append_journal(tmp_path, _entry(1), "backend")
+    append_journal(tmp_path, _entry(2), "backend")
+
+    update_journal_status(tmp_path, "backend", {"entry-1"}, "merged")
+
+    by_id = {entry.entry_id: entry.status for entry in load_journals(tmp_path)}
+    assert by_id == {"entry-1": "merged", "entry-2": "pending"}

--- a/tests/test_journal_replay.py
+++ b/tests/test_journal_replay.py
@@ -1,0 +1,83 @@
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+from lorekeep.cli import _do_auto_resolve
+from lorekeep.defaults import DEFAULT_SCHEMA
+from lorekeep.facts_io import read_facts
+from lorekeep.journal import append_journal
+from lorekeep.models import JournalEntry, Node
+
+
+def test_post_compile_replays_accepted_agent_facts(tmp_path):
+    out = tmp_path / "graph"
+    out.mkdir()
+    raw_fact = {
+        "kind": "node", "id": "svc:raw", "type": "service",
+        "ns": ["backend"], "valid_from": None, "valid_to": None,
+        "props": {"name": "raw"}, "src": ["raw/backend/x.md:1"],
+    }
+    (out / "facts.jsonl").write_text(json.dumps(raw_fact) + "\n")
+    schema = tmp_path / "schema.json"
+    schema.write_text(json.dumps(DEFAULT_SCHEMA))
+    pending = tmp_path / "pending"
+    agent_fact = {
+        "kind": "node", "id": "svc:agent", "type": "service",
+        "ns": ["backend"], "valid_from": None, "valid_to": None,
+        "props": {"name": "agent"}, "src": [],
+    }
+    append_journal(
+        pending,
+        JournalEntry(
+            entry_id="accepted-1",
+            fact=agent_fact,
+            agent="codex",
+            device="laptop",
+            ns="backend",
+            confidence=0.9,
+            proposed_at="2026-07-29T00:00:00Z",
+            status="merged",
+        ),
+        "backend",
+    )
+
+    changed = _do_auto_resolve(
+        out, pending, schema_path=schema, replay_accepted=True,
+    )
+
+    assert changed is True
+    nodes = [fact for fact in read_facts(out / "facts.jsonl") if isinstance(fact, Node)]
+    assert {node.id for node in nodes} == {"svc:raw", "svc:agent"}
+
+
+def test_concurrent_resolve_transactions_do_not_drop_facts(tmp_path):
+    out = tmp_path / "graph"
+    out.mkdir()
+    (out / "facts.jsonl").write_text("")
+    schema = tmp_path / "schema.json"
+    schema.write_text(json.dumps(DEFAULT_SCHEMA))
+    pending = tmp_path / "pending"
+    for index in range(2):
+        append_journal(
+            pending,
+            JournalEntry(
+                entry_id=f"pending-{index}",
+                fact={
+                    "kind": "node", "id": f"svc:{index}", "type": "service",
+                    "ns": ["backend"], "valid_from": None, "valid_to": None,
+                    "props": {}, "src": [],
+                },
+                agent="codex", device="laptop", ns="backend",
+                confidence=0.9, proposed_at=f"2026-07-29T00:00:0{index}Z",
+                status="pending",
+            ),
+            "backend",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        list(pool.map(
+            lambda _: _do_auto_resolve(out, pending, schema_path=schema),
+            range(2),
+        ))
+
+    nodes = [fact for fact in read_facts(out / "facts.jsonl") if isinstance(fact, Node)]
+    assert {node.id for node in nodes} == {"svc:0", "svc:1"}

--- a/tests/test_mcp_write_tools.py
+++ b/tests/test_mcp_write_tools.py
@@ -111,6 +111,14 @@ def test_link_facts_rejects_unknown_edge_type(fixtures: Path):
     assert "error" in r
 
 
+def test_link_facts_rejects_invalid_endpoint_types(fixtures: Path):
+    _setup(fixtures, ["backend"])
+    result = ms.link_facts(
+        "team:backend", "svc:auth", "depends_on", confidence=0.8,
+    )
+    assert "invalid endpoints" in result["error"]
+
+
 # ── flag_contradiction ───────────────────────────────────────────────────
 
 
@@ -148,6 +156,28 @@ def test_update_fact_rejects_unknown_id(fixtures: Path):
     _setup(fixtures, ["backend"])
     r = ms.update_fact("svc:nonexistent", {"lang": "rust"}, confidence=0.8)
     assert "error" in r
+
+
+def test_update_fact_rejects_hidden_id(fixtures: Path):
+    d, pending = _setup(fixtures, ["backend"])
+    hidden = {
+        "kind": "node", "id": "svc:secret", "type": "service",
+        "ns": ["private"], "valid_from": None, "valid_to": None,
+        "props": {"name": "secret"}, "src": [],
+    }
+    with (d / "facts.jsonl").open("a") as f:
+        f.write(json.dumps(hidden) + "\n")
+    ms.configure(
+        graph_dir=d,
+        allowed_ns=["backend"],
+        schema_path=fixtures / "schema.json",
+        pending_dir=pending,
+    )
+
+    result = ms.update_fact("svc:secret", {"lang": "rust"}, confidence=0.8)
+
+    assert "error" in result
+    assert _journal_entries(pending) == []
 
 
 # ── suggest_improvement ──────────────────────────────────────────────────

--- a/tests/test_merge_journals.py
+++ b/tests/test_merge_journals.py
@@ -109,6 +109,50 @@ def test_non_pending_entries_skipped():
     assert not any(n.id == "svc:new" for n in r.nodes)
 
 
+def test_accepted_entries_can_be_replayed_after_raw_compile():
+    entry = _entry(_node_fact(), confidence=0.9, status="merged")
+    r = merge_journals([], [], [entry], replay_accepted=True)
+    assert any(n.id == "svc:new" for n in r.nodes)
+    assert r.merge_count == 0
+
+
+def test_replay_does_not_overwrite_fresh_curator_properties():
+    raw = Node(
+        id="svc:new", type="service", ns=("backend",),
+        props={"status": "current", "owner": "curator"},
+    )
+    entry = _entry(
+        _node_fact(
+            props={"status": "stale", "agent_note": "keep this"},
+        ),
+        confidence=0.9,
+        status="merged",
+    )
+
+    result = merge_journals([raw], [], [entry], replay_accepted=True)
+    node = next(node for node in result.nodes if node.id == "svc:new")
+    assert node.props == {
+        "status": "current",
+        "owner": "curator",
+        "agent_note": "keep this",
+    }
+
+
+def test_replay_does_not_overwrite_fresh_curator_edge_properties():
+    raw_edge = _edge()
+    raw_edge = raw_edge.model_copy(update={"props": {"status": "current"}})
+    fact = _edge_fact()
+    fact["props"] = {"status": "stale", "agent_note": "keep"}
+    entry = _entry(fact, confidence=0.9, status="merged")
+
+    result = merge_journals([], [raw_edge], [entry], replay_accepted=True)
+
+    assert result.edges[0].props == {
+        "status": "current",
+        "agent_note": "keep",
+    }
+
+
 # ── Invalid schema ────────────────────────────────────────────────────────
 
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -28,6 +28,7 @@ def _nontty_console(buf: StringIO) -> Console:
 
 class TestHelpersColor:
     def test_ok_emits_color_and_glyph_in_tty(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
         buf = StringIO()
         monkeypatch.setattr(output, "console", _tty_console(buf))
         output.ok("done")
@@ -52,6 +53,7 @@ class TestHelpersColor:
         assert "namespaces=['me', 'public']" in _plain(buf.getvalue())
 
     def test_error_goes_to_stdout_console(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
         buf = StringIO()
         monkeypatch.setattr(output, "console", _tty_console(buf))
         output.error("boom")

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -64,3 +64,43 @@ def test_edge_ids_are_deterministic():
     edges = [e(frm="svc:a", to="svc:b"), e(frm="svc:b", to="svc:c")]
     r = resolve(nodes, edges)
     assert [x.id for x in r.edges] == ["e_depends_on_0001", "e_depends_on_0002"]
+
+
+# ── auto-normalize (Phase 3) ───────────────────────────────────────────────
+from lorekeep.compile.resolve import _normalize_id
+
+
+class TestNormalizeId:
+    def test_kebab_snake_space_collapse(self):
+        assert _normalize_id("concept:context_purity") == "concept:context-purity"
+        assert _normalize_id("concept:Context Purity") == "concept:context-purity"
+        assert _normalize_id("concept:context-purity") == "concept:context-purity"
+
+    def test_diacritics_preserved(self):
+        # Vietnamese diacritics MUST stay — nguyễn != nguyen
+        assert _normalize_id("person:nguyễn") == "person:nguyễn"
+        assert _normalize_id("person:Nguyễn") == "person:nguyễn"
+
+    def test_type_prefix_kept(self):
+        assert _normalize_id("svc:payments-api").startswith("svc:")
+
+
+class TestAutoMergeByNormalizedId:
+    def test_merges_case_and_separator_variants(self):
+        nodes = [
+            n("domain:context-purity"),
+            n("domain:context_purity"),
+            n("domain:Context Purity"),
+        ]
+        result = resolve(nodes, [])
+        assert len(result.nodes) == 1            # all 3 merged
+
+    def test_does_not_merge_different_diacritics(self):
+        nodes = [n("person:nguyen"), n("person:nguyễn")]
+        result = resolve(nodes, [])
+        assert len(result.nodes) == 2            # distinct, kept
+
+    def test_does_not_merge_different_types(self):
+        nodes = [n("svc:auth", type="service"), n("domain:auth", type="domain")]
+        result = resolve(nodes, [])
+        assert len(result.nodes) == 2

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,6 +1,8 @@
 from datetime import date
 from lorekeep.models import Node, Edge
 from lorekeep.compile.resolve import resolve, ResolveResult
+from lorekeep.defaults import DEFAULT_SCHEMA
+from lorekeep.models import Schema
 
 
 def n(id, type="service", name=None):
@@ -66,6 +68,16 @@ def test_edge_ids_are_deterministic():
     assert [x.id for x in r.edges] == ["e_depends_on_0001", "e_depends_on_0002"]
 
 
+def test_schema_quarantines_invalid_edge_endpoint_types():
+    nodes = [n("person:a", type="person"), n("goal:x", type="goal")]
+    edges = [e(type="depends_on", frm="person:a", to="goal:x")]
+
+    result = resolve(nodes, edges, schema=Schema.load(DEFAULT_SCHEMA))
+
+    assert result.edges == []
+    assert "invalid edge endpoints" in result.quarantined[0][1]
+
+
 # ── auto-normalize (Phase 3) ───────────────────────────────────────────────
 from lorekeep.compile.resolve import _normalize_id
 
@@ -81,6 +93,11 @@ class TestNormalizeId:
         assert _normalize_id("person:nguyễn") == "person:nguyễn"
         assert _normalize_id("person:Nguyễn") == "person:nguyễn"
 
+    def test_canonically_equivalent_unicode_collapses(self):
+        assert _normalize_id("person:nguyễn") == _normalize_id(
+            "person:nguye\u0302\u0303n"
+        )
+
     def test_type_prefix_kept(self):
         assert _normalize_id("svc:payments-api").startswith("svc:")
 
@@ -94,6 +111,7 @@ class TestAutoMergeByNormalizedId:
         ]
         result = resolve(nodes, [])
         assert len(result.nodes) == 1            # all 3 merged
+        assert result.nodes[0].id == "domain:context-purity"
 
     def test_does_not_merge_different_diacritics(self):
         nodes = [n("person:nguyen"), n("person:nguyễn")]

--- a/tests/test_schema_upgrade.py
+++ b/tests/test_schema_upgrade.py
@@ -1,0 +1,60 @@
+import json
+
+from lorekeep.defaults import DEFAULT_SCHEMA, DEFAULT_SCHEMA_V2
+from lorekeep.schema_io import upgrade_schema
+from typer.testing import CliRunner
+
+from lorekeep.cli import app
+
+
+def test_upgrade_stock_v2_creates_backup_and_is_idempotent(tmp_path):
+    path = tmp_path / "schema.json"
+    path.write_text(json.dumps(DEFAULT_SCHEMA_V2))
+
+    result = upgrade_schema(path)
+
+    assert result["changed"] is True
+    assert json.loads(path.read_text()) == DEFAULT_SCHEMA
+    backup = tmp_path / "schema.v2.backup.json"
+    assert json.loads(backup.read_text()) == DEFAULT_SCHEMA_V2
+    assert upgrade_schema(path)["changed"] is False
+
+
+def test_upgrade_dry_run_does_not_write(tmp_path):
+    path = tmp_path / "schema.json"
+    original = json.dumps(DEFAULT_SCHEMA_V2)
+    path.write_text(original)
+
+    result = upgrade_schema(path, dry_run=True)
+
+    assert result["changed"] is True
+    assert path.read_text() == original
+    assert not (tmp_path / "schema.v2.backup.json").exists()
+
+
+def test_upgrade_refuses_custom_schema_without_force(tmp_path):
+    path = tmp_path / "schema.json"
+    custom = {**DEFAULT_SCHEMA_V2, "node_types": {
+        **DEFAULT_SCHEMA_V2["node_types"],
+        "custom": {"props": {"name": "string"}},
+    }}
+    path.write_text(json.dumps(custom))
+
+    result = upgrade_schema(path)
+
+    assert result["custom"] is True
+    assert result["changed"] is False
+    assert json.loads(path.read_text()) == custom
+
+
+def test_schema_upgrade_cli_upgrades_existing_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "schema.json").write_text(json.dumps(DEFAULT_SCHEMA_V2))
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+
+    result = CliRunner().invoke(app, ["schema", "upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert "v2" in result.output and "v3" in result.output
+    assert json.loads((home / "schema.json").read_text()) == DEFAULT_SCHEMA

--- a/tests/test_watch_sessions.py
+++ b/tests/test_watch_sessions.py
@@ -1,5 +1,6 @@
 """Tests for agent watch session import and auto-resolve chain."""
 import json
+import sys
 import time
 from pathlib import Path
 
@@ -140,7 +141,7 @@ def test_watch_boots_and_shuts_down_cleanly(monkeypatch, tmp_path: Path):
     import subprocess
     import os
     result = subprocess.run(
-        ["timeout", "2", "python3", "-m", "lorekeep.cli", "agent", "watch",
+        ["timeout", "2", sys.executable, "-m", "lorekeep.cli", "agent", "watch",
          "--interval", "1", "--no-watch-sessions"],
         capture_output=True, text=True,
         cwd=str(tmp_path.parent),

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -599,3 +599,10 @@ class TestCompileSingleRegen:
 
         log = (home / "wiki" / "log.md").read_text()
         assert log.count("## [") == 1, f"expected 1 log entry, got {log.count('## [')}"
+
+
+def test_slug_preserves_vietnamese_diacritics():
+    """_slug must keep diacritics (only : / -> -); stripping loses meaning."""
+    from lorekeep.wiki import _slug
+    assert _slug("person:nguyễn") == "person-nguyễn"
+    assert _slug("domain:ẩm-thực") == "domain-ẩm-thực"


### PR DESCRIPTION
## Why

The original graph was extracting at the wrong altitude: low-level tokens became nodes, entity identity fragmented, and personal/team context was poorly connected. The first version of this PR fixed the prompt and default schema, but review found that existing installations would not actually migrate and that concurrency/sync claims exceeded the implementation.

This revision makes ontology v2 usable for existing data homes and hardens the agent/device write paths it depends on.

## What

### Ontology and extraction

- Schema version 3 with connected personal/work types: person, role, skill, domain, preference, value, goal, service, project, decision, team, document.
- Adds typed relationships for roles, skills, domains, goals, values, teams, projects, services, decisions, and documents.
- Endpoint specs support type unions; resolve and MCP writes validate endpoint types and quarantine invalid facts.
- Altitude rule keeps commands, env vars, filenames, error strings, tool names, and metrics as properties rather than nodes.
- Personal extraction is driven by `ns.personal`, not a hard-coded `me` namespace. Legacy configs infer a non-public default namespace safely.
- Extraction cache keys fingerprint the complete schema and personal/subject prompt mode.

### Migration and identity

- `lorekeep schema upgrade [--dry-run] [--force]` upgrades the stock v2 schema to v3 and creates `schema.v2.backup.json`.
- Custom older schemas are refused unless `--force` is explicit.
- New installs use `ns.default: [me]` and `ns.personal: me`; non-interactive init no longer writes personal profiles to `public`.
- Canonical IDs use lowercase, separator collapse, Unicode NFC, and preserved Vietnamese diacritics. Canonical IDs no longer depend on source ordering.

### Multi-agent durability and permission

- Fixes `update_fact` bypassing `ScopedGraph`; hidden nodes/edges cannot be updated by ID.
- MCP journals now record collision-resistant `entry_id`, agent identity, device identity, and microsecond timestamps.
- Agent integrations set `LOREKEEP_AGENT` for Claude, Cursor, Codex, and opencode.
- Journal append/status operations are process-locked and status updates key by `entry_id`, not second-precision timestamps.
- Resolve is transaction-locked across graph load, journal load, graph write, and status update.
- Accepted journal facts are replayed after every raw compile, so agent knowledge no longer disappears on the next compile.
- Replay preserves curator/raw precedence while retaining non-conflicting agent properties.
- Journal merge order and regenerated edge IDs are stable.

### Multi-device source model

- Durable sync sources are now `raw/` + `schema.json` + journals; `facts.jsonl`, manifest, wiki, and caches are deterministic local derivatives.
- Private backup now tracks journals so accepted agent facts can be replayed on another device.
- Backup commits tracked local changes before fetch/rebase, avoiding dirty-worktree failures.
- Daemon syncs before startup replay and replays journals after later compile/sync cycles.
- Simultaneous edits to the same raw file or namespace journal may still require manual Git conflict resolution; a central reconciliation server remains roadmap work.

## Verification

- Full local suite: **582 passed** (one third-party LiteLLM deprecation warning).
- Live provider validation: `deepseek/deepseek-chat` compiled the non-sensitive payments fixture into 4 nodes / 3 edges; `doctor` passed provider, graph, schema, and MCP checks. Temporal MCP queries correctly kept the auth service alive after the dependency ended.
- OpenRouter validation: `openrouter/deepseek/deepseek-chat` produced the same 4-node / 3-edge ontology shape with correct preferred props and temporal behavior; `doctor`, graph validation, agent checks, and MCP assertions passed. An unchanged recompile reused cache with the same run/facts hashes. One observed first-call latency was higher than the direct provider, but this single sample is not a benchmark.
- Live output review led to stronger extraction guardrails: preferred property keys are now included in the system prompt, temporal dates are scoped to the exact node/edge fact, and the complete system prompt fingerprints the extraction cache key.
- Targeted daemon/multi-agent/journal replay/backup/schema/core integration suite: **68 passed**.
- Fixed test isolation under `NO_COLOR=1` and made the daemon subprocess use the active virtualenv interpreter.
- End-to-end smoke: all **9 MCP read tools + 5 write tools** accepted; journals preserved identities for Codex/laptop, Claude/desktop, and opencode/tablet; resolve merged high-confidence facts and quarantined review-only entries; daemon startup replay reduced pending to zero; lazy reload exposed the new node without reconnect; namespace denial remained enforced.
- Smoke testing also found and fixed an FTS5 crash for common hyphenated/colon entity IDs by treating MCP search input as literal text.
- Added tests for schema migration, custom-schema refusal, personal namespace behavior, ontology connectivity, endpoint validation, hidden write rejection, concurrent journal appends, entry-id status isolation, accepted-fact replay, concurrent resolve transactions, curator precedence, tracked-change rebase, literal FTS search, and environment-independent CLI tests.

## Upgrade

```bash
lorekeep schema upgrade --dry-run
lorekeep schema upgrade
lorekeep compile
```

The schema backup is written next to `schema.json`. Keep the backup until the rebuilt graph and wiki have been reviewed.