### PR TITLE
feat: add privacy-safe runtime diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Report a reproducible Lorekeep runtime problem
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Run `lorekeep support`, paste the report
+        below, and attach the ZIP produced by the same command.
+
+        Do **not** attach `config.yaml`, `facts.jsonl`, raw documents, pending
+        journals, API keys, tokens, prompts, or private graph content.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What happened, and what did you expect instead?
+      placeholder: Describe the observed and expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction
+      description: Provide the shortest sequence of commands that reproduces the problem.
+      render: shell
+    validations:
+      required: true
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Runtime surface
+      options:
+        - CLI command
+        - Agent daemon
+        - MCP stdio
+        - MCP HTTP
+        - Compile/provider
+        - Wiki
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: support
+    attributes:
+      label: Sanitized support report
+      description: Paste the report from `lorekeep support` and drag its generated ZIP here.
+      placeholder: Paste the metadata-only report or attach the bundle.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add screenshots or other non-sensitive context if useful.
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy confirmation
+      options:
+        - label: I checked this report and removed credentials and private knowledge content.
+          required: true

--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ The [`docs/`](docs/README.md) index is the entry point.
 - [Serving the graph to coding agents](docs/guides/serve.md)
 - [Browsing the wiki](docs/guides/wiki.md)
 - [Data home & path resolution](docs/guides/data-home.md)
+- [Runtime logging & bug reports](docs/guides/runtime-logging.md)
 - [Backing up the data home](docs/guides/backup.md)
 
 **Architecture**

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,4 +30,5 @@ How to use it.
 - [Serving the graph to coding agents](guides/serve.md) — wire Claude Code / Cursor / Codex / opencode over MCP, write tools, daemon.
 - [Browsing the wiki](guides/wiki.md) — browse the graph in Obsidian: `wiki --open`, graph view, tags, Dataview queries.
 - [Data home & path resolution](guides/data-home.md) — env / `LOREKEEP_HOME` / dev mode / XDG.
+- [Runtime logging & bug reports](guides/runtime-logging.md) — rotating logs, privacy policy, support reports and bundles.
 - [Backing up the data home](guides/backup.md) — `lorekeep backup` to a private git repo: setup, restore, multi-device conflicts.

--- a/docs/guides/data-home.md
+++ b/docs/guides/data-home.md
@@ -3,13 +3,13 @@
 Lorekeep resolves its data home with a 4-tier precedence (high → low). All commands (`compile`, `serve`, `doctor`, …) use the same resolution, in `src/lorekeep/paths.py` — pure logic, no I/O.
 
 ```
-1. explicit per-path env   LOREKEEP_RAW / LOREKEEP_OUT / LOREKEEP_CACHE / LOREKEEP_SCHEMA / LOREKEEP_CONFIG
-2. LOREKEEP_HOME            → <home>/{config.yaml, schema.json, raw/, graph/, cache.json}
+1. explicit per-path env   LOREKEEP_RAW / LOREKEEP_OUT / LOREKEEP_CACHE / LOREKEEP_SCHEMA / LOREKEEP_CONFIG / LOREKEEP_LOGS
+2. LOREKEEP_HOME            → <home>/{config.yaml, schema.json, raw/, graph/, logs/, cache.json}
 3. dev mode                 .lorekeep/ present in CWD, or LOREKEEP_DEV=1 → <cwd>/.lorekeep/{...}
 4. XDG (default)            ~/.config/lorekeep (config) + ~/.local/share/lorekeep (data)
 ```
 
-`lorekeep init` bootstraps whichever home resolves, writing default `config.yaml` + `schema.json` and creating `raw/` + `graph/` (it preserves existing config/schema).
+`lorekeep init` bootstraps whichever home resolves, writing default `config.yaml` + `schema.json` and creating `raw/` + `graph/` (it preserves existing config/schema). Runtime commands create `logs/` lazily.
 
 ## Installed use (recommended)
 

--- a/docs/guides/runtime-logging.md
+++ b/docs/guides/runtime-logging.md
@@ -1,0 +1,75 @@
+# Runtime logging and bug reports
+
+Lorekeep writes operational logs for every CLI, daemon, and MCP process to:
+
+```text
+<LOREKEEP_HOME>/logs/lorekeep.log
+```
+
+The path follows normal data-home resolution. Set `LOREKEEP_LOGS` to override
+only the log directory. In a source checkout it is normally
+`.lorekeep/logs/lorekeep.log`; an installed Linux build normally uses
+`~/.local/share/lorekeep/logs/lorekeep.log`.
+
+The log is plain text, timestamps are UTC, and each entry includes a component,
+event, process ID, and per-process run ID. It rotates at 5 MiB and keeps five
+backups. `--verbose` or `LOREKEEP_DEBUG=1` enables DEBUG entries; `--quiet`
+records warnings and errors only for that invocation.
+
+Logs deliberately exclude prompts, MCP queries/results, raw documents, fact
+properties, and journal content. Credential-shaped values and home paths in
+third-party errors are redacted. Never paste `config.yaml`, `facts.jsonl`, raw
+documents, or pending journals into a public issue.
+
+## Prepare a GitHub issue
+
+One command prints a copy/paste-ready metadata report and creates the ZIP to
+attach to the same issue:
+
+```bash
+lorekeep support
+# ...Markdown report...
+# support bundle: ./lorekeep-support-20260804T120000Z.zip
+# sha256: ...
+```
+
+Choose the destination, or request only one side of the workflow:
+
+```bash
+lorekeep support --output ./support.zip
+lorekeep support --report-only
+lorekeep support --no-print --output ./support.zip
+```
+
+The ZIP has a strict allowlist: `report.md`, the last 1,000 runtime log lines
+after a second redaction pass, and a manifest counter summary. It never
+contains raw data, facts, configuration files, caches, or journals. The old
+`support report` and `support bundle` forms remain hidden compatibility aliases.
+
+## Daemon startup logs
+
+The unified runtime log is authoritative. Platform launchers can also retain
+small bootstrap logs for failures before Lorekeep starts:
+
+- systemd: `journalctl --user-unit lorekeep --since today`
+- launchd: `<LOREKEEP_HOME>/logs/daemon-bootstrap.log` and `.err.log`
+- `lorekeep init` background process: `<LOREKEEP_HOME>/logs/daemon-bootstrap.log`
+
+Older installations may still have `agent.log`, `daemon.log`, or
+`daemon.err.log` in the data-home root. They are not deleted automatically and
+are reported only by filename/status in a support report; their contents are
+never added to a support bundle.
+
+## Quick diagnosis
+
+```bash
+lorekeep doctor
+lorekeep agent daemon status
+lorekeep support
+```
+
+For MCP startup only, a timeout is expected because stdio waits for a client:
+
+```bash
+timeout 3 lorekeep serve --transport stdio </dev/null
+```

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -109,17 +109,27 @@ def hook() -> None:
         if session_dir and (session_dir / "memory").is_dir():
             written = import_claude_mem(session_dir, p["raw"], "claude-memory")
             total += len(written)
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning(
+            "Claude hook import failed error_type=%s", type(exc).__name__,
+            extra={"event": "hook.claude_failed"},
+        )
 
     try:
         from lorekeep.importer.codex import import_memories as import_codex_mem
         written = import_codex_mem(p["raw"], "codex-memory")
         total += len(written)
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning(
+            "Codex hook import failed error_type=%s", type(exc).__name__,
+            extra={"event": "hook.codex_failed"},
+        )
 
     if total:
+        log.info(
+            "memory hook completed file_count=%s", total,
+            extra={"event": "hook.complete"},
+        )
         typer.echo(f"lorekeep: imported {total} memory file(s)")
 
 
@@ -144,7 +154,10 @@ def _report_compile_errors(manifest, *, exit_on_total_failure: bool = True) -> N
     if not errs:
         return
     for e in errs:
-        log.error("compile error %s:%s: %s", e.path, e.line, e.message)
+        log.error(
+            "compile error line=%s", e.line,
+            extra={"event": "compile.manifest_error"},
+        )
     from lorekeep.output import dim, error, warn
     total_fail = manifest.node_count == 0 and manifest.chunk_count > 0
     if total_fail:
@@ -575,7 +588,18 @@ def serve(
         allowed = load_config(p["config"]).ns.default
     from lorekeep.mcp_server import configure, mcp
     configure(graph_dir=p["out"], allowed_ns=allowed, schema_path=p["schema"], pending_dir=p.get("pending"))
-    mcp.run(transport=transport)
+    log.info(
+        "MCP server starting transport=%s namespace_count=%s", transport, len(allowed),
+        extra={"event": "mcp.start"},
+    )
+    try:
+        mcp.run(transport=transport)
+    except Exception as exc:
+        log.exception(
+            "MCP server stopped unexpectedly error_type=%s", type(exc).__name__,
+            extra={"event": "mcp.failed"},
+        )
+        raise
 
 
 mcp_app = typer.Typer(help="Coding-agent integration.")
@@ -585,6 +609,63 @@ config_app = typer.Typer(help="View and edit lorekeep config.")
 app.add_typer(config_app, name="config")
 schema_app = typer.Typer(help="Inspect and upgrade the graph schema.")
 app.add_typer(schema_app, name="schema")
+support_app = typer.Typer(
+    help="Create privacy-safe diagnostics for bug reports.",
+    invoke_without_command=True,
+    no_args_is_help=False,
+)
+app.add_typer(support_app, name="support")
+
+
+@support_app.callback()
+def support(
+    ctx: typer.Context,
+    output: Path | None = typer.Option(None, "--output", "-o", help="Write the ZIP to this path."),
+    report_only: bool = typer.Option(False, "--report-only", help="Print the report without creating a ZIP."),
+    no_print: bool = typer.Option(False, "--no-print", help="Create the ZIP without printing the report."),
+) -> None:
+    """Print a support report and create its redacted attachment bundle."""
+    if ctx.invoked_subcommand is not None:
+        return
+    if report_only and no_print:
+        raise typer.BadParameter("--report-only and --no-print cannot be used together")
+    if report_only and output is not None:
+        raise typer.BadParameter("--output is only used when creating a bundle")
+
+    from lorekeep.support import build_report, create_bundle
+    if not no_print:
+        typer.echo(build_report(), nl=False)
+    if report_only:
+        return
+    path, digest = create_bundle(output)
+    if not no_print:
+        typer.echo()
+    typer.echo(f"support bundle: {path}")
+    typer.echo(f"sha256: {digest}")
+
+
+@support_app.command("report", hidden=True)
+def support_report(
+    output: Path | None = typer.Option(None, "--output", "-o", help="Write Markdown to this path."),
+) -> None:
+    """Print a metadata-only report suitable for a GitHub issue."""
+    from lorekeep.support import build_report, write_report
+    if output is None:
+        typer.echo(build_report(), nl=False)
+    else:
+        write_report(output)
+        typer.echo(f"support report: {output}")
+
+
+@support_app.command("bundle", hidden=True)
+def support_bundle(
+    output: Path | None = typer.Option(None, "--output", "-o", help="Write the ZIP to this path."),
+) -> None:
+    """Create a redacted, allowlisted ZIP for attachment to a bug report."""
+    from lorekeep.support import create_bundle
+    path, digest = create_bundle(output)
+    typer.echo(f"support bundle: {path}")
+    typer.echo(f"sha256: {digest}")
 
 
 @schema_app.command("upgrade")
@@ -826,8 +907,11 @@ def init(
     elif p["config"].exists():
         try:
             ns = load_config(p["config"]).ns.default[0]
-        except Exception:
-            pass
+        except Exception as exc:
+            log.warning(
+                "existing config could not be loaded error_type=%s",
+                type(exc).__name__, extra={"event": "init.config_invalid"},
+            )
 
     p["schema"].parent.mkdir(parents=True, exist_ok=True)
     if not p["schema"].exists():
@@ -1111,6 +1195,11 @@ def _auto_wire_agents(p: dict, ns: str) -> None:
                 hook_path = writer.write_hook(target, hook_cmd, hook_args)
                 typer.echo(f"  hooked {agent_name} session-end -> {hook_path}")
         except Exception as exc:
+            log.warning(
+                "agent wiring failed agent=%s error_type=%s",
+                agent_name, type(exc).__name__,
+                extra={"event": "init.agent_wiring_failed"},
+            )
             typer.echo(f"  {agent_name}: failed ({exc})")
 
     typer.echo("\n  " + agent_memory_snippet().replace("\n", "\n  ").strip())
@@ -1141,6 +1230,10 @@ def _auto_import_and_compile(p: dict) -> None:
             if imported:
                 typer.echo(f"  imported {imported} memory file(s) from Claude session")
     except Exception as exc:
+        log.warning(
+            "automatic memory import failed error_type=%s", type(exc).__name__,
+            extra={"event": "init.import_failed"},
+        )
         if os.environ.get("LOREKEEP_DEBUG"):
             typer.echo(f"  import error: {exc}")
 
@@ -1183,6 +1276,10 @@ def _auto_import_and_compile(p: dict) -> None:
             _auto_generate_wiki(p["out"], p["wiki"])
         typer.echo(f"  compiled: {manifest.node_count} nodes, {manifest.edge_count} edges")
     except Exception as exc:
+        log.exception(
+            "initial compile failed error_type=%s", type(exc).__name__,
+            extra={"event": "init.compile_failed"},
+        )
         typer.echo(f"  compile skipped: {exc}")
 
 
@@ -1192,7 +1289,9 @@ def _start_daemon(p: dict) -> None:
     import sys
 
     pid_path = p["home"] / "agent.pid"
-    log_path = p["home"] / "agent.log"
+    log_dir = p.get("logs", p["home"] / "logs")
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "daemon-bootstrap.log"
 
     # Check if already running
     if pid_path.exists():
@@ -1207,6 +1306,10 @@ def _start_daemon(p: dict) -> None:
     cmd = [sys.executable, "-m", "lorekeep.cli", "agent", "watch", "--interval", "60"]
     log_file = open(log_path, "a")
     try:
+        os.chmod(log_path, 0o600)
+    except OSError:
+        pass
+    try:
         proc = subprocess.Popen(
             cmd,
             stdout=log_file,
@@ -1217,6 +1320,10 @@ def _start_daemon(p: dict) -> None:
     finally:
         log_file.close()
     pid_path.write_text(str(proc.pid))
+    log.info(
+        "background daemon started pid=%s", proc.pid,
+        extra={"event": "daemon.background_started"},
+    )
     typer.echo(f"  daemon started (pid={proc.pid}, log={log_path})")
 
 
@@ -1442,9 +1549,17 @@ def daemon_install() -> None:
     p = resolve_paths()
     try:
         platform_name, config_path = svc_install(p["home"])
+        log.info(
+            "daemon service installed platform=%s", platform_name,
+            extra={"event": "daemon.service_installed"},
+        )
         typer.echo(f"daemon: installed as {platform_name} service → {config_path}")
         typer.echo(f"daemon: will auto-start on login/restart")
     except RuntimeError as exc:
+        log.error(
+            "daemon service install failed error_type=%s", type(exc).__name__,
+            extra={"event": "daemon.service_install_failed"},
+        )
         typer.echo(f"daemon: {exc}")
         raise typer.Exit(code=1)
 
@@ -1454,6 +1569,10 @@ def daemon_uninstall() -> None:
     """Remove the persistent daemon service."""
     from lorekeep.daemon_service import uninstall as svc_uninstall
     removed = svc_uninstall()
+    log.info(
+        "daemon service uninstall completed removed=%s", removed,
+        extra={"event": "daemon.service_uninstalled"},
+    )
     if removed:
         typer.echo("daemon: service removed")
     else:
@@ -1464,7 +1583,9 @@ def daemon_uninstall() -> None:
 def daemon_status() -> None:
     """Check if the persistent daemon service is installed and running."""
     from lorekeep.daemon_service import status as svc_status
-    typer.echo(svc_status())
+    state = svc_status()
+    log.info("daemon service status checked", extra={"event": "daemon.service_status"})
+    typer.echo(state)
 
 
 @agent_app.command()
@@ -1765,16 +1886,22 @@ def _discover_watchable_sessions() -> list[tuple[str, Path, Path]]:
         sd = find_claude()
         if sd and (sd / "memory").is_dir() and any((sd / "memory").glob("*.md")):
             sessions.append(("claude", sd, sd / "memory"))
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning(
+            "Claude session discovery failed error_type=%s", type(exc).__name__,
+            extra={"event": "daemon.session_discovery_failed"},
+        )
 
     try:
         from lorekeep.importer.codex import _codex_home
         mem_dir = _codex_home() / "memories"
         if mem_dir.is_dir() and any(mem_dir.glob("*.md")):
             sessions.append(("codex", mem_dir.parent, mem_dir))
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning(
+            "Codex session discovery failed error_type=%s", type(exc).__name__,
+            extra={"event": "daemon.session_discovery_failed"},
+        )
 
     return sessions
 
@@ -1820,6 +1947,10 @@ def watch(
     if watch_sessions:
         typer.echo("agent: session watch enabled (Claude + Codex memory dirs)")
     typer.echo("agent: MCP server lazy-reloads facts.jsonl — no reconnect needed")
+    log.info(
+        "daemon watch started interval=%s session_watch=%s",
+        interval, watch_sessions, extra={"event": "daemon.start"},
+    )
 
     pid_file = p["home"] / ".daemon.pid"
     if pid_file.exists():
@@ -1846,8 +1977,11 @@ def watch(
         if has_remote(p["home"]):
             typer.echo("agent: syncing backup from remote...")
             sync_backup(p["home"])
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning(
+            "startup backup sync failed error_type=%s", type(exc).__name__,
+            extra={"event": "daemon.backup_failed"},
+        )
 
     # Resolve/replay only after startup sync so remote journal events are visible.
     if pending_dir and pending_dir.exists():
@@ -1896,6 +2030,10 @@ def watch(
                     typer.echo("agent: compile done")
                     compiled = True
                 except Exception as exc:
+                    log.exception(
+                        "daemon compile failed error_type=%s", type(exc).__name__,
+                        extra={"event": "daemon.compile_failed"},
+                    )
                     typer.echo(f"agent: compile error: {exc}")
             last_raw_mtime = raw_mtime
             last_raw_count = raw_count
@@ -1906,8 +2044,11 @@ def watch(
                     from lorekeep.backup import sync_backup
                     if sync_backup(p["home"]):
                         typer.echo("agent: backup synced")
-                except Exception:
-                    pass
+                except Exception as exc:
+                    log.warning(
+                        "post-compile backup sync failed error_type=%s",
+                        type(exc).__name__, extra={"event": "daemon.backup_failed"},
+                    )
                 if has_pending:
                     _do_auto_resolve(
                         p["out"], pending_dir, p.get("wiki"), p.get("schema"),
@@ -1946,14 +2087,24 @@ def watch(
                                 typer.echo(f"agent: {agent_name} import done — {count} files → raw/{agent_name}-memory/")
                                 session_import_time[agent_name] = now
                         except Exception as exc:
+                            log.exception(
+                                "session import failed agent=%s error_type=%s",
+                                agent_name, type(exc).__name__,
+                                extra={"event": "daemon.session_import_failed"},
+                            )
                             typer.echo(f"agent: {agent_name} import error: {exc}")
                     session_state[agent_name] = mem_mtime
 
             time.sleep(interval)
         except KeyboardInterrupt:
+            log.info("daemon watch stopped", extra={"event": "daemon.stop"})
             typer.echo("\nagent: shutting down")
             break
         except Exception as exc:
+            log.exception(
+                "daemon loop failed error_type=%s", type(exc).__name__,
+                extra={"event": "daemon.loop_failed"},
+            )
             typer.echo(f"agent: error: {exc}")
             time.sleep(interval)
 
@@ -2060,11 +2211,20 @@ def _do_auto_resolve_unlocked(
 
             typer.echo(f"agent: resolve done — {merged.merge_count} merged, "
                        f"{merged.flagged_count} flagged, {merged.quarantine_count} quarantined")
+            log.info(
+                "auto-resolve completed merged=%s flagged=%s quarantined=%s",
+                merged.merge_count, merged.flagged_count, merged.quarantine_count,
+                extra={"event": "resolve.complete"},
+            )
 
             if wiki_dir:
                 _auto_generate_wiki(out_dir, wiki_dir)
             return True
     except Exception as exc:
+        log.exception(
+            "auto-resolve failed error_type=%s", type(exc).__name__,
+            extra={"event": "resolve.failed"},
+        )
         typer.echo(f"agent: resolve error: {exc}")
     return False
 
@@ -2074,7 +2234,12 @@ def _auto_generate_wiki(graph_dir: Path, wiki_dir: Path) -> None:
     try:
         from lorekeep.wiki import generate_wiki
         generate_wiki(graph_dir, wiki_dir)
+        log.info("wiki generated", extra={"event": "wiki.complete"})
     except Exception as exc:
+        log.warning(
+            "wiki generation skipped error_type=%s", type(exc).__name__,
+            extra={"event": "wiki.failed"},
+        )
         typer.echo(f"wiki: auto-gen skipped: {exc}")
 
 

--- a/src/lorekeep/compile/extract.py
+++ b/src/lorekeep/compile/extract.py
@@ -157,7 +157,10 @@ def parse_response(
     for n in data.get("nodes", []):
         ntype = n.get("type")
         if schema is not None and not schema.is_valid_node_type(ntype):
-            log.debug("dropping node with unknown type %r in %s", ntype, chunk.src)
+            log.debug(
+                "dropping node with unknown type=%r", ntype,
+                extra={"event": "extract.unknown_node_type"},
+            )
             continue
         props = dict(n.get("props", {}))
         if "name" in n and "name" not in props:
@@ -175,7 +178,10 @@ def parse_response(
     for e in data.get("edges", []):
         etype = e.get("type")
         if schema is not None and not schema.is_valid_edge_type(etype):
-            log.debug("dropping edge with unknown type %r in %s", etype, chunk.src)
+            log.debug(
+                "dropping edge with unknown type=%r", etype,
+                extra={"event": "extract.unknown_edge_type"},
+            )
             continue
         edges.append(Edge(
             id="",                      # assigned deterministically in resolve

--- a/src/lorekeep/daemon_service.py
+++ b/src/lorekeep/daemon_service.py
@@ -92,7 +92,7 @@ def status_systemd() -> str:
     """Return systemd service status string."""
     r = subprocess.run(
         ["systemctl", "--user", "is-active", "lorekeep"],
-        capture_output=True, text=True,
+        capture_output=True, text=True, timeout=3,
     )
     return r.stdout.strip() or r.stderr.strip()
 
@@ -130,9 +130,9 @@ def _launchd_plist(home: Path) -> str:
         <string>{home}</string>
     </dict>
     <key>StandardOutPath</key>
-    <string>{home}/daemon.log</string>
+    <string>{home}/logs/daemon-bootstrap.log</string>
     <key>StandardErrorPath</key>
-    <string>{home}/daemon.err.log</string>
+    <string>{home}/logs/daemon-bootstrap.err.log</string>
 </dict>
 </plist>
 """
@@ -140,6 +140,14 @@ def _launchd_plist(home: Path) -> str:
 
 def install_launchd(home: Path) -> Path:
     """Install launchd LaunchAgent. Returns the plist path."""
+    (home / "logs").mkdir(parents=True, exist_ok=True)
+    for name in ("daemon-bootstrap.log", "daemon-bootstrap.err.log"):
+        log_path = home / "logs" / name
+        log_path.touch(exist_ok=True)
+        try:
+            log_path.chmod(0o600)
+        except OSError:
+            pass
     plist_path = _launchd_plist_path()
     plist_path.parent.mkdir(parents=True, exist_ok=True)
     plist_path.write_text(_launchd_plist(home), encoding="utf-8")
@@ -161,7 +169,7 @@ def status_launchd() -> str:
     """Return launchd service status."""
     r = subprocess.run(
         ["launchctl", "list", _service_label()],
-        capture_output=True, text=True,
+        capture_output=True, text=True, timeout=3,
     )
     if r.returncode == 0:
         return "running"

--- a/src/lorekeep/journal.py
+++ b/src/lorekeep/journal.py
@@ -6,12 +6,15 @@ as append-only JSONL. Facts enter facts.jsonl after the resolve pass.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 
 from lorekeep.models import JournalEntry
+
+log = logging.getLogger("lorekeep.journal")
 
 
 def journal_path(pending_dir: Path, ns: str) -> Path:
@@ -63,6 +66,7 @@ def append_journal(pending_dir: Path, entry: JournalEntry, ns: str) -> JournalEn
             f.write(line)
             f.flush()
             os.fsync(f.fileno())
+    log.info("journal entry appended", extra={"event": "journal.append"})
     return entry
 
 
@@ -73,16 +77,25 @@ def load_journals(pending_dir: Path) -> list[JournalEntry]:
     for journal_file in sorted(pending_dir.rglob("journal.jsonl")):
         try:
             text = journal_file.read_text(encoding="utf-8")
-        except OSError:
+        except OSError as exc:
+            log.warning(
+                "journal file unreadable error_type=%s", type(exc).__name__,
+                extra={"event": "journal.read_failed"},
+            )
             continue
-        for line in text.splitlines():
+        for line_number, line in enumerate(text.splitlines(), start=1):
             line = line.strip()
             if not line:
                 continue
             try:
                 d = json.loads(line)
                 entries.append(JournalEntry.model_validate(d))
-            except Exception:
+            except Exception as exc:
+                log.warning(
+                    "invalid journal line line=%s error_type=%s",
+                    line_number, type(exc).__name__,
+                    extra={"event": "journal.invalid_line"},
+                )
                 continue
     return entries
 
@@ -108,7 +121,12 @@ def update_journal_status(pending_dir: Path, ns: str,
                 if key in entry_key_set and d.get("status") == "pending":
                     d["status"] = new_status
                 updated.append(json.dumps(d, sort_keys=True, ensure_ascii=False))
-            except Exception:
+            except Exception as exc:
+                log.warning(
+                    "journal status line preserved line=%s error_type=%s",
+                    len(updated) + 1, type(exc).__name__,
+                    extra={"event": "journal.status_invalid_line"},
+                )
                 updated.append(line_text)
         path.parent.mkdir(parents=True, exist_ok=True)
         fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")

--- a/src/lorekeep/mcp_server.py
+++ b/src/lorekeep/mcp_server.py
@@ -9,6 +9,7 @@ the next resolve pass.
 """
 from __future__ import annotations
 
+import logging
 import os
 import socket
 import uuid
@@ -23,6 +24,8 @@ from lorekeep.perm.ns import ScopedGraph
 from lorekeep.schema_io import load_schema
 from lorekeep.store.graph import GraphStore, parse_date
 from lorekeep.store.fts import FTSIndex
+
+log = logging.getLogger("lorekeep.mcp")
 
 mcp = FastMCP("lorekeep")
 
@@ -43,6 +46,10 @@ def configure(graph_dir, allowed_ns, schema_path=None, fts_path=None, pending_di
         _state["fts_path"] = Path(fts_path)
     else:
         _state["fts_path"] = _state["graph_dir"] / "fts.sqlite"
+    log.info(
+        "configuring graph namespace_count=%s", len(_state["allowed_ns"]),
+        extra={"event": "mcp.configure"},
+    )
     _rebuild()
 
 
@@ -66,9 +73,18 @@ def _rebuild() -> None:
             _fts.build(store.all_nodes())
         else:
             _fts = None
-    except Exception:
+    except Exception as exc:
+        log.warning(
+            "FTS unavailable; falling back to graph search error_type=%s",
+            type(exc).__name__, extra={"event": "mcp.fts_fallback"},
+        )
         _fts = None
     _state["facts_mtime"] = facts.stat().st_mtime if facts.exists() else 0
+    log.info(
+        "graph loaded node_count=%s edge_count=%s fts=%s",
+        len(store.node_ids()), len(store.all_edges()), _fts is not None,
+        extra={"event": "mcp.graph_loaded"},
+    )
 
 
 def _require() -> ScopedGraph:
@@ -78,6 +94,7 @@ def _require() -> ScopedGraph:
     facts = _state["graph_dir"] / "facts.jsonl"
     mtime = facts.stat().st_mtime if facts.exists() else 0
     if _scope is None or mtime != _state.get("facts_mtime"):
+        log.info("facts changed; reloading graph", extra={"event": "mcp.reload"})
         _rebuild()
     return _scope
 

--- a/src/lorekeep/output.py
+++ b/src/lorekeep/output.py
@@ -2,13 +2,20 @@
 
 Single chokepoint for all ``rich`` interaction. The module-level
 :class:`~rich.console.Console` auto-strips color in a non-tty (tests via
-CliRunner, the daemon's ``agent.log`` redirect), so plain-text contracts hold
+CliRunner, the daemon bootstrap-log redirect), so plain-text contracts hold
 and ANSI never leaks into captured output or log files.
 """
 from __future__ import annotations
 
 import logging
+import os
+import sys
+import threading
+import traceback
+import uuid
 from contextlib import contextmanager
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rich.console import Console
@@ -22,6 +29,105 @@ stderr_console = Console(stderr=True)
 
 _quiet = False
 _logging_configured = False
+_file_handler: logging.Handler | None = None
+_run_id = uuid.uuid4().hex[:12]
+_exception_hooks_configured = False
+
+
+class _PrivateRotatingFileHandler(RotatingFileHandler):
+    """Rotating handler that reapplies private permissions after rollover."""
+
+    def _open(self):
+        stream = super()._open()
+        try:
+            os.chmod(self.baseFilename, 0o600)
+        except OSError:
+            pass
+        return stream
+
+
+class _SafeFileFormatter(logging.Formatter):
+    """Plain UTC formatter that redacts the fully rendered traceback."""
+
+    converter = __import__("time").gmtime
+
+    def formatException(self, ei) -> str:
+        """Keep stack frames and exception type, but never exception content."""
+        exc_type, _exc_value, tb = ei
+        frames = "".join(traceback.format_tb(tb))
+        return f"{frames}{exc_type.__module__}.{exc_type.__name__}: [details redacted]"
+
+    def format(self, record: logging.LogRecord) -> str:
+        from lorekeep.redaction import redact_text
+        return redact_text(super().format(record))
+
+
+class _RuntimeContextFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.run_id = _run_id
+        return True
+
+
+def runtime_log_path() -> Path:
+    """Return the resolved unified runtime log path without creating it."""
+    from lorekeep.paths import resolve_paths
+    return resolve_paths()["logs"] / "lorekeep.log"
+
+
+def _make_file_handler(path: Path) -> logging.Handler:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        path.parent.chmod(0o700)
+    except OSError:
+        pass
+    handler = _PrivateRotatingFileHandler(
+        path, maxBytes=5 * 1024 * 1024, backupCount=5, encoding="utf-8",
+    )
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+    handler.setFormatter(_SafeFileFormatter(
+        "%(asctime)sZ level=%(levelname)s component=%(name)s "
+        "event=%(event)s pid=%(process)d run_id=%(run_id)s %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+        defaults={"event": "runtime"},
+    ))
+    handler.addFilter(_RuntimeContextFilter())
+    return handler
+
+
+def _install_exception_hooks() -> None:
+    """Record otherwise-unhandled main-thread and worker-thread failures."""
+    global _exception_hooks_configured
+    if _exception_hooks_configured:
+        return
+    previous_sys_hook = sys.excepthook
+    previous_thread_hook = threading.excepthook
+
+    def _sys_hook(exc_type, exc_value, tb) -> None:
+        if issubclass(exc_type, KeyboardInterrupt):
+            previous_sys_hook(exc_type, exc_value, tb)
+            return
+        logging.getLogger("lorekeep.runtime").critical(
+            "unhandled exception error_type=%s", exc_type.__name__,
+            exc_info=(exc_type, exc_value, tb), extra={"event": "runtime.unhandled"},
+        )
+
+    def _thread_hook(args: threading.ExceptHookArgs) -> None:
+        if issubclass(args.exc_type, KeyboardInterrupt):
+            previous_thread_hook(args)
+            return
+        logging.getLogger("lorekeep.runtime").critical(
+            "unhandled thread exception error_type=%s thread=%s",
+            args.exc_type.__name__, args.thread.name if args.thread else "unknown",
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+            extra={"event": "runtime.thread_unhandled"},
+        )
+
+    sys.excepthook = _sys_hook
+    threading.excepthook = _thread_hook
+    _exception_hooks_configured = True
 
 
 def is_quiet() -> bool:
@@ -106,7 +212,7 @@ def progress(description: str, total: int | None = None) -> Iterator[_NullProgre
     """A Rich Progress bar in a tty; a silent no-op elsewhere.
 
     Hard-gated on ``console.is_terminal`` so progress text can never appear in
-    CliRunner capture or ``agent.log`` (belt-and-suspenders on top of Rich's
+    CliRunner capture or daemon bootstrap logs (belt-and-suspenders on top of Rich's
     own auto-disable in a non-tty).
     """
     if not console.is_terminal:
@@ -146,9 +252,23 @@ def configure_logging(level: int = logging.INFO) -> None:
     no new INFO/DEBUG noise. ``propagate`` stays True (pytest ``caplog`` depends
     on it). Idempotent: the handler is attached once per process.
     """
-    global _quiet, _logging_configured
+    global _quiet, _logging_configured, _file_handler
     _quiet = level >= logging.WARNING
-    logging.getLogger("lorekeep").setLevel(level)
+    lorekeep_logger = logging.getLogger("lorekeep")
+    lorekeep_logger.setLevel(level)
+    if _file_handler is None:
+        try:
+            _file_handler = _make_file_handler(runtime_log_path())
+            lorekeep_logger.addHandler(_file_handler)
+        except OSError as exc:
+            # Logging must never make the CLI unusable (read-only homes, full
+            # disks, and restrictive containers are all legitimate runtimes).
+            logging.getLogger(__name__).debug("file logging unavailable: %s", exc)
+    elif _file_handler not in lorekeep_logger.handlers:
+        lorekeep_logger.addHandler(_file_handler)
+    if _file_handler is not None:
+        _file_handler.setLevel(level)
+    _install_exception_hooks()
     if _logging_configured:
         return
     from rich.logging import RichHandler

--- a/src/lorekeep/paths.py
+++ b/src/lorekeep/paths.py
@@ -31,6 +31,7 @@ def resolve_paths() -> dict[str, Path]:
         schema = home / "schema.json"
         pending = home / "pending"
         wiki = home / "wiki"
+        logs = home / "logs"
     elif dev:
         home = cwd / ".lorekeep"
         config = home / "config.yaml"
@@ -40,6 +41,7 @@ def resolve_paths() -> dict[str, Path]:
         schema = home / "schema.json"
         pending = home / "pending"
         wiki = home / "wiki"
+        logs = home / "logs"
     else:
         from platformdirs import user_config_dir, user_data_dir
         home = Path(user_data_dir("lorekeep"))
@@ -50,6 +52,7 @@ def resolve_paths() -> dict[str, Path]:
         schema = home / "schema.json"
         pending = home / "pending"
         wiki = home / "wiki"
+        logs = home / "logs"
 
     def override(env_name: str, current: Path) -> Path:
         v = os.environ.get(env_name)
@@ -64,4 +67,5 @@ def resolve_paths() -> dict[str, Path]:
         "config": override("LOREKEEP_CONFIG", config),
         "pending": override("LOREKEEP_PENDING", pending),
         "wiki": override("LOREKEEP_WIKI", wiki),
+        "logs": override("LOREKEEP_LOGS", logs),
     }

--- a/src/lorekeep/pipeline.py
+++ b/src/lorekeep/pipeline.py
@@ -31,6 +31,10 @@ def compile_graph(
     chunks = ingest(raw_root, chunk_lines=chunk_lines)
     cache = ExtractionCache(cache_path)
     total = len(chunks)
+    log.info(
+        "compile started chunk_count=%s", total,
+        extra={"event": "compile.start"},
+    )
 
     all_nodes: list[Node] = []
     all_edges: list[Edge] = []
@@ -48,7 +52,11 @@ def compile_graph(
             for ak, av in aliases.items():       # union variants, last-writer-wins drops aliases
                 all_aliases[ak] = list(dict.fromkeys(all_aliases.get(ak, []) + av))
         except Exception as exc:               # skip-and-log; partial compile is valid
-            log.exception("compile: chunk failed path=%s line=%s", chunk.path, chunk.start_line)
+            log.exception(
+                "compile: chunk failed line=%s error_type=%s",
+                chunk.start_line, type(exc).__name__,
+                extra={"event": "compile.chunk_failed"},
+            )
             errors.append({"path": chunk.path, "line": chunk.start_line,
                            "message": str(exc)})
     cache.save()
@@ -82,4 +90,9 @@ def compile_graph(
         quarantine=[{"fact": q[0], "reason": q[1]} for q in resolved.quarantined],
     )
     write_graph(out_dir, resolved.nodes, resolved.edges, manifest)
+    log.info(
+        "compile completed chunk_count=%s node_count=%s edge_count=%s error_count=%s",
+        len(chunks), len(resolved.nodes), len(resolved.edges), len(errors),
+        extra={"event": "compile.complete"},
+    )
     return manifest

--- a/src/lorekeep/redaction.py
+++ b/src/lorekeep/redaction.py
@@ -1,0 +1,47 @@
+"""Conservative secret and path redaction for diagnostics.
+
+Runtime logs intentionally contain operational metadata only.  This module is
+the final safety net for exception messages and support artifacts, where a
+third-party exception may still contain credentials.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+_SECRET_ASSIGNMENT = re.compile(
+    r"(?i)(api[_-]?key|access[_-]?token|auth[_-]?token|password|passwd|secret)"
+    r"(\s*[=:]\s*)([^\s,;]+)"
+)
+_BEARER = re.compile(r"(?i)\b(bearer\s+)[A-Za-z0-9._~+/=-]+")
+_URL_USERINFO = re.compile(r"(https?://)([^/@\s]+)@", re.IGNORECASE)
+_URL_SECRET_QUERY = re.compile(
+    r"(?i)([?&](?:api[_-]?key|access[_-]?token|token|key|secret|password)=)[^&#\s]+"
+)
+_COMMON_KEY = re.compile(
+    r"\b(?:sk|rk|pk|or|ds)-[A-Za-z0-9_-]{12,}\b",
+    re.IGNORECASE,
+)
+
+
+def redact_text(value: object, *, home: Path | None = None) -> str:
+    """Return a copy safe for logs and user-shareable diagnostics."""
+    text = str(value)
+    text = _SECRET_ASSIGNMENT.sub(r"\1\2[REDACTED]", text)
+    text = _BEARER.sub(r"\1[REDACTED]", text)
+    text = _URL_USERINFO.sub(r"\1[REDACTED]@", text)
+    text = _URL_SECRET_QUERY.sub(r"\1[REDACTED]", text)
+    text = _COMMON_KEY.sub("[REDACTED]", text)
+
+    resolved_home = home
+    if resolved_home is None:
+        try:
+            resolved_home = Path.home()
+        except (RuntimeError, OSError):
+            resolved_home = None
+    if resolved_home:
+        home_text = os.fspath(resolved_home)
+        if home_text and home_text != os.path.sep:
+            text = text.replace(home_text, "~")
+    return text

--- a/src/lorekeep/support.py
+++ b/src/lorekeep/support.py
@@ -1,0 +1,192 @@
+"""Privacy-safe diagnostics for GitHub issue reports."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from lorekeep import __version__
+from lorekeep.paths import resolve_paths
+from lorekeep.redaction import redact_text
+
+LOG_TAIL_LINES = 1000
+REPORT_EVENT_LINES = 20
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _display_path(path: Path, home: Path) -> str:
+    try:
+        rel = path.resolve().relative_to(home.resolve())
+        return "~" if not rel.parts else f"~/{rel.as_posix()}"
+    except (OSError, ValueError):
+        return redact_text(path)
+
+
+def _file_health(path: Path) -> str:
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return "missing"
+    except OSError as exc:
+        return f"unreadable ({type(exc).__name__})"
+    kind = "dir" if path.is_dir() else "file"
+    return f"{kind}, {stat.st_size} bytes"
+
+
+def _safe_config(config_path: Path) -> dict[str, Any]:
+    """Load only explicitly allowlisted, non-content config fields."""
+    try:
+        from lorekeep.config import load_config
+        cfg = load_config(config_path)
+    except Exception as exc:
+        return {"status": f"invalid ({type(exc).__name__})"}
+    return {
+        "status": "loaded" if config_path.exists() else "defaults",
+        "provider_model": cfg.provider.model,
+        "api_key_env_name": cfg.provider.api_key_env or "not configured",
+        "compile_chunk_lines": cfg.compile.chunk_lines,
+        "observability_provider": cfg.observability.provider or "disabled",
+        "install_source": cfg.install_source or "unknown",
+    }
+
+
+def _manifest_summary(path: Path) -> dict[str, Any]:
+    try:
+        from lorekeep.models import Manifest
+        manifest = Manifest.from_json(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {"status": "missing"}
+    except Exception as exc:
+        return {"status": f"invalid ({type(exc).__name__})"}
+    return {
+        "status": "loaded",
+        "compiled_at": manifest.compiled_at or "unknown",
+        "run_id": manifest.run_id,
+        "facts_hash_prefix": manifest.facts_hash[:12],
+        "chunk_count": manifest.chunk_count,
+        "node_count": manifest.node_count,
+        "edge_count": manifest.edge_count,
+        "error_count": len(manifest.errors),
+        "quarantined_count": manifest.quarantined_count,
+        "flagged_count": manifest.flagged_count,
+        "merged_count": manifest.merged_count,
+    }
+
+
+def _service_status() -> str:
+    try:
+        from lorekeep.daemon_service import status
+        return redact_text(status())
+    except Exception as exc:
+        return f"unavailable ({type(exc).__name__})"
+
+
+def _log_tail(log_path: Path, lines: int = LOG_TAIL_LINES) -> str:
+    try:
+        content = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except FileNotFoundError:
+        return "runtime log is missing\n"
+    except OSError as exc:
+        return f"runtime log is unreadable ({type(exc).__name__})\n"
+    return "\n".join(redact_text(line) for line in content[-lines:]) + "\n"
+
+
+def _recent_events(log_path: Path, limit: int = REPORT_EVENT_LINES) -> list[str]:
+    """Return structured warning/error headers, excluding traceback bodies."""
+    try:
+        lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    levels = (" level=WARNING ", " level=ERROR ", " level=CRITICAL ")
+    return [redact_text(line) for line in lines if any(level in line for level in levels)][-limit:]
+
+
+def build_report() -> str:
+    """Build copy/paste-ready Markdown without raw knowledge content."""
+    paths = resolve_paths()
+    home = paths["home"]
+    safe_config = _safe_config(paths["config"])
+    manifest = _manifest_summary(paths["out"] / "manifest.json")
+    generated = _utc_now().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    rows = [
+        ("Lorekeep", __version__),
+        ("Python", platform.python_version()),
+        ("Platform", f"{platform.system()} {platform.release()} ({platform.machine()})"),
+        ("Generated", generated),
+        ("Daemon", _service_status()),
+    ]
+    config_rows = [(key, value) for key, value in safe_config.items()]
+    manifest_rows = [(key, value) for key, value in manifest.items()]
+    path_rows = [
+        (key, f"{_display_path(paths[key], home)} — {_file_health(paths[key])}")
+        for key in ("home", "config", "schema", "raw", "out", "pending", "wiki", "logs")
+    ]
+    legacy_rows = [
+        (name, _file_health(home / name))
+        for name in ("agent.log", "daemon.log", "daemon.err.log")
+    ]
+    recent_events = _recent_events(paths["logs"] / "lorekeep.log")
+    recent_block = "\n".join(recent_events) if recent_events else "No warning/error events found."
+
+    def table(items: list[tuple[str, Any]]) -> str:
+        return "\n".join(
+            f"| {redact_text(k)} | {redact_text(v, home=home).replace('|', '\\|')} |"
+            for k, v in items
+        )
+
+    return (
+        "# Lorekeep support report\n\n"
+        "> Metadata only. Raw documents, graph facts, prompts, queries, journal "
+        "content and credential values are excluded.\n\n"
+        "## Runtime\n\n| Field | Value |\n|---|---|\n" + table(rows) + "\n\n"
+        "## Safe configuration\n\n| Field | Value |\n|---|---|\n" + table(config_rows) + "\n\n"
+        "## Graph manifest summary\n\n| Field | Value |\n|---|---|\n" + table(manifest_rows) + "\n\n"
+        "## Path health\n\n| Path | State |\n|---|---|\n" + table(path_rows) + "\n\n"
+        "## Legacy logs\n\n| File | State |\n|---|---|\n" + table(legacy_rows) + "\n"
+        "\n## Recent warning/error events\n\n```text\n" + recent_block + "\n```\n"
+    )
+
+
+def write_report(output: Path) -> Path:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(build_report(), encoding="utf-8")
+    _private_file(output)
+    return output
+
+
+def _private_file(path: Path) -> None:
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def create_bundle(output: Path | None = None) -> tuple[Path, str]:
+    """Create an allowlisted support archive and return (path, sha256)."""
+    paths = resolve_paths()
+    if output is None:
+        stamp = _utc_now().strftime("%Y%m%dT%H%M%SZ")
+        output = Path.cwd() / f"lorekeep-support-{stamp}.zip"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    report = build_report()
+    tail = _log_tail(paths["logs"] / "lorekeep.log")
+    summary = json.dumps(
+        _manifest_summary(paths["out"] / "manifest.json"),
+        indent=2, sort_keys=True, ensure_ascii=False,
+    ) + "\n"
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("report.md", report)
+        archive.writestr("logs/runtime-tail.log", tail)
+        archive.writestr("manifest-summary.json", summary)
+    _private_file(output)
+    digest = hashlib.sha256(output.read_bytes()).hexdigest()
+    return output, digest

--- a/tests/test_daemon_service.py
+++ b/tests/test_daemon_service.py
@@ -94,6 +94,11 @@ class TestLaunchdPlist:
         assert f"LOREKEEP_HOME" in plist
         assert str(tmp_path) in plist
 
+    def test_plist_uses_bootstrap_logs_under_data_home(self, tmp_path):
+        plist = _launchd_plist(tmp_path)
+        assert f"{tmp_path}/logs/daemon-bootstrap.log" in plist
+        assert f"{tmp_path}/logs/daemon-bootstrap.err.log" in plist
+
     def test_plist_path_in_library(self):
         path = _launchd_plist_path()
         assert "Library/LaunchAgents" in str(path)
@@ -107,6 +112,9 @@ class TestLaunchdPlist:
             from lorekeep.daemon_service import install_launchd
             plist_path = install_launchd(tmp_path / "data")
         assert plist_path.exists()
+        if sys.platform != "win32":
+            assert (tmp_path / "data/logs/daemon-bootstrap.log").stat().st_mode & 0o777 == 0o600
+            assert (tmp_path / "data/logs/daemon-bootstrap.err.log").stat().st_mode & 0o777 == 0o600
 
 
 class TestWindowsScript:

--- a/tests/test_journal_logging.py
+++ b/tests/test_journal_logging.py
@@ -1,0 +1,15 @@
+import logging
+
+from lorekeep.journal import load_journals
+
+
+def test_corrupt_journal_line_warns_without_logging_content(tmp_path, caplog):
+    path = tmp_path / "pending" / "private" / "journal.jsonl"
+    path.parent.mkdir(parents=True)
+    path.write_text('{"secret":"raw-private-content"}\nnot-json-secret-content\n')
+    with caplog.at_level(logging.WARNING, logger="lorekeep.journal"):
+        assert load_journals(tmp_path / "pending") == []
+    assert caplog.text.count("invalid journal line") == 2
+    assert "line=1" in caplog.text and "line=2" in caplog.text
+    assert "raw-private-content" not in caplog.text
+    assert "not-json-secret-content" not in caplog.text

--- a/tests/test_mcp_reload.py
+++ b/tests/test_mcp_reload.py
@@ -30,3 +30,20 @@ def test_no_reload_when_unchanged(tmp_path: Path, fixtures: Path):
     m1 = ms._state.get("facts_mtime")
     ms.get_node("svc:auth")                       # query; no file change
     assert ms._state.get("facts_mtime") == m1     # no reload fired
+
+
+def test_fts_failure_is_logged_without_stopping_mcp(tmp_path, fixtures, monkeypatch, caplog):
+    d = tmp_path / "graph"
+    d.mkdir()
+    shutil.copy(fixtures / "gold/payments.facts.jsonl", d / "facts.jsonl")
+
+    class BrokenFTS:
+        def __init__(self, _path):
+            raise OSError("private index detail")
+
+    monkeypatch.setattr(ms, "FTSIndex", BrokenFTS)
+    with caplog.at_level("WARNING", logger="lorekeep.mcp"):
+        ms.configure(graph_dir=d, allowed_ns=["backend"], schema_path=fixtures / "schema.json")
+    assert ms._fts is None
+    assert "FTS unavailable" in caplog.text
+    assert "private index detail" not in caplog.text

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -13,6 +13,7 @@ def test_dev_mode_via_lorekeep_marker(tmp_path: Path, monkeypatch):
     assert p["out"] == tmp_path / ".lorekeep" / "graph"
     assert p["schema"] == tmp_path / ".lorekeep" / "schema.json"
     assert p["pending"] == tmp_path / ".lorekeep" / "pending"
+    assert p["logs"] == tmp_path / ".lorekeep" / "logs"
 
 
 def test_lorekeep_home_overrides_dev(tmp_path: Path, monkeypatch):
@@ -25,6 +26,7 @@ def test_lorekeep_home_overrides_dev(tmp_path: Path, monkeypatch):
     assert p["config"] == home / "config.yaml"
     assert p["raw"] == home / "raw"
     assert p["schema"] == home / "schema.json"
+    assert p["logs"] == home / "logs"
 
 
 def test_xdg_default(tmp_path: Path, monkeypatch):
@@ -40,6 +42,7 @@ def test_xdg_default(tmp_path: Path, monkeypatch):
     assert p["config"] == tmp_path / "xdg-config" / "lorekeep" / "config.yaml"
     assert p["raw"] == tmp_path / "xdg-data" / "lorekeep" / "raw"
     assert p["schema"] == tmp_path / "xdg-data" / "lorekeep" / "schema.json"
+    assert p["logs"] == tmp_path / "xdg-data" / "lorekeep" / "logs"
 
 
 def test_explicit_env_overrides_everything(tmp_path: Path, monkeypatch):
@@ -48,9 +51,11 @@ def test_explicit_env_overrides_everything(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("LOREKEEP_RAW", "/custom/raw")
     monkeypatch.setenv("LOREKEEP_OUT", "/custom/graph")
     monkeypatch.setenv("LOREKEEP_CONFIG", "/custom/config.yaml")
+    monkeypatch.setenv("LOREKEEP_LOGS", "/custom/logs")
     p = resolve_paths()
     assert p["home"] == tmp_path / ".lorekeep"
     assert p["raw"] == Path("/custom/raw")
     assert p["out"] == Path("/custom/graph")
     assert p["config"] == Path("/custom/config.yaml")
     assert p["schema"] == tmp_path / ".lorekeep" / "schema.json"
+    assert p["logs"] == Path("/custom/logs")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -10,7 +10,8 @@ def copy_fixture(src: Path, dst: Path) -> None:
     dst.write_text(src.read_text())
 
 
-def test_compile_pipeline_produces_facts(tmp_path: Path, fixtures: Path):
+def test_compile_pipeline_produces_facts(tmp_path: Path, fixtures: Path, caplog):
+    import logging as _logging
     raw = tmp_path / "raw"
     copy_fixture(fixtures / "raw/backend/payments.md",
                  raw / "teams/backend/payments.md")
@@ -36,13 +37,16 @@ def test_compile_pipeline_produces_facts(tmp_path: Path, fixtures: Path):
     })
     provider = FakeProvider([canned])
 
-    manifest = compile_graph(raw_root=raw, out_dir=out, schema=schema,
-                             provider=provider, cache_path=cache, chunk_lines=60)
+    with caplog.at_level(_logging.INFO, logger="lorekeep"):
+        manifest = compile_graph(raw_root=raw, out_dir=out, schema=schema,
+                                 provider=provider, cache_path=cache, chunk_lines=60)
     facts = (out / "facts.jsonl").read_text().splitlines()
     assert len(facts) == 6                       # 4 nodes + 2 edges
     assert (out / "manifest.json").exists()
     assert manifest.node_count == 4
     assert manifest.edge_count == 2
+    assert any(getattr(r, "event", "") == "compile.start" for r in caplog.records)
+    assert any(getattr(r, "event", "") == "compile.complete" for r in caplog.records)
 
 
 def test_pipeline_per_chunk_failure_logs_exception(tmp_path: Path, fixtures: Path, caplog):

--- a/tests/test_runtime_logging.py
+++ b/tests/test_runtime_logging.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+import os
+import re
+import sys
+import threading
+from pathlib import Path
+
+from lorekeep import output
+from lorekeep.redaction import redact_text
+
+
+def test_file_handler_writes_context_utc_and_redacted_traceback(tmp_path: Path):
+    path = tmp_path / "logs" / "lorekeep.log"
+    handler = output._make_file_handler(path)
+    logger = logging.getLogger("lorekeep.test.runtime")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+    try:
+        raise RuntimeError("api_key=sk-super-secret-value")
+    except RuntimeError:
+        logger.exception("operation failed", extra={"event": "test.failed"})
+    finally:
+        handler.close()
+        logger.handlers.clear()
+
+    text = path.read_text(encoding="utf-8")
+    assert re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", text)
+    assert "event=test.failed" in text
+    assert "run_id=" in text
+    assert "RuntimeError: [details redacted]" in text
+    assert "super-secret" not in text
+    assert "\x1b[" not in text
+
+
+def test_file_handler_rotation_and_private_permissions(tmp_path: Path):
+    path = tmp_path / "logs" / "lorekeep.log"
+    handler = output._make_file_handler(path)
+    handler.maxBytes = 100
+    logger = logging.getLogger("lorekeep.test.rotation")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+    for _ in range(10):
+        logger.info("x" * 80, extra={"event": "test.rotation"})
+    handler.close()
+    logger.handlers.clear()
+    assert path.with_suffix(".log.1").exists()
+    if os.name != "nt":
+        assert path.stat().st_mode & 0o777 == 0o600
+        assert path.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_redaction_covers_credentials_urls_and_home(tmp_path: Path):
+    source = (
+        f"api_key=abc123 password: hunter2 Authorization: Bearer secret-token "
+        f"https://user:pass@example.test/a?token=qwerty path={tmp_path}/raw"
+    )
+    result = redact_text(source, home=tmp_path)
+    for secret in ("abc123", "hunter2", "secret-token", "user:pass", "qwerty"):
+        assert secret not in result
+    assert "~/raw" in result
+
+
+def test_redaction_preserves_harmless_metadata():
+    value = "provider=openrouter model=openrouter/deepseek-chat count=12"
+    assert redact_text(value) == value
+
+
+def test_unhandled_exception_hook_logs_type_not_value(monkeypatch, caplog):
+    previous_sys = sys.excepthook
+    previous_thread = threading.excepthook
+    previous_configured = output._exception_hooks_configured
+    monkeypatch.setattr(output, "_exception_hooks_configured", False)
+    try:
+        output._install_exception_hooks()
+        try:
+            raise ValueError("raw-private-exception-content")
+        except ValueError as exc:
+            with caplog.at_level(logging.CRITICAL, logger="lorekeep.runtime"):
+                output.sys.excepthook(type(exc), exc, exc.__traceback__)
+    finally:
+        sys.excepthook = previous_sys
+        threading.excepthook = previous_thread
+        output._exception_hooks_configured = previous_configured
+    assert "unhandled exception error_type=ValueError" in caplog.text
+    # The safe file formatter strips the value; caplog sees the original
+    # record and therefore only assert the structured message itself here.
+    assert caplog.records[-1].getMessage().endswith("ValueError")

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import os
+import zipfile
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from lorekeep.cli import app
+from lorekeep.support import build_report, create_bundle
+
+runner = CliRunner()
+
+
+def _seed_home(tmp_path: Path, monkeypatch) -> Path:
+    home = tmp_path / "data"
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "provider:\n"
+        "  model: openrouter/deepseek/deepseek-chat\n"
+        "  api_key_env: OPENROUTER_API_KEY\n"
+        "  api_key: sk-must-never-appear\n"
+        "  api_base: https://user:pass@example.test/?token=hidden\n",
+        encoding="utf-8",
+    )
+    graph = home / "graph"
+    graph.mkdir()
+    (graph / "manifest.json").write_text(json.dumps({
+        "schema_version": 3, "chunk_count": 2, "node_count": 3,
+        "edge_count": 1, "run_id": "compile-123", "facts_hash": "a" * 64,
+        "errors": [{"path": "raw/private.md", "line": 1,
+                    "message": "prompt body secret-content"}],
+    }), encoding="utf-8")
+    logs = home / "logs"
+    logs.mkdir()
+    (logs / "lorekeep.log").write_text(
+        "2026-08-04T00:00:00Z level=ERROR component=lorekeep "
+        "event=compile.failed api_key=sk-log-secret\n", encoding="utf-8",
+    )
+    (home / "raw").mkdir()
+    (home / "raw" / "private.md").write_text("raw-private-content", encoding="utf-8")
+    return home
+
+
+def test_report_is_metadata_only_and_handles_missing_service(tmp_path: Path, monkeypatch):
+    _seed_home(tmp_path, monkeypatch)
+    monkeypatch.setattr("lorekeep.daemon_service.status", lambda: "inactive")
+    report = build_report()
+    assert "openrouter/deepseek/deepseek-chat" in report
+    assert "OPENROUTER_API_KEY" in report
+    assert "error_count | 1" in report
+    assert "inactive" in report
+    assert "event=compile.failed" in report
+    for forbidden in ("must-never", "user:pass", "hidden", "private.md",
+                      "prompt body", "raw-private-content"):
+        assert forbidden not in report
+
+
+def test_bundle_has_strict_allowlist_and_redacted_tail(tmp_path: Path, monkeypatch):
+    _seed_home(tmp_path, monkeypatch)
+    monkeypatch.setattr("lorekeep.daemon_service.status", lambda: "inactive")
+    output = tmp_path / "support.zip"
+    path, digest = create_bundle(output)
+    assert path == output
+    assert len(digest) == 64
+    if os.name != "nt":
+        assert output.stat().st_mode & 0o777 == 0o600
+    with zipfile.ZipFile(output) as archive:
+        assert set(archive.namelist()) == {
+            "report.md", "logs/runtime-tail.log", "manifest-summary.json",
+        }
+        combined = b"".join(archive.read(name) for name in archive.namelist()).decode()
+    assert "sk-log-secret" not in combined
+    assert "raw-private-content" not in combined
+    assert "prompt body" not in combined
+    assert "[REDACTED]" in combined
+
+
+def test_support_cli_prints_report_and_creates_bundle(tmp_path: Path, monkeypatch):
+    _seed_home(tmp_path, monkeypatch)
+    monkeypatch.setattr("lorekeep.daemon_service.status", lambda: "inactive")
+    output = tmp_path / "cli-support.zip"
+    result = runner.invoke(app, ["support", "--output", str(output)])
+    assert result.exit_code == 0, result.output
+    assert "# Lorekeep support report" in result.output
+    assert output.exists()
+    assert "support bundle:" in result.output
+    assert "sha256:" in result.output
+
+
+def test_support_cli_report_only_creates_no_bundle(tmp_path: Path, monkeypatch):
+    _seed_home(tmp_path, monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("lorekeep.daemon_service.status", lambda: "inactive")
+    result = runner.invoke(app, ["support", "--report-only"])
+    assert result.exit_code == 0, result.output
+    assert "# Lorekeep support report" in result.output
+    assert not list(tmp_path.glob("lorekeep-support-*.zip"))
+
+
+def test_support_cli_no_print_only_outputs_bundle_location(tmp_path: Path, monkeypatch):
+    _seed_home(tmp_path, monkeypatch)
+    monkeypatch.setattr("lorekeep.daemon_service.status", lambda: "inactive")
+    output = tmp_path / "quiet-support.zip"
+    result = runner.invoke(app, ["support", "--no-print", "--output", str(output)])
+    assert result.exit_code == 0, result.output
+    assert "# Lorekeep support report" not in result.output
+    assert "support bundle:" in result.output
+    assert output.exists()
+
+
+def test_hidden_legacy_support_aliases_still_work(tmp_path: Path, monkeypatch):
+    _seed_home(tmp_path, monkeypatch)
+    monkeypatch.setattr("lorekeep.daemon_service.status", lambda: "inactive")
+    report = runner.invoke(app, ["support", "report"])
+    assert report.exit_code == 0, report.output
+    assert "# Lorekeep support report" in report.output
+    output = tmp_path / "legacy.zip"
+    bundle = runner.invoke(app, ["support", "bundle", "--output", str(output)])
+    assert bundle.exit_code == 0, bundle.output
+    assert output.exists()
+
+
+def test_report_survives_invalid_config_and_manifest(tmp_path: Path, monkeypatch):
+    home = tmp_path / "data"
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    (home / "graph").mkdir(parents=True)
+    (home / "config.yaml").write_text("provider: [", encoding="utf-8")
+    (home / "graph" / "manifest.json").write_text("not-json", encoding="utf-8")
+    monkeypatch.setattr("lorekeep.daemon_service.status", lambda: "inactive")
+    report = build_report()
+    assert "invalid (ParserError)" in report
+    assert "invalid (JSONDecodeError)" in report


### PR DESCRIPTION
## Summary

- add always-on rotating runtime logs for CLI, daemon, compile, MCP, journal, resolve, wiki, and unhandled exceptions
- add privacy-safe redaction, metadata-only tracebacks, stable event fields, run IDs, UTC timestamps, and private file permissions
- add a unified `lorekeep support` workflow that prints the report and creates its attachment ZIP in one command
- retain hidden `support report` and `support bundle` compatibility aliases
- add a GitHub bug-report form and runtime logging/support documentation

## Why

Lorekeep previously spread diagnostics across stderr, an append-only daemon log, platform-native service logs, and several silent best-effort exception paths. This made multi-device and agent runtime failures difficult to reproduce or report. The new workflow produces consistent local evidence without packaging knowledge-graph content or credentials.

## User impact

Run `lorekeep support` after a failure. It prints a copy/paste-ready Markdown report and creates a ZIP containing only the report, a redacted runtime-log tail, and a filtered manifest summary. Use `--report-only`, `--no-print`, or `--output PATH` when needed.

## Validation

- `uv run pytest tests/test_core_regression.py -q` — 26 passed
- `uv run pytest -q` — 626 passed
- `uv build` — sdist and wheel built successfully
- manual smoke tests for help, report, bundle creation, file permissions, and an intentionally failing MCP startup