### PR TITLE
ci: make releases atomic

### DIFF
--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -3,13 +3,11 @@ name: auto-merge-release-please
 # When release-please creates or updates a Release PR on the
 # release-please--branches--main branch, enable auto-merge so it
 # merges automatically once branch-protection checks pass.
-#
-# NOTE: uv.lock sync happens post-release in release-please.yml
-# (sync-uv-lock job), NOT here. GITHUB_TOKEN PRs don't trigger
-# pull_request workflows, so pre-merge uv lock never runs.
+# The Release PR itself contains every versioned file, including uv.lock.
 on:
   pull_request:
-    types: [opened, synchronize]
+    # release-please may add autorelease: pending immediately after opening.
+    types: [opened, synchronize, labeled]
 
 permissions:
   contents: write
@@ -17,11 +15,14 @@ permissions:
 
 jobs:
   auto-merge:
-    if: startsWith(github.head_ref, 'release-please--')
+    if: >-
+      startsWith(github.head_ref, 'release-please--') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     runs-on: ubuntu-latest
     steps:
       - name: Enable auto-merge for Release PR
         run: |
           gh pr merge --auto --merge "${{ github.event.pull_request.html_url }}"
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,14 @@ jobs:
         with:
           enable-cache: true
 
-      - run: uv sync
+      - name: Verify committed lockfile
+        run: uv lock --check
 
-      - run: uv run pytest -q
+      - name: Install locked dependencies
+        run: uv sync --locked
+
+      - name: Verify release metadata
+        run: uv run --locked python scripts/check-release-integrity.py
+
+      - name: Run tests
+        run: uv run --locked pytest -q

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,9 @@ name: release-please
 # the git tag + GitHub Release, then the publish job builds and publishes to
 # PyPI via OIDC trusted publishing (no API token).
 #
+# The Release PR updates every committed release artifact atomically, including
+# uv.lock. Publishing refuses inconsistent source versions, tags, or artifacts.
+#
 # IMPORTANT: Uses RELEASE_PLEASE_TOKEN (a Personal Access Token) instead of
 # GITHUB_TOKEN. PRs created by GITHUB_TOKEN don't trigger downstream workflow
 # runs (GitHub prevents this to avoid loops). A PAT-authored PR merge DOES
@@ -28,6 +31,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -40,11 +47,20 @@ jobs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
+      - name: Require release automation token
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_PLEASE_TOKEN" ]; then
+            echo "RELEASE_PLEASE_TOKEN is required so generated PRs trigger CI" >&2
+            exit 1
+          fi
+
       - id: rp
         uses: googleapis/release-please-action@v5
         with:
           # PAT required: GITHUB_TOKEN PRs don't trigger push events on merge
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   publish:
     needs: release-please
@@ -61,45 +77,19 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
-      - run: uv build
+      - name: Verify release source
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag_name || needs.release-please.outputs.tag_name }}
+        run: |
+          uv lock --check
+          python scripts/check-release-integrity.py --tag "$RELEASE_TAG"
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Verify distribution metadata
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag_name || needs.release-please.outputs.tag_name }}
+        run: python scripts/check-release-integrity.py --tag "$RELEASE_TAG" --dist dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-
-  sync-uv-lock:
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: main
-
-      - uses: astral-sh/setup-uv@v7
-
-      - run: uv lock
-
-      - name: Sync uv.lock via PR
-        run: |
-          if git diff --quiet uv.lock; then
-            echo "uv.lock already in sync"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b chore/sync-uv-lock-${{ needs.release-please.outputs.tag_name }}
-          git add uv.lock
-          git commit -m "chore: sync uv.lock to ${{ needs.release-please.outputs.tag_name }}"
-          git push origin chore/sync-uv-lock-${{ needs.release-please.outputs.tag_name }}
-          gh pr create \
-            --title "chore: sync uv.lock to ${{ needs.release-please.outputs.tag_name }}" \
-            --body "Auto-synced after release." \
-            --base main \
-            --head chore/sync-uv-lock-${{ needs.release-please.outputs.tag_name }}
-          sleep 3
-          gh pr merge --merge --auto --delete-branch \
-            chore/sync-uv-lock-${{ needs.release-please.outputs.tag_name }}
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,14 @@
     ".": {
       "release-type": "python",
       "include-v-in-tag": true,
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name=='lorekeep')].version"
+        }
+      ]
     }
   }
 }

--- a/scripts/check-release-integrity.py
+++ b/scripts/check-release-integrity.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Fail when committed release versions or built artifacts disagree."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from email import policy
+from email.parser import BytesParser
+import json
+from pathlib import Path
+import re
+import sys
+import tarfile
+import tomllib
+import zipfile
+
+
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
+)
+CHANGELOG_VERSION_RE = re.compile(r"^## \[([^]]+)]", re.MULTILINE)
+
+
+class IntegrityError(Exception):
+    """A user-actionable collection of release integrity failures."""
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        super().__init__("; ".join(errors))
+
+
+def _load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise IntegrityError([f"cannot read {path}: {exc}"]) from exc
+
+
+def _load_toml(path: Path) -> dict[str, object]:
+    try:
+        with path.open("rb") as handle:
+            return tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise IntegrityError([f"cannot read {path}: {exc}"]) from exc
+
+
+def _require_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise IntegrityError([f"{label} must be a non-empty string"])
+    return value
+
+
+def _manifest_version(root: Path) -> str:
+    data = _load_json(root / ".release-please-manifest.json")
+    if not isinstance(data, dict):
+        raise IntegrityError([".release-please-manifest.json must contain an object"])
+    return _require_string(data.get("."), ".release-please-manifest.json['.']")
+
+
+def _project_metadata(root: Path) -> tuple[str, str]:
+    data = _load_toml(root / "pyproject.toml")
+    project = data.get("project")
+    if not isinstance(project, dict):
+        raise IntegrityError(["pyproject.toml is missing [project]"])
+    name = _require_string(project.get("name"), "pyproject.toml project.name")
+    version = _require_string(project.get("version"), "pyproject.toml project.version")
+    return name, version
+
+
+def _module_version(root: Path) -> str:
+    path = root / "src" / "lorekeep" / "__init__.py"
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError) as exc:
+        raise IntegrityError([f"cannot read {path}: {exc}"]) from exc
+
+    values: list[str] = []
+    for node in tree.body:
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "__version__"
+            for target in node.targets
+        ):
+            value = node.value
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "__version__"
+        ):
+            value = node.value
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            values.append(value.value)
+
+    if len(values) != 1:
+        raise IntegrityError(
+            [f"{path} must define exactly one literal __version__; found {len(values)}"]
+        )
+    return values[0]
+
+
+def _lock_version(root: Path, project_name: str) -> str:
+    path = root / "uv.lock"
+    data = _load_toml(path)
+    packages = data.get("package", [])
+    if not isinstance(packages, list):
+        raise IntegrityError(["uv.lock is missing [[package]] entries"])
+
+    local_packages: list[dict[str, object]] = []
+    for package in packages:
+        if not isinstance(package, dict) or package.get("name") != project_name:
+            continue
+        source = package.get("source")
+        if isinstance(source, dict) and source.get("editable") == ".":
+            local_packages.append(package)
+
+    if len(local_packages) != 1:
+        raise IntegrityError(
+            [
+                "uv.lock must contain exactly one editable "
+                f"{project_name!r} package; found {len(local_packages)}"
+            ]
+        )
+    return _require_string(local_packages[0].get("version"), "uv.lock local version")
+
+
+def _changelog_version(root: Path) -> str:
+    path = root / "CHANGELOG.md"
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise IntegrityError([f"cannot read {path}: {exc}"]) from exc
+    match = CHANGELOG_VERSION_RE.search(content)
+    if match is None:
+        raise IntegrityError(["CHANGELOG.md has no version heading"])
+    return match.group(1)
+
+
+def _metadata_headers(content: bytes, label: str) -> tuple[str, str]:
+    message = BytesParser(policy=policy.default).parsebytes(content)
+    name = message.get("Name")
+    version = message.get("Version")
+    if not name or not version:
+        raise IntegrityError([f"{label} metadata must contain Name and Version"])
+    return str(name), str(version)
+
+
+def _wheel_metadata(path: Path) -> tuple[str, str]:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            members = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+            if len(members) != 1:
+                raise IntegrityError(
+                    [f"{path} must contain exactly one .dist-info/METADATA file"]
+                )
+            return _metadata_headers(archive.read(members[0]), str(path))
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise IntegrityError([f"cannot read wheel {path}: {exc}"]) from exc
+
+
+def _sdist_metadata(path: Path) -> tuple[str, str]:
+    try:
+        with tarfile.open(path, "r:gz") as archive:
+            members = [
+                member
+                for member in archive.getmembers()
+                if member.isfile() and member.name.endswith("/PKG-INFO")
+            ]
+            if len(members) != 1:
+                raise IntegrityError([f"{path} must contain exactly one PKG-INFO file"])
+            extracted = archive.extractfile(members[0])
+            if extracted is None:
+                raise IntegrityError([f"cannot extract metadata from {path}"])
+            return _metadata_headers(extracted.read(), str(path))
+    except (OSError, tarfile.TarError) as exc:
+        raise IntegrityError([f"cannot read sdist {path}: {exc}"]) from exc
+
+
+def _normalized_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value).lower()
+
+
+def _artifact_errors(dist: Path, project_name: str, version: str) -> list[str]:
+    wheels = sorted(dist.glob("*.whl"))
+    sdists = sorted(dist.glob("*.tar.gz"))
+    errors: list[str] = []
+    if len(wheels) != 1:
+        errors.append(f"{dist} must contain exactly one wheel; found {len(wheels)}")
+    if len(sdists) != 1:
+        errors.append(f"{dist} must contain exactly one sdist; found {len(sdists)}")
+    if errors:
+        return errors
+
+    for path, reader in ((wheels[0], _wheel_metadata), (sdists[0], _sdist_metadata)):
+        try:
+            artifact_name, artifact_version = reader(path)
+        except IntegrityError as exc:
+            errors.extend(exc.errors)
+            continue
+        if _normalized_name(artifact_name) != _normalized_name(project_name):
+            errors.append(
+                f"{path}: expected project {project_name!r}, found {artifact_name!r}"
+            )
+        if artifact_version != version:
+            errors.append(
+                f"{path}: expected version {version!r}, found {artifact_version!r}"
+            )
+    return errors
+
+
+def check_release(root: Path, *, tag: str | None = None, dist: Path | None = None) -> str:
+    """Validate source and optional artifacts, returning the canonical version."""
+
+    project_name, expected = _project_metadata(root)
+    versions = {
+        ".release-please-manifest.json": _manifest_version(root),
+        "pyproject.toml": expected,
+        "src/lorekeep/__init__.py": _module_version(root),
+        "uv.lock": _lock_version(root, project_name),
+        "CHANGELOG.md": _changelog_version(root),
+    }
+
+    errors = [
+        f"{path}: expected version {expected!r}, found {version!r}"
+        for path, version in versions.items()
+        if version != expected
+    ]
+    if SEMVER_RE.fullmatch(expected) is None:
+        errors.append(f"pyproject.toml version is not SemVer: {expected!r}")
+    if tag is not None and tag != f"v{expected}":
+        errors.append(f"release tag: expected {f'v{expected}'!r}, found {tag!r}")
+    if dist is not None:
+        errors.extend(_artifact_errors(dist, project_name, expected))
+
+    if errors:
+        raise IntegrityError(errors)
+    return expected
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="repository root (defaults to the script's parent repository)",
+    )
+    parser.add_argument("--tag", help="expected release tag, including the v prefix")
+    parser.add_argument("--dist", type=Path, help="directory containing one wheel and sdist")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    root = args.root.resolve()
+    dist = args.dist.resolve() if args.dist is not None else None
+    try:
+        version = check_release(root, tag=args.tag, dist=dist)
+    except IntegrityError as exc:
+        print("release integrity check failed:", file=sys.stderr)
+        for error in exc.errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print(f"release integrity OK: lorekeep {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_integrity.py
+++ b/tests/test_release_integrity.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+import json
+import subprocess
+import sys
+import tarfile
+import zipfile
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "check-release-integrity.py"
+VERSION = "1.2.3"
+
+
+def _write_repo(
+    root: Path,
+    *,
+    manifest: str = VERSION,
+    project: str = VERSION,
+    module: str = VERSION,
+    lock: str = VERSION,
+    changelog: str = VERSION,
+    lock_entries: int = 1,
+) -> None:
+    (root / "src" / "lorekeep").mkdir(parents=True)
+    (root / ".release-please-manifest.json").write_text(
+        json.dumps({".": manifest}), encoding="utf-8"
+    )
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "lorekeep"\nversion = "{project}"\n',
+        encoding="utf-8",
+    )
+    (root / "src" / "lorekeep" / "__init__.py").write_text(
+        f'__version__ = "{module}"\n', encoding="utf-8"
+    )
+    packages = "".join(
+        "\n[[package]]\n"
+        'name = "lorekeep"\n'
+        f'version = "{lock}"\n'
+        'source = { editable = "." }\n'
+        for _ in range(lock_entries)
+    )
+    (root / "uv.lock").write_text(f"version = 1\n{packages}", encoding="utf-8")
+    (root / "CHANGELOG.md").write_text(
+        f"# Changelog\n\n## [{changelog}] (2026-01-01)\n",
+        encoding="utf-8",
+    )
+
+
+def _run(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_artifacts(dist: Path, *, wheel_version: str, sdist_version: str) -> None:
+    dist.mkdir()
+    wheel = dist / f"lorekeep-{wheel_version}-py3-none-any.whl"
+    wheel_metadata = (
+        "Metadata-Version: 2.4\n"
+        "Name: lorekeep\n"
+        f"Version: {wheel_version}\n\n"
+    ).encode()
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(
+            f"lorekeep-{wheel_version}.dist-info/METADATA", wheel_metadata
+        )
+
+    sdist = dist / f"lorekeep-{sdist_version}.tar.gz"
+    sdist_metadata = (
+        "Metadata-Version: 2.4\n"
+        "Name: lorekeep\n"
+        f"Version: {sdist_version}\n\n"
+    ).encode()
+    with tarfile.open(sdist, "w:gz") as archive:
+        info = tarfile.TarInfo(f"lorekeep-{sdist_version}/PKG-INFO")
+        info.size = len(sdist_metadata)
+        archive.addfile(info, BytesIO(sdist_metadata))
+
+
+def test_matching_release_metadata_passes(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0
+    assert "release integrity OK: lorekeep 1.2.3" in result.stdout
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize(
+    ("field", "expected_file"),
+    [
+        ("manifest", ".release-please-manifest.json"),
+        ("module", "src/lorekeep/__init__.py"),
+        ("lock", "uv.lock"),
+        ("changelog", "CHANGELOG.md"),
+    ],
+)
+def test_mismatched_source_version_fails(
+    tmp_path: Path, field: str, expected_file: str
+) -> None:
+    kwargs = {field: "9.9.9"}
+    _write_repo(tmp_path, **kwargs)
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 1
+    assert expected_file in result.stderr
+    assert "expected version '1.2.3', found '9.9.9'" in result.stderr
+
+
+def test_non_semver_project_version_fails(tmp_path: Path) -> None:
+    _write_repo(
+        tmp_path,
+        manifest="next",
+        project="next",
+        module="next",
+        lock="next",
+        changelog="next",
+    )
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 1
+    assert "pyproject.toml version is not SemVer: 'next'" in result.stderr
+
+
+@pytest.mark.parametrize("lock_entries", [0, 2])
+def test_requires_exactly_one_editable_project_package(
+    tmp_path: Path, lock_entries: int
+) -> None:
+    _write_repo(tmp_path, lock_entries=lock_entries)
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 1
+    assert f"found {lock_entries}" in result.stderr
+    assert "exactly one editable 'lorekeep' package" in result.stderr
+
+
+def test_release_tag_must_match_source_version(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+
+    result = _run(tmp_path, "--tag", "v1.2.4")
+
+    assert result.returncode == 1
+    assert "release tag: expected 'v1.2.3', found 'v1.2.4'" in result.stderr
+
+
+def test_distribution_metadata_passes(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+    dist = tmp_path / "dist"
+    _write_artifacts(dist, wheel_version=VERSION, sdist_version=VERSION)
+
+    result = _run(tmp_path, "--tag", "v1.2.3", "--dist", str(dist))
+
+    assert result.returncode == 0
+
+
+def test_distribution_version_mismatch_fails(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+    dist = tmp_path / "dist"
+    _write_artifacts(dist, wheel_version="1.2.4", sdist_version=VERSION)
+
+    result = _run(tmp_path, "--dist", str(dist))
+
+    assert result.returncode == 1
+    assert "expected version '1.2.3', found '1.2.4'" in result.stderr
+
+
+def test_distribution_requires_one_wheel_and_sdist(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+    dist = tmp_path / "dist"
+    dist.mkdir()
+
+    result = _run(tmp_path, "--dist", str(dist))
+
+    assert result.returncode == 1
+    assert "exactly one wheel; found 0" in result.stderr
+    assert "exactly one sdist; found 0" in result.stderr
+
+
+def test_repository_release_metadata_is_consistent() -> None:
+    result = _run(REPO_ROOT)
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def _workflow(name: str) -> dict[str, object]:
+    data = yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def _run_commands(job: dict[str, object]) -> list[str]:
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    return [
+        step["run"]
+        for step in steps
+        if isinstance(step, dict) and isinstance(step.get("run"), str)
+    ]
+
+
+def test_release_please_updates_local_uv_lock_version() -> None:
+    config = json.loads(
+        (REPO_ROOT / "release-please-config.json").read_text(encoding="utf-8")
+    )
+
+    assert config["packages"]["."]["extra-files"] == [
+        {
+            "type": "toml",
+            "path": "uv.lock",
+            "jsonpath": "$.package[?(@.name=='lorekeep')].version",
+        }
+    ]
+
+
+def test_ci_never_repairs_the_committed_lockfile() -> None:
+    workflow = _workflow("ci.yml")
+    commands = _run_commands(workflow["jobs"]["test"])
+
+    assert "uv lock --check" in commands
+    assert "uv sync --locked" in commands
+    assert "uv run --locked python scripts/check-release-integrity.py" in commands
+    assert "uv run --locked pytest -q" in commands
+    assert "uv sync" not in commands
+
+
+def test_release_publish_is_atomic_and_has_no_follow_up_pr() -> None:
+    workflow = _workflow("release-please.yml")
+    jobs = workflow["jobs"]
+
+    assert "sync-uv-lock" not in jobs
+    assert workflow["concurrency"]["cancel-in-progress"] is False
+
+    release_steps = jobs["release-please"]["steps"]
+    release_action = next(step for step in release_steps if step.get("id") == "rp")
+    assert release_action["with"]["token"] == "${{ secrets.RELEASE_PLEASE_TOKEN }}"
+
+    commands = _run_commands(jobs["publish"])
+    source_check = next(i for i, command in enumerate(commands) if "uv lock --check" in command)
+    build = commands.index("uv build")
+    artifact_check = next(
+        i for i, command in enumerate(commands) if "--dist dist" in command
+    )
+    assert source_check < build < artifact_check
+
+
+def test_auto_merge_is_limited_to_trusted_release_please_prs() -> None:
+    path = WORKFLOWS / "auto-merge-release-please.yml"
+    content = path.read_text(encoding="utf-8")
+    workflow = _workflow(path.name)
+    condition = workflow["jobs"]["auto-merge"]["if"]
+
+    assert "release-please--" in condition
+    assert "head.repo.full_name == github.repository" in condition
+    assert "autorelease: pending" in condition
+    assert "types: [opened, synchronize, labeled]" in content
+    assert "gh pr merge --auto --merge" in content
+    assert "secrets.RELEASE_PLEASE_TOKEN ||" not in content


### PR DESCRIPTION
## Summary

- update the project entry in `uv.lock` inside the Release Please PR
- remove the post-release lockfile branch/PR workflow
- make CI fail instead of silently repairing stale lockfiles
- verify source versions, release tags, wheel metadata, and sdist metadata before publishing
- restrict Release Please auto-merge to trusted same-repository PRs with the pending-release label

## Root cause

Release Please updated the manifest, changelog, `pyproject.toml`, and package version, but `uv.lock` was repaired only after tagging. CI used plain `uv sync`, which could update the lockfile in the runner and hide the committed mismatch.

## Validation

- `uv lock --check`
- `17 passed` targeted release tests
- `628 passed` full test suite
- `26 passed` core regression suite
- built wheel and sdist; integrity guard passed for tag `v0.13.2`

Repository `allow_auto_merge` is enabled; merge-commit remains the only allowed merge strategy.