### PR TITLE
ci: sync uv.lock on release-please PRs

### DIFF
--- a/.github/workflows/sync-uv-lock.yml
+++ b/.github/workflows/sync-uv-lock.yml
@@ -1,0 +1,55 @@
+name: sync-uv-lock
+
+# Release-please bumps the version in pyproject.toml when it creates the Release
+# PR, but its TOML extra-files updater does not reliably update uv.lock (the
+# JSONPath filter on the [[package]] array is silently skipped). This workflow
+# regenerates uv.lock on the release-please branch so that CI's
+# `uv lock --check` passes.
+#
+# Flow:
+#   1. release-please opens/updates the Release PR (bumps pyproject.toml)
+#   2. this workflow runs `uv lock` and pushes the synced lockfile
+#   3. the push triggers a new CI run (synchronize event)
+#   4. CI passes on the new commit → auto-merge merges the Release PR
+#   5. release-please creates the tag + GitHub Release + publishes to PyPI
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-uv-lock-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  sync-lock:
+    if: startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.head_ref }}
+          # RELEASE_PLEASE_TOKEN (PAT) required: pushes with GITHUB_TOKEN
+          # don't trigger downstream workflow runs.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Regenerate uv.lock
+        run: uv lock
+
+      - name: Commit if lockfile changed
+        run: |
+          if git diff --quiet uv.lock; then
+            echo "uv.lock already in sync — nothing to do"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: sync uv.lock for release"
+          git push


### PR DESCRIPTION
## Summary

- add a workflow (`sync-uv-lock.yml`) that runs `uv lock` and pushes the synced lockfile whenever release-please opens or updates a Release PR

## Why

Release-please bumps the version in `pyproject.toml` when creating the Release PR, but its TOML extra-files updater does not reliably update `uv.lock` (the JSONPath filter on the `[[package]]` array is silently skipped). This leaves `uv.lock` stale, causing CI's `uv lock --check` to fail and blocking **every** release.

This was observed on Release PR #148 (v0.14.0): CI failed with `"The lockfile at uv.lock needs to be updated"`, blocking the release.

## How it works

1. release-please opens/updates the Release PR (bumps `pyproject.toml`)
2. this workflow runs `uv lock` and pushes the synced lockfile
3. the push triggers a new CI run (synchronize event)
4. CI passes on the new commit → auto-merge merges the Release PR
5. release-please creates the tag + GitHub Release + publishes to PyPI

Uses `concurrency` to avoid duplicate runs. Uses `RELEASE_PLEASE_TOKEN` (PAT) for pushes so the synchronize event triggers downstream workflows.

## Validation

- workflow file is syntactically valid YAML
- logic mirrors the existing `sync-uv-lock` job in `release-please.yml` (post-release) but runs **pre-merge** on the release-please branch