### PR TITLE
chore: sync uv.lock to v0.13.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1030,7 +1030,7 @@ wheels = [
 
 [[package]]
 name = "lorekeep"
-version = "0.12.2"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "litellm" },


### PR DESCRIPTION
Auto-synced after release.