### PR TITLE
fix: preserve facts in wiki projection

### DIFF
--- a/docs/guides/wiki.md
+++ b/docs/guides/wiki.md
@@ -70,18 +70,35 @@ sources:
   - "raw/backend/payments.md:3"
 tags: ["service", "backend", "entity"]
 aliases: ["payments-api"]  # human-readable name; canonical ID stays above
+props:                     # complete, lossless copy of the node fact's props
+  lang: "go"
+  name: "payments-api"
+lang: "go"                 # safe props are mirrored for Obsidian/Dataview
+name: "payments-api"
 depends_on:                  # ← relationship field (out-edges)
   - "[[svc-auth]]"
 ---
 ```
 
-The body shows a Properties table, explicit **Relationships** (`depends_on →`,
-`← decided_by`), and a Timeline. Each relationship row retains the source edge
-fact's ID, namespaces, validity window, provenance, and properties, so a page
-can be checked directly against `facts.jsonl`. The index uses readable
-`name`/`title` link aliases; relationship tables retain a canonical link plus
-a readable Label column. The filename and frontmatter `id` remain the
-canonical ontology ID.
+The body shows a first-class **Description** section when the ontology fact has
+`props.description`, a Properties table for the remaining props, explicit
+**Relationships** (`depends_on →`, `← decided_by`), and a Timeline. Description
+paragraphs and Markdown are preserved instead of being flattened into a table
+cell.
+
+Every node prop is retained under the frontmatter `props` object. Safe keys are
+also mirrored at the top level so queries such as `TABLE lang` remain concise.
+Reserved keys (`id`, `kind`, `tags`, and so on) cannot overwrite generated
+metadata; their original fact values remain available through `props.<key>`.
+Likewise, a custom edge type that collides with metadata or a mirrored prop is
+emitted as `relation_<edge-type>`.
+
+Each relationship row retains the source edge fact's ID, namespaces, validity
+window, provenance, and properties, so a page can be checked directly against
+`facts.jsonl`. Parallel or temporal edge facts remain separate rows. The index
+uses readable `name`/`title` link aliases and a short description when present;
+relationship tables retain a canonical link plus a readable Label column. The
+filename and frontmatter `id` remain the canonical ontology ID.
 
 ## 4. Graph view
 
@@ -108,8 +125,8 @@ Every entity page is tagged `[<type>, <ns>..., entity]` (e.g.
 
 - **Tag pane** (right sidebar) — click a tag to filter the file list.
 - **Graph coloring** — color groups can key off tags (`#service`, `#backend`).
-- **Search** — `tag:service lang:go` finds Go services via Obsidian's query
-  syntax.
+- **Search** — `tag:#service [lang:go]` finds Go services using Obsidian's
+  property-search syntax.
 
 ## 6. Dataview queries (community plugin)
 
@@ -122,6 +139,10 @@ All services with their stack and start date:
 TABLE lang, valid_from
 FROM #service
 ```
+
+The complete fact props are also queryable as nested Dataview fields, for
+example `TABLE props.lang, props.status`. Top-level mirrors are provided for
+ordinary, non-reserved prop keys; `props.<key>` is the canonical fallback.
 
 Currently-valid entities (no end date — `valid_to` is the empty string for
 "present"):

--- a/docs/guides/wiki.md
+++ b/docs/guides/wiki.md
@@ -60,6 +60,7 @@ queryable lists):
 
 ```yaml
 ---
+kind: "node"
 id: "svc:payments-api"
 type: "service"
 ns: ["backend"]
@@ -68,13 +69,19 @@ valid_to: ""                 # empty ⇒ currently valid
 sources:
   - "raw/backend/payments.md:3"
 tags: ["service", "backend", "entity"]
+aliases: ["payments-api"]  # human-readable name; canonical ID stays above
 depends_on:                  # ← relationship field (out-edges)
   - "[[svc-auth]]"
 ---
 ```
 
 The body shows a Properties table, explicit **Relationships** (`depends_on →`,
-`← decided_by`, with validity windows as `from → to`), and a Timeline.
+`← decided_by`), and a Timeline. Each relationship row retains the source edge
+fact's ID, namespaces, validity window, provenance, and properties, so a page
+can be checked directly against `facts.jsonl`. The index uses readable
+`name`/`title` link aliases; relationship tables retain a canonical link plus
+a readable Label column. The filename and frontmatter `id` remain the
+canonical ontology ID.
 
 ## 4. Graph view
 
@@ -84,11 +91,11 @@ directly. Tips:
 
 - **Start focused** — open a single entity, then run *Command → Open local
   graph*. The full graph of a large vault is a hairball.
-- **Filter** — in graph settings, set *Files to exclude* or filter by
-  `path:entities/` to drop `index`/`overview`/`log`.
-- **Color groups** — add color groups by `path:entities/service/`,
-  `path:entities/team/`, etc., or by tag (`#backend`, `#frontend`) to color by
-  namespace.
+- **Filter** — exclude `index.md`, `overview.md`, and `log.md` in graph
+  settings, or color/filter by the `#entity` tag. Entity notes use a flat
+  layout, so there is no `entities/` path to filter.
+- **Color groups** — use type tags (`#service`, `#team`) or namespace tags
+  (`#backend`, `#frontend`) to color by ontology type or namespace.
 - **Backlinks** — the panel at the bottom of each page is Obsidian's
   auto-generated inbound-reference list (incoming edges); the Relationships
   section in the body is the explicit version.

--- a/src/lorekeep/wiki.py
+++ b/src/lorekeep/wiki.py
@@ -42,13 +42,13 @@ def _yaml_scalar(value: str) -> str:
     """Quote a YAML scalar so special chars (colon, etc.) are safe."""
     if value is None:
         return "null"
-    return json.dumps(str(value))
+    return json.dumps(str(value), ensure_ascii=False)
 
 
 def _yaml_list(items: list[str]) -> str:
     if not items:
         return "[]"
-    return "[" + ", ".join(json.dumps(str(i)) for i in items) + "]"
+    return "[" + ", ".join(json.dumps(str(i), ensure_ascii=False) for i in items) + "]"
 
 
 def _fmt_date(d) -> str:
@@ -74,12 +74,33 @@ def _fmt_prop_value(val) -> str:
     if isinstance(val, str):
         s = val.replace("|", "\\|").replace("\n", " ")
     else:
-        s = json.dumps(val, ensure_ascii=False).replace("|", "\\|").replace("\n", " ")
+        s = json.dumps(val, ensure_ascii=False, sort_keys=True).replace("|", "\\|").replace("\n", " ")
     return s
+
+
+def _node_title(node: Node) -> str:
+    """Return the human label using the ontology's name/title conventions.
+
+    Most ontology node types use ``props.name``. Goals, decisions, and
+    documents use ``props.title`` instead, so treating ``name`` as the only
+    display field makes a correct v2 fact look like an opaque ID in the wiki.
+    """
+    for key in ("name", "title"):
+        value = node.props.get(key)
+        if value is not None and str(value).strip():
+            return str(value)
+    return node.id
+
+
+def _wikilink(node: Node) -> str:
+    """Return a readable Obsidian link while retaining the stable file slug."""
+    label = _node_title(node).replace("\n", " ").replace("|", "\\|")
+    return f"[[{_slug(node.id)}|{label}]]"
 
 
 def _frontmatter(node: Node, out_edges: list[Edge] | None = None) -> str:
     lines = ["---"]
+    lines.append(f"kind: {_yaml_scalar(node.kind)}")
     lines.append(f"id: {_yaml_scalar(node.id)}")
     lines.append(f"type: {_yaml_scalar(node.type)}")
     lines.append(f"ns: {_yaml_list(list(node.ns))}")
@@ -88,11 +109,17 @@ def _frontmatter(node: Node, out_edges: list[Edge] | None = None) -> str:
     if node.src:
         lines.append("sources:")
         for s in node.src:
-            lines.append(f"  - {json.dumps(str(s))}")
+            lines.append(f"  - {json.dumps(str(s), ensure_ascii=False)}")
     else:
         lines.append("sources: []")
     tags = [node.type] + list(node.ns) + ["entity"]
     lines.append(f"tags: {_yaml_list(tags)}")
+    title = _node_title(node)
+    if title != node.id:
+        # Obsidian resolves aliases to the same stable file, so humans can
+        # search/link by the ontology's display property without losing the
+        # canonical fact ID in the filename/frontmatter.
+        lines.append(f"aliases: {_yaml_list([title])}")
     # Out-edges as relationship frontmatter fields. Tolaria detects any
     # frontmatter field holding [[wikilink]] values as a relationship (panel +
     # neighborhood graph); Obsidian/Dataview treat them as queryable lists.
@@ -120,35 +147,66 @@ def _props_table(node: Node) -> str:
 
 
 def _relationships(
-    node: Node, out_edges: list[Edge], in_edges: list[Edge]
+    out_edges: list[Edge], in_edges: list[Edge], store: GraphStore,
 ) -> str:
+    """Render every edge touching node with its fact metadata.
+
+    A bare wikilink is enough for navigation, but it drops edge identity,
+    namespace, provenance, and arbitrary properties. Keeping those fields in
+    the generated table makes the human projection auditable against
+    facts.jsonl without sacrificing Obsidian graph links.
+    """
     sections: list[str] = []
+
+    def add_table(edges: list[Edge], *, outgoing: bool) -> None:
+        sections.extend([
+            "| Entity | Label | Fact ID | Namespaces | Validity | Sources | Properties |",
+            "|---|---|---|---|---|---|---|",
+        ])
+        for edge in edges:
+            other_id = edge.to if outgoing else edge.from_
+            other = store.get_node(other_id)
+            entity = f"[[{_slug(other.id)}]]" if other is not None else _fmt_prop_value(other_id)
+            label = _node_title(other) if other is not None else other_id
+            sections.append(
+                "| " + " | ".join([
+                    entity,
+                    _fmt_prop_value(label),
+                    f"<code>{_fmt_prop_value(edge.id)}</code>",
+                    _fmt_prop_value(list(edge.ns)),
+                    _fmt_validity(edge.valid_from, edge.valid_to),
+                    _fmt_prop_value(list(edge.src)),
+                    _fmt_prop_value(edge.props),
+                ]) + " |"
+            )
 
     if out_edges:
         sections.extend(["", "## Relationships", ""])
         by_type: dict[str, list[Edge]] = {}
-        for e in out_edges:
-            by_type.setdefault(e.type, []).append(e)
+        for edge in out_edges:
+            by_type.setdefault(edge.type, []).append(edge)
         for etype in sorted(by_type):
             sections.append(f"### {etype} \u2192")
             sections.append("")
-            for e in sorted(by_type[etype], key=lambda e: e.to):
-                validity = _fmt_validity(e.valid_from, e.valid_to)
-                sections.append(f"- [[{_slug(e.to)}]] ({validity})")
+            add_table(
+                sorted(by_type[etype], key=lambda edge: (edge.to, edge.id)),
+                outgoing=True,
+            )
             sections.append("")
 
     if in_edges:
         if not out_edges:
             sections.extend(["", "## Relationships", ""])
         by_type = {}
-        for e in in_edges:
-            by_type.setdefault(e.type, []).append(e)
+        for edge in in_edges:
+            by_type.setdefault(edge.type, []).append(edge)
         for etype in sorted(by_type):
             sections.append(f"### \u2190 {etype}")
             sections.append("")
-            for e in sorted(by_type[etype], key=lambda e: e.from_):
-                validity = _fmt_validity(e.valid_from, e.valid_to)
-                sections.append(f"- [[{_slug(e.from_)}]] ({validity})")
+            add_table(
+                sorted(by_type[etype], key=lambda edge: (edge.from_, edge.id)),
+                outgoing=False,
+            )
             sections.append("")
 
     return "\n".join(sections)
@@ -166,7 +224,7 @@ def _timeline(node: Node) -> str:
 
 
 def _entity_page(node: Node, store: GraphStore) -> str:
-    title = node.props.get("name", node.id)
+    title = _node_title(node)
     out_e = store.out_edges(node.id)
     in_e = store.in_edges(node.id)
 
@@ -178,7 +236,7 @@ def _entity_page(node: Node, store: GraphStore) -> str:
         f"> ID: `{node.id}`",
     ]
     parts.append(_props_table(node))
-    parts.append(_relationships(node, out_e, in_e))
+    parts.append(_relationships(out_e, in_e, store))
     parts.append(_timeline(node))
     parts.append("")
     return "\n".join(parts)
@@ -208,14 +266,13 @@ def _index_page(store: GraphStore) -> str:
         lines.append(f"## {ntype.title()}s")
         lines.append("")
         for n in sorted(by_type[ntype], key=lambda n: n.id):
-            title = n.props.get("name", n.id)
-            slug = _slug(n.id)
+            title = _node_title(n)
             summary_parts = [title]
             if n.props.get("lang"):
                 summary_parts.append(f"({n.props['lang']})")
             if n.valid_from:
                 summary_parts.append(f"\u2014 since {_fmt_date(n.valid_from)}")
-            lines.append(f"- [[{slug}]] \u2014 {' '.join(summary_parts)}")
+            lines.append(f"- {_wikilink(n)} \u2014 {' '.join(summary_parts)}")
         lines.append("")
 
     return "\n".join(lines)
@@ -390,5 +447,7 @@ def generate_wiki(
     return {
         "nodes": len(nodes),
         "edges": len(edges),
-        "pages": len(nodes) + 2,
+        # One page per node plus the three generated vault pages:
+        # index.md, overview.md, and the append-only log.md.
+        "pages": len(nodes) + 3,
     }

--- a/src/lorekeep/wiki.py
+++ b/src/lorekeep/wiki.py
@@ -23,10 +23,25 @@ import re
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from lorekeep.compile.writer import _atomic_write
 from lorekeep.models import Edge, Manifest, Node
 from lorekeep.store.graph import GraphStore
+
+
+_RESERVED_FRONTMATTER_KEYS = frozenset({
+    "kind",
+    "id",
+    "type",
+    "ns",
+    "valid_from",
+    "valid_to",
+    "sources",
+    "tags",
+    "aliases",
+    "props",
+})
 
 
 def _slug(node_id: str) -> str:
@@ -49,6 +64,28 @@ def _yaml_list(items: list[str]) -> str:
     if not items:
         return "[]"
     return "[" + ", ".join(json.dumps(str(i), ensure_ascii=False) for i in items) + "]"
+
+
+def _yaml_value(value: Any) -> str:
+    """Render JSON-compatible data as deterministic, YAML-compatible syntax."""
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        default=str,
+    )
+
+
+def _yaml_key(value: str) -> str:
+    """Keep ordinary ontology keys readable and quote YAML-ambiguous keys."""
+    key = str(value)
+    ambiguous = {"null", "true", "false", "yes", "no", "on", "off"}
+    if (
+        re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]*", key)
+        and key.lower() not in ambiguous
+    ):
+        return key
+    return _yaml_scalar(key)
 
 
 def _fmt_date(d) -> str:
@@ -87,18 +124,34 @@ def _node_title(node: Node) -> str:
     """
     for key in ("name", "title"):
         value = node.props.get(key)
-        if value is not None and str(value).strip():
-            return str(value)
+        if value is not None:
+            label = str(value).strip()
+            if label:
+                return label
     return node.id
+
+
+def _node_aliases(node: Node) -> list[str]:
+    """Return all distinct human labels carried by the ontology fact."""
+    aliases: list[str] = []
+    for key in ("name", "title"):
+        value = node.props.get(key)
+        if value is None:
+            continue
+        alias = str(value).strip()
+        if alias and alias != node.id and alias not in aliases:
+            aliases.append(alias)
+    return aliases
 
 
 def _wikilink(node: Node) -> str:
     """Return a readable Obsidian link while retaining the stable file slug."""
-    label = _node_title(node).replace("\n", " ").replace("|", "\\|")
+    label = " ".join(_node_title(node).split()).replace("|", "\\|")
     return f"[[{_slug(node.id)}|{label}]]"
 
 
 def _frontmatter(node: Node, out_edges: list[Edge] | None = None) -> str:
+    out_edges = out_edges or []
     lines = ["---"]
     lines.append(f"kind: {_yaml_scalar(node.kind)}")
     lines.append(f"id: {_yaml_scalar(node.id)}")
@@ -114,12 +167,33 @@ def _frontmatter(node: Node, out_edges: list[Edge] | None = None) -> str:
         lines.append("sources: []")
     tags = [node.type] + list(node.ns) + ["entity"]
     lines.append(f"tags: {_yaml_list(tags)}")
-    title = _node_title(node)
-    if title != node.id:
+    aliases = _node_aliases(node)
+    if aliases:
         # Obsidian resolves aliases to the same stable file, so humans can
         # search/link by the ontology's display property without losing the
         # canonical fact ID in the filename/frontmatter.
-        lines.append(f"aliases: {_yaml_list([title])}")
+        lines.append(f"aliases: {_yaml_list(aliases)}")
+
+    # ``props`` is the canonical, lossless projection of the node properties.
+    # Safe keys are mirrored at the top level for ergonomic Obsidian/Dataview
+    # queries. Reserved metadata remains authoritative; a custom prop with the
+    # same name is still available under ``props``.
+    if node.props:
+        lines.append("props:")
+        for key in sorted(node.props):
+            lines.append(
+                f"  {_yaml_key(key)}: {_yaml_value(node.props[key])}"
+            )
+    else:
+        lines.append("props: {}")
+
+    mirrored_prop_keys: set[str] = set()
+    for key in sorted(node.props):
+        if key in _RESERVED_FRONTMATTER_KEYS:
+            continue
+        lines.append(f"{_yaml_key(key)}: {_yaml_value(node.props[key])}")
+        mirrored_prop_keys.add(key)
+
     # Out-edges as relationship frontmatter fields. Tolaria detects any
     # frontmatter field holding [[wikilink]] values as a relationship (panel +
     # neighborhood graph); Obsidian/Dataview treat them as queryable lists.
@@ -128,22 +202,54 @@ def _frontmatter(node: Node, out_edges: list[Edge] | None = None) -> str:
         by_type: dict[str, list[str]] = {}
         for e in out_edges:
             by_type.setdefault(e.type, []).append(_slug(e.to))
+        used_keys = set(_RESERVED_FRONTMATTER_KEYS) | mirrored_prop_keys
         for etype in sorted(by_type):
+            field = etype
+            if field in used_keys:
+                base = f"relation_{etype}"
+                field = base
+                suffix = 2
+                while field in used_keys:
+                    field = f"{base}_{suffix}"
+                    suffix += 1
+            used_keys.add(field)
             targets = sorted(set(by_type[etype]))
-            lines.append(f"{etype}:")
+            lines.append(f"{_yaml_key(field)}:")
             for t in targets:
                 lines.append(f'  - "[[{t}]]"')
     lines.append("---")
     return "\n".join(lines)
 
 
+def _description(node: Node) -> str:
+    """Render the semantic description as readable Markdown, not a table cell."""
+    value = node.props.get("description")
+    if value is None:
+        return ""
+    text = str(value).replace("\r\n", "\n").replace("\r", "\n").strip()
+    if not text:
+        return ""
+    return "\n".join(["", "## Description", "", text])
+
+
 def _props_table(node: Node) -> str:
-    if not node.props:
+    keys = [key for key in sorted(node.props) if key != "description"]
+    if not keys:
         return ""
     lines = ["", "## Properties", "", "| Key | Value |", "|---|---|"]
-    for key in sorted(node.props):
+    for key in keys:
         lines.append(f"| {_fmt_prop_value(key)} | {_fmt_prop_value(node.props[key])} |")
     return "\n".join(lines)
+
+
+def _description_summary(node: Node, *, limit: int = 160) -> str:
+    value = node.props.get("description")
+    if value is None:
+        return ""
+    summary = " ".join(str(value).split())
+    if len(summary) <= limit:
+        return summary
+    return summary[:limit - 1].rstrip() + "\u2026"
 
 
 def _relationships(
@@ -235,6 +341,7 @@ def _entity_page(node: Node, store: GraphStore) -> str:
         "",
         f"> ID: `{node.id}`",
     ]
+    parts.append(_description(node))
     parts.append(_props_table(node))
     parts.append(_relationships(out_e, in_e, store))
     parts.append(_timeline(node))
@@ -266,13 +373,18 @@ def _index_page(store: GraphStore) -> str:
         lines.append(f"## {ntype.title()}s")
         lines.append("")
         for n in sorted(by_type[ntype], key=lambda n: n.id):
-            title = _node_title(n)
-            summary_parts = [title]
+            summary_parts: list[str] = []
+            description = _description_summary(n)
+            if description:
+                summary_parts.append(description)
             if n.props.get("lang"):
-                summary_parts.append(f"({n.props['lang']})")
+                summary_parts.append(f"lang: {n.props['lang']}")
             if n.valid_from:
-                summary_parts.append(f"\u2014 since {_fmt_date(n.valid_from)}")
-            lines.append(f"- {_wikilink(n)} \u2014 {' '.join(summary_parts)}")
+                summary_parts.append(f"since {_fmt_date(n.valid_from)}")
+            line = f"- {_wikilink(n)}"
+            if summary_parts:
+                line += " \u2014 " + " \u00b7 ".join(summary_parts)
+            lines.append(line)
         lines.append("")
 
     return "\n".join(lines)

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -14,6 +14,29 @@ from lorekeep.wiki import _slug, generate_wiki
 runner = CliRunner()
 
 
+def _build_wiki(
+    tmp_path: Path,
+    nodes: list[Node],
+    edges: list[Edge] | None = None,
+) -> Path:
+    """Write a small graph and return its generated wiki directory."""
+    from lorekeep.compile.writer import write_graph
+
+    edge_facts = edges or []
+    graph = tmp_path / "graph"
+    write_graph(graph, nodes, edge_facts, Manifest(
+        schema_version=3,
+        chunk_count=0,
+        node_count=len(nodes),
+        edge_count=len(edge_facts),
+        run_id="test-run",
+        facts_hash="test-hash",
+    ))
+    wiki = tmp_path / "wiki"
+    generate_wiki(graph, wiki)
+    return wiki
+
+
 # ── Fixtures ───────────────────────────────────────────────────────────────
 
 @pytest.fixture
@@ -200,6 +223,37 @@ class TestGenerateWiki:
         assert "[[goal-ship|Ship v2]]" in index
         assert "[[dec-adr-1|Adopt v2]]" in index
         assert "[[doc-brief|Design brief]]" in index
+        import yaml
+        frontmatter = yaml.safe_load(
+            (wiki / "goal-ship.md").read_text().split("---")[1]
+        )
+        assert frontmatter["title"] == "Ship v2"
+        assert frontmatter["props"]["title"] == "Ship v2"
+        assert frontmatter["aliases"] == ["Ship v2"]
+
+    def test_name_precedes_title_and_id_is_the_fallback(self, tmp_path):
+        nodes = [
+            Node(
+                id="doc:both", type="document", ns=("team",),
+                props={"name": "Human name", "title": "Document title"},
+            ),
+            Node(id="domain:opaque", type="domain", ns=("team",), props={}),
+        ]
+        wiki = _build_wiki(tmp_path, nodes)
+
+        import yaml
+        both_page = (wiki / "doc-both.md").read_text()
+        both_fm = yaml.safe_load(both_page.split("---")[1])
+        assert "# Human name" in both_page
+        assert both_fm["aliases"] == ["Human name", "Document title"]
+        assert both_fm["name"] == "Human name"
+        assert both_fm["title"] == "Document title"
+
+        fallback_page = (wiki / "domain-opaque.md").read_text()
+        fallback_fm = yaml.safe_load(fallback_page.split("---")[1])
+        assert "# domain:opaque" in fallback_page
+        assert "aliases" not in fallback_fm
+        assert fallback_fm["props"] == {}
 
     def test_entity_timeline(self, graph_dir, wiki_dir):
         generate_wiki(graph_dir, wiki_dir)
@@ -258,6 +312,191 @@ class TestGenerateWiki:
         assert (wiki_dir / "svc-payments-api.md").exists()
 
 
+class TestRichEntityProjection:
+    def test_description_is_readable_and_preserves_paragraphs(self, tmp_path):
+        description = (
+            "Tóm tắt miền AI.\n\n"
+            "Giữ **Markdown**, Unicode và dấu | trong nội dung."
+        )
+        node = Node(
+            id="domain:ai",
+            type="domain",
+            ns=("private",),
+            props={"name": "AI", "description": description},
+        )
+        wiki = _build_wiki(tmp_path, [node])
+        page = (wiki / "domain-ai.md").read_text()
+
+        assert f"## Description\n\n{description}" in page
+        assert "| description |" not in page
+
+        import yaml
+        frontmatter = yaml.safe_load(page.split("---")[1])
+        assert frontmatter["name"] == "AI"
+        assert frontmatter["description"] == description
+        assert frontmatter["props"] == node.props
+
+        index = (wiki / "index.md").read_text()
+        assert (
+            "[[domain-ai|AI]] — Tóm tắt miền AI. "
+            "Giữ **Markdown**, Unicode và dấu | trong nội dung."
+        ) in index
+
+    def test_empty_description_has_no_section_but_remains_lossless(self, tmp_path):
+        node = Node(
+            id="value:empty",
+            type="value",
+            ns=("private",),
+            props={"name": "Empty description", "description": " \n "},
+        )
+        wiki = _build_wiki(tmp_path, [node])
+        page = (wiki / "value-empty.md").read_text()
+
+        assert "## Description" not in page
+        assert "| description |" not in page
+
+        import yaml
+        frontmatter = yaml.safe_load(page.split("---")[1])
+        assert frontmatter["description"] == " \n "
+        assert frontmatter["props"] == node.props
+
+    def test_typed_props_round_trip_and_safe_keys_are_queryable(self, tmp_path):
+        props = {
+            "name": "typed",
+            "enabled": True,
+            "port": 8080,
+            "ratio": 0.5,
+            "owners": ["Mạnh", "backend"],
+            "config": {"z": 1, "a": 2},
+            "none": None,
+            "yes": "quoted YAML key",
+            "needs:quote": "safe",
+        }
+        node = Node(
+            id="svc:typed", type="service", ns=("test",), props=props,
+        )
+        wiki = _build_wiki(tmp_path, [node])
+        page = (wiki / "svc-typed.md").read_text()
+
+        import yaml
+        frontmatter = yaml.safe_load(page.split("---")[1])
+        assert frontmatter["props"] == props
+        for key, value in props.items():
+            assert frontmatter[key] == value
+        assert 'config: {"a": 2, "z": 1}' in page
+
+    def test_reserved_props_and_relationship_fields_do_not_overwrite_metadata(
+        self, tmp_path,
+    ):
+        props = {
+            "title": "Collision document",
+            "kind": "runbook",
+            "id": "shadow-id",
+            "type": "shadow-type",
+            "ns": ["shadow-ns"],
+            "valid_from": "1999-01-01",
+            "valid_to": "2000-01-01",
+            "sources": ["shadow.md:1"],
+            "tags": ["shadow"],
+            "aliases": ["Shadow alias"],
+            "props": {"nested": True},
+            "relation_kind": "occupied",
+        }
+        source = Node(
+            id="doc:collision",
+            type="document",
+            ns=("team",),
+            props=props,
+            src=("team/doc.md:1",),
+        )
+        target = Node(
+            id="domain:target",
+            type="domain",
+            ns=("team",),
+            props={"name": "Target"},
+        )
+        edges = [
+            Edge(
+                id="e-kind", type="kind",
+                from_=source.id, to=target.id, ns=("team",),
+            ),
+            Edge(
+                id="e-title", type="title",
+                from_=source.id, to=target.id, ns=("team",),
+            ),
+        ]
+        wiki = _build_wiki(tmp_path, [source, target], edges)
+
+        import yaml
+        page = (wiki / "doc-collision.md").read_text()
+        frontmatter = yaml.safe_load(page.split("---")[1])
+        assert frontmatter["kind"] == "node"
+        assert frontmatter["id"] == source.id
+        assert frontmatter["type"] == "document"
+        assert frontmatter["ns"] == ["team"]
+        assert frontmatter["valid_from"] == ""
+        assert frontmatter["valid_to"] == ""
+        assert frontmatter["sources"] == ["team/doc.md:1"]
+        assert frontmatter["tags"] == ["document", "team", "entity"]
+        assert frontmatter["aliases"] == ["Collision document"]
+        assert frontmatter["props"] == props
+        assert frontmatter["relation_kind"] == "occupied"
+        assert frontmatter["relation_kind_2"] == ["[[domain-target]]"]
+        assert frontmatter["relation_title"] == ["[[domain-target]]"]
+
+
+class TestRichRelationships:
+    def test_title_labels_and_parallel_edge_facts_are_preserved(self, tmp_path):
+        source = Node(
+            id="svc:source", type="service", ns=("team",),
+            props={"name": "Source service"},
+        )
+        target = Node(
+            id="dec:target", type="decision", ns=("team",),
+            props={"title": "Target decision"},
+        )
+        edges = [
+            Edge(
+                id="edge-a",
+                type="relates_to",
+                from_=source.id,
+                to=target.id,
+                ns=("team",),
+                valid_from=date(2025, 1, 1),
+                props={"reason": "first"},
+                src=("team/a.md:1",),
+            ),
+            Edge(
+                id="edge-b",
+                type="relates_to",
+                from_=source.id,
+                to=target.id,
+                ns=("team",),
+                valid_from=date(2026, 1, 1),
+                props={"reason": "second"},
+                src=("team/b.md:2",),
+            ),
+        ]
+        wiki = _build_wiki(tmp_path, [source, target], edges)
+        source_page = (wiki / "svc-source.md").read_text()
+        target_page = (wiki / "dec-target.md").read_text()
+
+        assert "| [[dec-target]] | Target decision |" in source_page
+        assert "| [[svc-source]] | Source service |" in target_page
+        for edge in edges:
+            marker = f"<code>{edge.id}</code>"
+            assert source_page.count(marker) == 1
+            assert target_page.count(marker) == 1
+            assert edge.src[0] in source_page
+            assert edge.src[0] in target_page
+            assert edge.props["reason"] in source_page
+            assert edge.props["reason"] in target_page
+
+        import yaml
+        frontmatter = yaml.safe_load(source_page.split("---")[1])
+        assert frontmatter["relates_to"] == ["[[dec-target]]"]
+
+
 class TestDeterminism:
     def test_entity_pages_byte_identical(self, graph_dir, wiki_dir, tmp_path):
         """Re-generating unchanged facts yields identical pages (except log)."""
@@ -282,6 +521,23 @@ class TestDeterminism:
         svc_pos = index.find("[[svc-auth|auth]]")
         svc2_pos = index.find("[[svc-payments-api|payments-api]]")
         assert svc_pos < svc2_pos  # auth before payments-api (alphabetical)
+
+    def test_nested_props_have_stable_key_order(self, tmp_path):
+        node = Node(
+            id="svc:nested",
+            type="service",
+            ns=("test",),
+            props={
+                "name": "nested",
+                "config": {"z": 1, "a": {"last": 2, "first": 1}},
+            },
+        )
+        wiki = _build_wiki(tmp_path, [node])
+        page = (wiki / "svc-nested.md").read_text()
+
+        expected = '{"a": {"first": 1, "last": 2}, "z": 1}'
+        assert f"  config: {expected}" in page
+        assert f"config: {expected}" in page
 
 
 # ── CLI tests ──────────────────────────────────────────────────────────────
@@ -426,6 +682,7 @@ class TestSyncInvariant:
             assert frontmatter["valid_from"] == (fact["valid_from"] or "")
             assert frontmatter["valid_to"] == (fact["valid_to"] or "")
             assert frontmatter["sources"] == fact["src"]
+            assert frontmatter["props"] == fact["props"]
 
     def test_every_edge_has_wikilinks(self, graph_dir, wiki_dir):
         generate_wiki(graph_dir, wiki_dir)
@@ -481,6 +738,9 @@ class TestYAMLFrontmatter:
         assert data["valid_from"] == "2024-01-15"
         assert data["sources"] == ["raw/backend/payments.md:3"]
         assert "entity" in data["tags"]
+        assert data["props"] == {"name": "payments-api", "lang": "go"}
+        assert data["name"] == "payments-api"
+        assert data["lang"] == "go"
 
     def test_frontmatter_null_dates(self, graph_dir, wiki_dir):
         generate_wiki(graph_dir, wiki_dir)
@@ -507,6 +767,7 @@ class TestYAMLFrontmatter:
         assert 'id: "person:nguyễn"' in page
         assert 'ns: ["cá-nhân"]' in page
         assert 'aliases: ["Mạnh"]' in page
+        assert 'name: "Mạnh"' in page
 
     def test_frontmatter_relationship_fields(self, graph_dir, wiki_dir):
         """Out-edges are emitted as frontmatter fields holding [[wikilinks]] —

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -53,6 +53,7 @@ def sample_edges() -> list[Edge]:
             id="e_dep_1", type="depends_on",
             from_="svc:payments-api", to="svc:auth",
             ns=("backend",), valid_from=date(2024, 1, 15), valid_to=date(2025, 3, 1),
+            props={"reason": "internal auth"},
             src=("raw/backend/payments.md:6",),
         ),
         Edge(
@@ -106,6 +107,7 @@ class TestGenerateWiki:
         assert (wiki_dir / "index.md").exists()
         assert result["nodes"] == 4
         assert result["edges"] == 2
+        assert result["pages"] == 7  # 4 entity pages + index + overview + log
 
     def test_generates_overview(self, graph_dir, wiki_dir):
         generate_wiki(graph_dir, wiki_dir)
@@ -126,6 +128,7 @@ class TestGenerateWiki:
         generate_wiki(graph_dir, wiki_dir)
         page = (wiki_dir / "svc-payments-api.md").read_text()
         assert page.startswith("---")
+        assert 'kind: "node"' in page
         assert 'id: "svc:payments-api"' in page
         assert 'type: "service"' in page
         assert 'ns: ["backend"]' in page
@@ -133,6 +136,7 @@ class TestGenerateWiki:
         assert "sources:" in page
         assert "raw/backend/payments.md:3" in page
         assert "tags:" in page
+        assert 'aliases: ["payments-api"]' in page
 
     def test_entity_title_from_props(self, graph_dir, wiki_dir):
         generate_wiki(graph_dir, wiki_dir)
@@ -159,6 +163,44 @@ class TestGenerateWiki:
         page = (wiki_dir / "svc-auth.md").read_text()
         assert "[[svc-payments-api]]" in page
 
+    def test_relationship_rows_preserve_edge_fact_metadata(self, graph_dir, wiki_dir):
+        """A human can audit a rendered relationship back to its edge fact."""
+        generate_wiki(graph_dir, wiki_dir)
+        source_page = (wiki_dir / "svc-payments-api.md").read_text()
+        target_page = (wiki_dir / "svc-auth.md").read_text()
+        assert "| [[svc-auth]] | auth |" in source_page
+        assert "| [[svc-payments-api]] | payments-api |" in target_page
+        for page in (source_page, target_page):
+            assert "| Entity | Label | Fact ID | Namespaces | Validity | Sources | Properties |" in page
+            assert "<code>e_dep_1</code>" in page
+            assert '["backend"]' in page
+            assert "raw/backend/payments.md:6" in page
+            assert "internal auth" in page
+
+    def test_title_property_is_used_for_ontology_title_nodes(self, tmp_path):
+        """goal/decision/document use title, not name, in ontology v2."""
+        nodes = [
+            Node(id="goal:ship", type="goal", ns=("team",), props={"title": "Ship v2"}),
+            Node(id="dec:adr-1", type="decision", ns=("team",), props={"title": "Adopt v2"}),
+            Node(id="doc:brief", type="document", ns=("team",), props={"title": "Design brief"}),
+        ]
+        graph = tmp_path / "graph"
+        from lorekeep.compile.writer import write_graph
+        write_graph(graph, nodes, [], Manifest(
+            schema_version=3, chunk_count=0, node_count=3, edge_count=0,
+            run_id="x", facts_hash="y",
+        ))
+        wiki = tmp_path / "wiki"
+        generate_wiki(graph, wiki)
+
+        assert "# Ship v2" in (wiki / "goal-ship.md").read_text()
+        assert "# Adopt v2" in (wiki / "dec-adr-1.md").read_text()
+        assert "# Design brief" in (wiki / "doc-brief.md").read_text()
+        index = (wiki / "index.md").read_text()
+        assert "[[goal-ship|Ship v2]]" in index
+        assert "[[dec-adr-1|Adopt v2]]" in index
+        assert "[[doc-brief|Design brief]]" in index
+
     def test_entity_timeline(self, graph_dir, wiki_dir):
         generate_wiki(graph_dir, wiki_dir)
         page = (wiki_dir / "svc-payments-api.md").read_text()
@@ -171,8 +213,8 @@ class TestGenerateWiki:
         assert "## Services" in index
         assert "## Teams" in index
         assert "## Decisions" in index
-        assert "[[svc-payments-api]]" in index
-        assert "[[team-backend]]" in index
+        assert "[[svc-payments-api|payments-api]]" in index
+        assert "[[team-backend|team-backend]]" in index
 
     def test_log_appended(self, graph_dir, wiki_dir):
         generate_wiki(graph_dir, wiki_dir)
@@ -237,8 +279,8 @@ class TestDeterminism:
         """Entity pages and index entries are sorted for deterministic output."""
         generate_wiki(graph_dir, wiki_dir)
         index = (wiki_dir / "index.md").read_text()
-        svc_pos = index.find("[[svc-auth]]")
-        svc2_pos = index.find("[[svc-payments-api]]")
+        svc_pos = index.find("[[svc-auth|auth]]")
+        svc2_pos = index.find("[[svc-payments-api|payments-api]]")
         assert svc_pos < svc2_pos  # auth before payments-api (alphabetical)
 
 
@@ -355,12 +397,10 @@ class TestWikiCLI:
 
 
 class TestSyncInvariant:
-    """Every node → entity page, every edge → wikilink on both endpoints."""
+    """Every fact has a corresponding, auditable wiki projection."""
 
     def test_every_node_has_entity_page(self, graph_dir, wiki_dir):
         generate_wiki(graph_dir, wiki_dir)
-        from lorekeep.facts_io import read_facts
-        from lorekeep.models import Node as NodeT
         for line in (graph_dir / "facts.jsonl").read_text().splitlines():
             d = json.loads(line)
             if d["kind"] != "node":
@@ -368,6 +408,24 @@ class TestSyncInvariant:
             slug = _slug(d["id"])
             page = wiki_dir / f"{slug}.md"
             assert page.exists(), f"missing entity page for {d['id']}"
+
+    def test_every_node_frontmatter_matches_its_fact(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        import yaml
+
+        for line in (graph_dir / "facts.jsonl").read_text().splitlines():
+            fact = json.loads(line)
+            if fact["kind"] != "node":
+                continue
+            page = (wiki_dir / f"{_slug(fact['id'])}.md").read_text()
+            frontmatter = yaml.safe_load(page.split("---")[1])
+            assert frontmatter["kind"] == fact["kind"]
+            assert frontmatter["id"] == fact["id"]
+            assert frontmatter["type"] == fact["type"]
+            assert frontmatter["ns"] == fact["ns"]
+            assert frontmatter["valid_from"] == (fact["valid_from"] or "")
+            assert frontmatter["valid_to"] == (fact["valid_to"] or "")
+            assert frontmatter["sources"] == fact["src"]
 
     def test_every_edge_has_wikilinks(self, graph_dir, wiki_dir):
         generate_wiki(graph_dir, wiki_dir)
@@ -388,6 +446,26 @@ class TestSyncInvariant:
             assert f"[[{from_slug}]]" in to_pg.read_text(), \
                 f"edge {d['id']}: [[{from_slug}]] missing on target page"
 
+    def test_every_edge_metadata_is_visible_on_both_endpoints(self, graph_dir, wiki_dir):
+        generate_wiki(graph_dir, wiki_dir)
+        for line in (graph_dir / "facts.jsonl").read_text().splitlines():
+            fact = json.loads(line)
+            if fact["kind"] != "edge":
+                continue
+            pages = [
+                wiki_dir / f"{_slug(fact['from'])}.md",
+                wiki_dir / f"{_slug(fact['to'])}.md",
+            ]
+            for page in pages:
+                text = page.read_text()
+                assert f"<code>{fact['id']}</code>" in text
+                assert json.dumps(fact["ns"]) in text
+                for source in fact["src"]:
+                    assert source in text
+                for key, value in fact["props"].items():
+                    assert key in text
+                    assert str(value) in text
+
 
 class TestYAMLFrontmatter:
     def test_frontmatter_parses_as_yaml(self, graph_dir, wiki_dir):
@@ -396,6 +474,7 @@ class TestYAMLFrontmatter:
         page = (wiki_dir / "svc-payments-api.md").read_text()
         fm_block = page.split("---")[1]
         data = yaml.safe_load(fm_block)
+        assert data["kind"] == "node"
         assert data["id"] == "svc:payments-api"
         assert data["type"] == "service"
         assert data["ns"] == ["backend"]
@@ -410,6 +489,24 @@ class TestYAMLFrontmatter:
         fm_block = page.split("---")[1]
         data = yaml.safe_load(fm_block)
         assert data["valid_from"] == ""
+
+    def test_frontmatter_preserves_unicode_for_obsidian_readability(self, tmp_path):
+        node = Node(
+            id="person:nguyễn", type="person", ns=("cá-nhân",),
+            props={"name": "Mạnh"}, src=("cá-nhân/about.md:1",),
+        )
+        graph = tmp_path / "graph"
+        from lorekeep.compile.writer import write_graph
+        write_graph(graph, [node], [], Manifest(
+            schema_version=3, chunk_count=0, node_count=1, edge_count=0,
+            run_id="x", facts_hash="y",
+        ))
+        wiki = tmp_path / "wiki"
+        generate_wiki(graph, wiki)
+        page = (wiki / "person-nguyễn.md").read_text()
+        assert 'id: "person:nguyễn"' in page
+        assert 'ns: ["cá-nhân"]' in page
+        assert 'aliases: ["Mạnh"]' in page
 
     def test_frontmatter_relationship_fields(self, graph_dir, wiki_dir):
         """Out-edges are emitted as frontmatter fields holding [[wikilinks]] —


### PR DESCRIPTION
## Why

The compiled facts were structurally correct, but the generated Obsidian projection was not fully auditable, queryable, or consistently readable:

- ontology v2 nodes using `props.title` (goals, decisions, documents) fell back to technical IDs;
- descriptions were flattened into a generic Properties table row and multiline Markdown lost its structure;
- node props were absent from frontmatter, so documented Obsidian/Dataview queries such as `lang` could not work;
- relationship pages showed only a wikilink and validity, omitting edge identity, namespace, provenance, and properties;
- Unicode labels were escaped in YAML output;
- the CLI page count omitted the generated append-only log page.

## What changed

- Use the ontology `name` → `title` → canonical ID convention for entity headings, aliases, index links, and relationship labels.
- Render `props.description` as a dedicated Markdown section while preserving paragraphs, Unicode, pipes, and Markdown.
- Preserve the complete typed node property map under frontmatter `props`, with safe keys mirrored at the top level for concise Obsidian/Dataview queries.
- Prevent custom props or edge types from overwriting reserved metadata; colliding relation fields receive a deterministic `relation_` prefix.
- Render every relationship on both endpoints with canonical link, readable label, fact ID, namespace, validity, sources, and properties. Parallel/temporal edge facts remain separate rows.
- Add canonical node `kind`, all distinct `name`/`title` aliases, Unicode-safe YAML, stable nested-key ordering, and the correct generated page count.
- Add short descriptions to index entries and update the wiki guide with the actual frontmatter/query contract.

## Test coverage

Added regression coverage for:

- `name`, `title`, aliases, and canonical-ID fallback;
- single-line, multiline, empty, Unicode, pipe, and Markdown descriptions;
- typed property YAML round-trips for strings, booleans, numbers, lists, nested dictionaries, and nulls;
- YAML-ambiguous keys, reserved metadata collisions, and relation-field collisions;
- title-based relationship labels and parallel edge facts;
- nested property ordering and byte-stable wiki generation;
- node/edge facts-to-wiki parity.

## Verification

- Wiki unit tests: **53 passed**.
- Mandatory core regression: **26 passed**.
- Full suite: **594 passed**, with one existing third-party LiteLLM deprecation warning.
- `git diff --check`: clean.

No source facts or committed generated vault files were changed.