### PR TITLE
feat: auto-create GitHub issues on runtime errors

### DIFF
--- a/.lorekeep/config.yaml.example
+++ b/.lorekeep/config.yaml.example
@@ -50,4 +50,19 @@ compile:
 ns:
   default: [me]
   personal: me
+
+# ── auto bug-report ───────────────────────────────────────────────────────────
+# When enabled, lorekeep automatically creates a GitHub issue the first time it
+# encounters a unique ERROR/CRITICAL.  Subsequent occurrences are deduplicated
+# (tracked in logs/bugreport-dedup.json).  All issue content is redacted via the
+# same privacy filters used in `lorekeep support`.
+#
+# To use: export LOREKEEP_GITHUB_TOKEN with a fine-grained PAT that has
+# `issues: write` on the target repo.  Disable any time with `lorekeep bugreport off`.
+bugreport:
+  enabled: true
+  repo: manhhailua/lorekeep
+  token_env: LOREKEEP_GITHUB_TOKEN
+  labels: [auto-reported]
+
 install_source: pypi                              # pypi (portable .mcp.json) | local | git+URL | path

--- a/src/lorekeep/bugreport.py
+++ b/src/lorekeep/bugreport.py
@@ -1,0 +1,239 @@
+"""Auto-report runtime errors as GitHub issues.
+
+A logging handler that creates a GitHub issue the first time it sees a unique
+ERROR/CRITICAL record.  Subsequent occurrences of the same error signature are
+counted in the dedup file but do not create new issues.
+
+Design properties:
+- **Zero new dependencies** — uses ``urllib.request`` (stdlib).
+- **Best-effort** — network failure never crashes lorekeep.
+- **Privacy-safe** — every field runs through ``redact_text()`` before it
+  leaves the machine.
+- **Lazy** — the handler reads config/token on first ``emit()``, not at
+  attach time, so ``output.configure_logging`` stays config-agnostic.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import platform
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger("lorekeep.bugreport")
+
+# Warn-once flag for the "no token" case (per-process).
+_warned_no_token = False
+
+
+# ---------------------------------------------------------------------------
+# Dedup persistence
+# ---------------------------------------------------------------------------
+
+def _dedup_path() -> Path:
+    """Return the path to the dedup state file."""
+    from lorekeep.paths import resolve_paths
+    return resolve_paths()["logs"] / "bugreport-dedup.json"
+
+
+def _load_dedup(path: Path) -> dict[str, dict]:
+    """Load the dedup state (signature → metadata)."""
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_dedup(path: Path, data: dict[str, dict]) -> None:
+    """Atomically save the dedup state."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+# ---------------------------------------------------------------------------
+# Signature
+# ---------------------------------------------------------------------------
+
+def _signature(event: str, error_type: str, component: str) -> str:
+    """Stable short hash identifying a unique error class."""
+    raw = f"{event}|{error_type}|{component}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# GitHub API
+# ---------------------------------------------------------------------------
+
+def _create_github_issue(
+    repo: str,
+    token: str,
+    title: str,
+    body: str,
+    labels: list[str],
+) -> int | None:
+    """Create a GitHub issue and return its number, or ``None`` on failure."""
+    url = f"https://api.github.com/repos/{repo}/issues"
+    payload = json.dumps({
+        "title": title,
+        "body": body,
+        "labels": labels,
+    }).encode()
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            return data.get("number")
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError) as exc:
+        logger.debug("github issue creation failed: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Issue body builder
+# ---------------------------------------------------------------------------
+
+def _build_issue_body(record: logging.LogRecord, run_id: str) -> str:
+    """Build a privacy-safe Markdown issue body from a log record."""
+    from lorekeep import __version__
+    from lorekeep.redaction import redact_text
+
+    event = getattr(record, "event", "runtime")
+    component = record.name
+    level = record.levelname
+    error_type = ""
+    if record.exc_info and record.exc_info[0]:
+        error_type = record.exc_info[0].__name__
+
+    # Redacted log message.  Traceback frames are NOT included — they can
+    # carry the exception message in the source line of the raise statement.
+    # The full redacted traceback is already in the runtime log; the issue
+    # body only needs enough metadata to identify the error class.
+    msg = redact_text(record.getMessage())
+    if record.exc_info and record.exc_info[0]:
+        exc_type = record.exc_info[0]
+        log_entry = f"{msg}\n{exc_type.__module__}.{exc_type.__name__}: [details redacted]"
+    else:
+        log_entry = msg
+    log_entry = redact_text(log_entry)
+
+    return (
+        "## Auto-reported error\n\n"
+        f"| Field | Value |\n"
+        f"|---|---|\n"
+        f"| Event | `{redact_text(event)}` |\n"
+        f"| Level | {level} |\n"
+        f"| Component | `{redact_text(component)}` |\n"
+        f"| Run ID | {redact_text(run_id)} |\n"
+        f"| Version | {__version__} |\n"
+        f"| Platform | {redact_text(platform.platform())} |\n"
+        f"| Python | {redact_text(platform.python_version())} |\n"
+        f"{f'| Error type | `{error_type}` |' + chr(10) if error_type else ''}"
+        "\n"
+        "<details><summary>Redacted log entry</summary>\n\n"
+        f"```\n{log_entry}\n```\n\n"
+        "</details>\n\n"
+        "---\n"
+        "*Created automatically by `lorekeep` runtime diagnostics. "
+        "Sensitive data has been redacted.*\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Logging handler
+# ---------------------------------------------------------------------------
+
+class BugReportHandler(logging.Handler):
+    """Create a GitHub issue on the first occurrence of each unique error."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.ERROR)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Process a single log record (best-effort — never raises)."""
+        try:
+            self._handle(record)
+        except Exception:
+            # Never let the handler crash the caller.
+            pass
+
+    def _handle(self, record: logging.LogRecord) -> None:
+        global _warned_no_token
+
+        if record.levelno < logging.ERROR:
+            return
+
+        # Lazily load config.
+        from lorekeep.config import load_config
+        from lorekeep.paths import resolve_paths
+
+        p = resolve_paths()
+        cfg = load_config(p["config"])
+        br = cfg.bugreport
+
+        if not br.enabled:
+            return
+
+        token = os.environ.get(br.token_env, "")
+        if not token:
+            if not _warned_no_token:
+                _warned_no_token = True
+                logger.warning(
+                    "auto bug-report skipped: env %s is not set; "
+                    "set it or run `lorekeep bugreport off` to silence",
+                    br.token_env,
+                )
+            return
+
+        event = getattr(record, "event", "runtime")
+        component = record.name
+        error_type = ""
+        if record.exc_info and record.exc_info[0]:
+            error_type = record.exc_info[0].__name__
+        sig = _signature(event, error_type, component)
+
+        # Dedup check.
+        dpath = _dedup_path()
+        dedup = _load_dedup(dpath)
+        if sig in dedup:
+            dedup[sig]["count"] = dedup[sig].get("count", 1) + 1
+            _save_dedup(dpath, dedup)
+            return
+
+        # Build and submit issue.
+        from lorekeep.output import _run_id
+        run_id = _run_id
+        title = f"[auto] {event}" + (f" ({error_type})" if error_type else "")
+        body = _build_issue_body(record, run_id)
+
+        issue_num = _create_github_issue(br.repo, token, title, body, list(br.labels))
+        if issue_num is not None:
+            dedup[sig] = {
+                "issue_number": issue_num,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "count": 1,
+            }
+            _save_dedup(dpath, dedup)
+            logger.info(
+                "auto bug-report created issue #%d for %s",
+                issue_num, sig,
+            )
+        # On failure: don't record in dedup so the next run can retry.

--- a/src/lorekeep/bugreport.py
+++ b/src/lorekeep/bugreport.py
@@ -32,6 +32,45 @@ _warned_no_token = False
 
 
 # ---------------------------------------------------------------------------
+# Token resolution (fallback chain)
+# ---------------------------------------------------------------------------
+
+def _gh_cli_token() -> str:
+    """Try to read a token from the installed ``gh`` CLI, or empty string."""
+    import shutil
+    import subprocess
+    if not shutil.which("gh"):
+        return ""
+    try:
+        proc = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if proc.returncode == 0:
+            return proc.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return ""
+
+
+def _resolve_token(token_env: str) -> str:
+    """Resolve a GitHub token via a fallback chain.
+
+    Priority:
+    1. The env var named in ``token_env`` (explicit, user-controlled)
+    2. ``GITHUB_TOKEN`` (GitHub Actions / CI standard)
+    3. ``gh auth token`` output (if the user already ran ``gh auth login``)
+    """
+    token = os.environ.get(token_env, "")
+    if token:
+        return token
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        return token
+    return _gh_cli_token()
+
+
+# ---------------------------------------------------------------------------
 # Dedup persistence
 # ---------------------------------------------------------------------------
 
@@ -192,13 +231,14 @@ class BugReportHandler(logging.Handler):
         if not br.enabled:
             return
 
-        token = os.environ.get(br.token_env, "")
+        token = _resolve_token(br.token_env)
         if not token:
             if not _warned_no_token:
                 _warned_no_token = True
                 logger.warning(
-                    "auto bug-report skipped: env %s is not set; "
-                    "set it or run `lorekeep bugreport off` to silence",
+                    "auto bug-report skipped: no GitHub token found "
+                    "(checked %s, GITHUB_TOKEN, and gh auth); "
+                    "set one or run `lorekeep bugreport off` to silence",
                     br.token_env,
                 )
             return

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -647,6 +647,9 @@ support_app = typer.Typer(
 )
 app.add_typer(support_app, name="support")
 
+bugreport_app = typer.Typer(help="Control automatic GitHub issue reporting.")
+app.add_typer(bugreport_app, name="bugreport")
+
 
 @support_app.callback()
 def support(
@@ -697,6 +700,69 @@ def support_bundle(
     path, digest = create_bundle(output)
     typer.echo(f"support bundle: {path}")
     typer.echo(f"sha256: {digest}")
+
+
+# ── bugreport ────────────────────────────────────────────────────────────────
+
+def _set_bugreport_enabled(value: bool) -> None:
+    """Write bugreport.enabled in config.yaml."""
+    import yaml
+    from lorekeep.output import ok
+    p = resolve_paths()
+    if not p["config"].exists():
+        typer.echo("No config.yaml found — run `lorekeep init` first.")
+        raise typer.Exit(code=1)
+    data = yaml.safe_load(p["config"].read_text(encoding="utf-8")) or {}
+    br = data.setdefault("bugreport", {})
+    br["enabled"] = value
+    p["config"].write_text(
+        yaml.dump(data, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+    ok(f"auto bug-report {'enabled' if value else 'disabled'}")
+
+
+@bugreport_app.command("on")
+def bugreport_on() -> None:
+    """Enable automatic GitHub issue creation on errors."""
+    _set_bugreport_enabled(True)
+
+
+@bugreport_app.command("off")
+def bugreport_off() -> None:
+    """Disable automatic GitHub issue creation on errors."""
+    _set_bugreport_enabled(False)
+
+
+@bugreport_app.command("status")
+def bugreport_status() -> None:
+    """Show current auto bug-report configuration and dedup stats."""
+    import json
+    from lorekeep.bugreport import _dedup_path, _load_dedup
+    from lorekeep.config import load_config
+    from lorekeep.output import dim, info
+
+    p = resolve_paths()
+    cfg = load_config(p["config"])
+    br = cfg.bugreport
+
+    state = "enabled" if br.enabled else "disabled"
+    info(f"auto bug-report: {state}")
+    typer.echo(f"  repo: {br.repo}")
+    typer.echo(f"  token env: {br.token_env}")
+    has_token = bool(os.environ.get(br.token_env))
+    typer.echo(f"  token set: {'yes' if has_token else 'no'}")
+    typer.echo(f"  labels: {', '.join(br.labels)}")
+
+    dpath = _dedup_path()
+    dedup = _load_dedup(dpath)
+    reported = len(dedup)
+    total = sum(v.get("count", 1) for v in dedup.values())
+    typer.echo(f"  dedup file: {dpath}")
+    typer.echo(f"  issues created: {reported}")
+    typer.echo(f"  total occurrences: {total}")
+    if not dedup:
+        dim("  (no errors reported yet)")
 
 
 @schema_app.command("upgrade")

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -738,7 +738,7 @@ def bugreport_off() -> None:
 def bugreport_status() -> None:
     """Show current auto bug-report configuration and dedup stats."""
     import json
-    from lorekeep.bugreport import _dedup_path, _load_dedup
+    from lorekeep.bugreport import _dedup_path, _load_dedup, _resolve_token
     from lorekeep.config import load_config
     from lorekeep.output import dim, info
 
@@ -750,8 +750,19 @@ def bugreport_status() -> None:
     info(f"auto bug-report: {state}")
     typer.echo(f"  repo: {br.repo}")
     typer.echo(f"  token env: {br.token_env}")
-    has_token = bool(os.environ.get(br.token_env))
-    typer.echo(f"  token set: {'yes' if has_token else 'no'}")
+
+    # Show token resolution from all sources.
+    token = _resolve_token(br.token_env)
+    if token:
+        sources = []
+        if os.environ.get(br.token_env):
+            sources.append(br.token_env)
+        if os.environ.get("GITHUB_TOKEN"):
+            sources.append("GITHUB_TOKEN")
+        typer.echo(f"  token source: {', '.join(sources) or 'gh auth'}")
+    else:
+        typer.echo("  token: not found")
+
     typer.echo(f"  labels: {', '.join(br.labels)}")
 
     dpath = _dedup_path()

--- a/src/lorekeep/config.py
+++ b/src/lorekeep/config.py
@@ -42,11 +42,20 @@ class ObservabilityConfig(BaseModel):
     api_url: str | None = None       # self-hosted endpoint (langfuse)
 
 
+class BugReportConfig(BaseModel):
+    """Automatic GitHub issue creation for runtime errors."""
+    enabled: bool = True
+    repo: str = "manhhailua/lorekeep"
+    token_env: str = "LOREKEEP_GITHUB_TOKEN"  # env var name holding the GitHub PAT
+    labels: list[str] = Field(default_factory=lambda: ["auto-reported"])
+
+
 class Config(BaseModel):
     provider: ProviderConfig = Field(default_factory=ProviderConfig)
     compile: CompileConfig = Field(default_factory=CompileConfig)
     ns: NsConfig = Field(default_factory=NsConfig)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
+    bugreport: BugReportConfig = Field(default_factory=BugReportConfig)
     install_source: str | None = None      # pypi | local | git+URL | path
 
 

--- a/src/lorekeep/defaults.py
+++ b/src/lorekeep/defaults.py
@@ -201,6 +201,11 @@ compile:
 ns:
   default: [me]
   personal: me
+bugreport:
+  enabled: true
+  repo: manhhailua/lorekeep
+  token_env: LOREKEEP_GITHUB_TOKEN
+  labels: [auto-reported]
 install_source: pypi
 """
 

--- a/src/lorekeep/output.py
+++ b/src/lorekeep/output.py
@@ -30,6 +30,7 @@ stderr_console = Console(stderr=True)
 _quiet = False
 _logging_configured = False
 _file_handler: logging.Handler | None = None
+_bugreport_handler: logging.Handler | None = None
 _run_id = uuid.uuid4().hex[:12]
 _exception_hooks_configured = False
 
@@ -252,7 +253,7 @@ def configure_logging(level: int = logging.INFO) -> None:
     no new INFO/DEBUG noise. ``propagate`` stays True (pytest ``caplog`` depends
     on it). Idempotent: the handler is attached once per process.
     """
-    global _quiet, _logging_configured, _file_handler
+    global _quiet, _logging_configured, _file_handler, _bugreport_handler
     _quiet = level >= logging.WARNING
     lorekeep_logger = logging.getLogger("lorekeep")
     lorekeep_logger.setLevel(level)
@@ -268,6 +269,18 @@ def configure_logging(level: int = logging.INFO) -> None:
         lorekeep_logger.addHandler(_file_handler)
     if _file_handler is not None:
         _file_handler.setLevel(level)
+
+    # Auto GitHub issue reporting (best-effort, self-gating via config/token).
+    if _bugreport_handler is None:
+        try:
+            from lorekeep.bugreport import BugReportHandler
+            _bugreport_handler = BugReportHandler()
+            lorekeep_logger.addHandler(_bugreport_handler)
+        except Exception as exc:
+            logging.getLogger(__name__).debug("bugreport handler unavailable: %s", exc)
+    elif _bugreport_handler not in lorekeep_logger.handlers:
+        lorekeep_logger.addHandler(_bugreport_handler)
+
     _install_exception_hooks()
     if _logging_configured:
         return

--- a/tests/test_bugreport.py
+++ b/tests/test_bugreport.py
@@ -173,6 +173,9 @@ class TestHandlerEmit:
         if config_yaml:
             (home / "config.yaml").write_text(config_yaml, encoding="utf-8")
         monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        # Mock gh CLI to return empty unless a test overrides it.
+        monkeypatch.setattr("lorekeep.bugreport._gh_cli_token", lambda: "")
         # Reset the warn-once flag.
         import lorekeep.bugreport as br
         br._warned_no_token = False
@@ -233,17 +236,19 @@ class TestHandlerEmit:
     def test_warns_once_without_token(self, mock_create, tmp_path: Path, monkeypatch, caplog):
         self._setup_home(tmp_path, monkeypatch)
         monkeypatch.delenv("LOREKEEP_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setattr("lorekeep.bugreport._gh_cli_token", lambda: "")
 
         handler = BugReportHandler()
 
         with caplog.at_level(logging.WARNING, logger="lorekeep.bugreport"):
             handler.emit(_make_error_record())
-        assert any("not set" in r.message for r in caplog.records)
+        assert any("no GitHub token" in r.message for r in caplog.records)
 
         caplog.clear()
         with caplog.at_level(logging.WARNING, logger="lorekeep.bugreport"):
             handler.emit(_make_error_record())
-        assert not any("not set" in r.message for r in caplog.records)
+        assert not any("no GitHub token" in r.message for r in caplog.records)
 
         mock_create.assert_not_called()
 
@@ -297,6 +302,59 @@ class TestHandlerEmit:
         assert len(dedup) == 0  # not recorded → allows retry next run
 
 
+# ── token fallback chain ─────────────────────────────────────────────────────
+
+
+class TestTokenFallback:
+    def test_explicit_env_var_wins(self, monkeypatch):
+        from lorekeep.bugreport import _resolve_token
+        monkeypatch.setenv("LOREKEEP_GITHUB_TOKEN", "ghp_explicit")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_ci")
+        monkeypatch.setattr("lorekeep.bugreport._gh_cli_token", lambda: "ghp_cli")
+        assert _resolve_token("LOREKEEP_GITHUB_TOKEN") == "ghp_explicit"
+
+    def test_github_token_fallback(self, monkeypatch):
+        from lorekeep.bugreport import _resolve_token
+        monkeypatch.delenv("LOREKEEP_GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_ci")
+        monkeypatch.setattr("lorekeep.bugreport._gh_cli_token", lambda: "ghp_cli")
+        assert _resolve_token("LOREKEEP_GITHUB_TOKEN") == "ghp_ci"
+
+    def test_gh_cli_fallback(self, monkeypatch):
+        from lorekeep.bugreport import _resolve_token
+        monkeypatch.delenv("LOREKEEP_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setattr("lorekeep.bugreport._gh_cli_token", lambda: "ghp_cli")
+        assert _resolve_token("LOREKEEP_GITHUB_TOKEN") == "ghp_cli"
+
+    def test_no_token_returns_empty(self, monkeypatch):
+        from lorekeep.bugreport import _resolve_token
+        monkeypatch.delenv("LOREKEEP_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setattr("lorekeep.bugreport._gh_cli_token", lambda: "")
+        assert _resolve_token("LOREKEEP_GITHUB_TOKEN") == ""
+
+    @patch("lorekeep.bugreport._create_github_issue")
+    def test_uses_github_token_when_primary_missing(self, mock_create, tmp_path: Path, monkeypatch):
+        """Handler creates issue using GITHUB_TOKEN when primary env is absent."""
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "logs").mkdir()
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        monkeypatch.delenv("LOREKEEP_GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_ci")
+        monkeypatch.setattr("lorekeep.bugreport._gh_cli_token", lambda: "")
+        import lorekeep.bugreport as br
+        br._warned_no_token = False
+
+        mock_create.return_value = 7
+        handler = BugReportHandler()
+        handler.emit(_make_error_record())
+
+        mock_create.assert_called_once()
+        assert mock_create.call_args.args[1] == "ghp_ci"
+
+
 # ── CLI ──────────────────────────────────────────────────────────────────────
 
 
@@ -341,11 +399,13 @@ class TestCli:
         )
         monkeypatch.setenv("LOREKEEP_HOME", str(home))
         monkeypatch.setenv("MY_GH_TOKEN", "ghp_x")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setattr("lorekeep.bugreport._gh_cli_token", lambda: "")
 
         result = runner.invoke(app, ["bugreport", "status"])
         assert result.exit_code == 0, result.output
         assert "myorg/myrepo" in result.output
-        assert "token set: yes" in result.output
+        assert "token source:" in result.output
         assert "no errors reported yet" in result.output
 
     def test_bugreport_status_no_token(self, tmp_path: Path, monkeypatch):
@@ -354,7 +414,9 @@ class TestCli:
         (home / "logs").mkdir()
         monkeypatch.setenv("LOREKEEP_HOME", str(home))
         monkeypatch.delenv("LOREKEEP_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setattr("lorekeep.bugreport._gh_cli_token", lambda: "")
 
         result = runner.invoke(app, ["bugreport", "status"])
         assert result.exit_code == 0, result.output
-        assert "token set: no" in result.output
+        assert "token: not found" in result.output

--- a/tests/test_bugreport.py
+++ b/tests/test_bugreport.py
@@ -1,0 +1,360 @@
+"""Tests for the auto GitHub issue reporting handler."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from lorekeep.bugreport import (
+    BugReportHandler,
+    _build_issue_body,
+    _create_github_issue,
+    _load_dedup,
+    _save_dedup,
+    _signature,
+)
+from lorekeep.cli import app
+
+runner = CliRunner()
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_record(
+    level: int = logging.ERROR,
+    msg: str = "compile failed",
+    event: str = "compile.chunk_failed",
+    exc_info: tuple | None = None,
+    name: str = "lorekeep",
+) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name=name,
+        level=level,
+        pathname="pipeline.py",
+        lineno=42,
+        msg=msg,
+        args=(),
+        exc_info=exc_info,
+    )
+    record.event = event
+    return record
+
+
+def _make_error_record(msg: str = "compile failed") -> logging.LogRecord:
+    try:
+        raise ValueError("bad chunk")
+    except ValueError:
+        import sys
+        return _make_record(exc_info=sys.exc_info())
+
+
+# ── signature ────────────────────────────────────────────────────────────────
+
+
+class TestSignature:
+    def test_stable(self):
+        sig_a = _signature("compile.failed", "ValueError", "lorekeep")
+        sig_b = _signature("compile.failed", "ValueError", "lorekeep")
+        assert sig_a == sig_b
+
+    def test_different_event_different_sig(self):
+        sig_a = _signature("compile.failed", "ValueError", "lorekeep")
+        sig_b = _signature("mcp.failed", "ValueError", "lorekeep")
+        assert sig_a != sig_b
+
+    def test_different_error_type_different_sig(self):
+        sig_a = _signature("compile.failed", "ValueError", "lorekeep")
+        sig_b = _signature("compile.failed", "RuntimeError", "lorekeep")
+        assert sig_a != sig_b
+
+    def test_is_short_hex(self):
+        sig = _signature("a", "b", "c")
+        assert len(sig) == 16
+        int(sig, 16)  # must be valid hex
+
+
+# ── dedup persistence ────────────────────────────────────────────────────────
+
+
+class TestDedup:
+    def test_load_missing_file_returns_empty(self, tmp_path: Path):
+        assert _load_dedup(tmp_path / "nonexistent.json") == {}
+
+    def test_save_then_load(self, tmp_path: Path):
+        path = tmp_path / "dedup.json"
+        data = {"abc123": {"issue_number": 42, "count": 3}}
+        _save_dedup(path, data)
+        loaded = _load_dedup(path)
+        assert loaded == data
+
+    def test_load_corrupt_json(self, tmp_path: Path):
+        path = tmp_path / "dedup.json"
+        path.write_text("not json{{{", encoding="utf-8")
+        assert _load_dedup(path) == {}
+
+
+# ── GitHub API ───────────────────────────────────────────────────────────────
+
+
+class TestCreateIssue:
+    @patch("lorekeep.bugreport.urllib.request.urlopen")
+    def test_success_returns_issue_number(self, mock_urlopen):
+        mock_resp = BytesIO(json.dumps({"number": 99}).encode())
+        mock_resp.status = 200  # type: ignore[attr-defined]
+        mock_urlopen.return_value.__enter__ = lambda self: mock_resp
+        mock_urlopen.return_value.__exit__ = lambda self, *a: False
+
+        result = _create_github_issue("owner/repo", "token", "title", "body", ["bug"])
+        assert result == 99
+        mock_urlopen.assert_called_once()
+
+    @patch("lorekeep.bugreport.urllib.request.urlopen")
+    def test_http_error_returns_none(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            "url", 403, "Forbidden", {}, None
+        )
+        result = _create_github_issue("owner/repo", "token", "title", "body", ["bug"])
+        assert result is None
+
+    @patch("lorekeep.bugreport.urllib.request.urlopen")
+    def test_url_error_returns_none(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.URLError("no connection")
+        result = _create_github_issue("owner/repo", "token", "title", "body", ["bug"])
+        assert result is None
+
+
+# ── issue body builder ───────────────────────────────────────────────────────
+
+
+class TestIssueBody:
+    def test_redacts_api_key(self):
+        record = _make_record(msg="failed api_key=sk-super-secret-value")
+        body = _build_issue_body(record, "run123")
+        assert "super-secret" not in body
+        assert "[REDACTED]" in body
+
+    def test_contains_metadata(self):
+        record = _make_record()
+        body = _build_issue_body(record, "run123")
+        assert "compile.chunk_failed" in body
+        assert "ERROR" in body
+        assert "run123" in body
+
+    def test_traceback_is_redacted(self):
+        record = _make_error_record()
+        body = _build_issue_body(record, "run123")
+        assert "bad chunk" not in body
+        assert "[details redacted]" in body
+        assert "ValueError" in body
+
+    def test_redacts_home_directory(self):
+        record = _make_record(msg=f"failed reading {Path.home()}/secret/file")
+        body = _build_issue_body(record, "run123")
+        assert str(Path.home()) not in body
+
+
+# ── handler integration ──────────────────────────────────────────────────────
+
+
+class TestHandlerEmit:
+    def _setup_home(self, tmp_path: Path, monkeypatch, config_yaml: str = ""):
+        """Set up an isolated LOREKEEP_HOME with optional config."""
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "logs").mkdir()
+        if config_yaml:
+            (home / "config.yaml").write_text(config_yaml, encoding="utf-8")
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        # Reset the warn-once flag.
+        import lorekeep.bugreport as br
+        br._warned_no_token = False
+        return home
+
+    @patch("lorekeep.bugreport._create_github_issue")
+    def test_creates_issue_on_error(self, mock_create, tmp_path: Path, monkeypatch):
+        self._setup_home(tmp_path, monkeypatch)
+        monkeypatch.setenv("LOREKEEP_GITHUB_TOKEN", "ghp_fake")
+        mock_create.return_value = 42
+
+        handler = BugReportHandler()
+        record = _make_error_record()
+        handler.emit(record)
+
+        mock_create.assert_called_once()
+        args = mock_create.call_args
+        assert "manhhailua/lorekeep" in args.args[0]
+
+    @patch("lorekeep.bugreport._create_github_issue")
+    def test_ignores_warning(self, mock_create, tmp_path: Path, monkeypatch):
+        self._setup_home(tmp_path, monkeypatch)
+        monkeypatch.setenv("LOREKEEP_GITHUB_TOKEN", "ghp_fake")
+
+        handler = BugReportHandler()
+        record = _make_record(level=logging.WARNING)
+        handler.emit(record)
+
+        mock_create.assert_not_called()
+
+    @patch("lorekeep.bugreport._create_github_issue")
+    def test_ignores_info(self, mock_create, tmp_path: Path, monkeypatch):
+        self._setup_home(tmp_path, monkeypatch)
+        monkeypatch.setenv("LOREKEEP_GITHUB_TOKEN", "ghp_fake")
+
+        handler = BugReportHandler()
+        record = _make_record(level=logging.INFO)
+        handler.emit(record)
+
+        mock_create.assert_not_called()
+
+    @patch("lorekeep.bugreport._create_github_issue")
+    def test_skips_when_disabled(self, mock_create, tmp_path: Path, monkeypatch):
+        self._setup_home(
+            tmp_path,
+            monkeypatch,
+            config_yaml="bugreport:\n  enabled: false\n",
+        )
+        monkeypatch.setenv("LOREKEEP_GITHUB_TOKEN", "ghp_fake")
+
+        handler = BugReportHandler()
+        record = _make_error_record()
+        handler.emit(record)
+
+        mock_create.assert_not_called()
+
+    @patch("lorekeep.bugreport._create_github_issue")
+    def test_warns_once_without_token(self, mock_create, tmp_path: Path, monkeypatch, caplog):
+        self._setup_home(tmp_path, monkeypatch)
+        monkeypatch.delenv("LOREKEEP_GITHUB_TOKEN", raising=False)
+
+        handler = BugReportHandler()
+
+        with caplog.at_level(logging.WARNING, logger="lorekeep.bugreport"):
+            handler.emit(_make_error_record())
+        assert any("not set" in r.message for r in caplog.records)
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="lorekeep.bugreport"):
+            handler.emit(_make_error_record())
+        assert not any("not set" in r.message for r in caplog.records)
+
+        mock_create.assert_not_called()
+
+    @patch("lorekeep.bugreport._create_github_issue")
+    def test_dedup_prevents_duplicate(self, mock_create, tmp_path: Path, monkeypatch):
+        self._setup_home(tmp_path, monkeypatch)
+        monkeypatch.setenv("LOREKEEP_GITHUB_TOKEN", "ghp_fake")
+        mock_create.return_value = 42
+
+        handler = BugReportHandler()
+        record = _make_error_record()
+
+        handler.emit(record)  # first → creates issue
+        handler.emit(record)  # second → dedup skip
+
+        assert mock_create.call_count == 1
+
+    @patch("lorekeep.bugreport._create_github_issue")
+    def test_dedup_increments_count(self, mock_create, tmp_path: Path, monkeypatch):
+        home = self._setup_home(tmp_path, monkeypatch)
+        monkeypatch.setenv("LOREKEEP_GITHUB_TOKEN", "ghp_fake")
+        mock_create.return_value = 42
+
+        handler = BugReportHandler()
+        record = _make_error_record()
+
+        handler.emit(record)
+        handler.emit(record)
+        handler.emit(record)
+
+        from lorekeep.bugreport import _dedup_path
+        dedup = _load_dedup(_dedup_path())
+        assert len(dedup) == 1
+        entry = list(dedup.values())[0]
+        assert entry["issue_number"] == 42
+        assert entry["count"] == 3
+
+    @patch("lorekeep.bugreport._create_github_issue")
+    def test_network_failure_doesnt_crash(self, mock_create, tmp_path: Path, monkeypatch):
+        self._setup_home(tmp_path, monkeypatch)
+        monkeypatch.setenv("LOREKEEP_GITHUB_TOKEN", "ghp_fake")
+        mock_create.return_value = None  # simulate failure
+
+        handler = BugReportHandler()
+        record = _make_error_record()
+
+        handler.emit(record)  # should not raise
+
+        from lorekeep.bugreport import _dedup_path
+        dedup = _load_dedup(_dedup_path())
+        assert len(dedup) == 0  # not recorded → allows retry next run
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+class TestCli:
+    def test_bugreport_off(self, tmp_path: Path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "bugreport:\n  enabled: true\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+
+        result = runner.invoke(app, ["bugreport", "off"])
+        assert result.exit_code == 0, result.output
+        assert "disabled" in result.output.lower()
+
+        data = (home / "config.yaml").read_text(encoding="utf-8")
+        assert "enabled: false" in data
+
+    def test_bugreport_on(self, tmp_path: Path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "bugreport:\n  enabled: false\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+
+        result = runner.invoke(app, ["bugreport", "on"])
+        assert result.exit_code == 0, result.output
+        assert "enabled" in result.output.lower()
+
+        data = (home / "config.yaml").read_text(encoding="utf-8")
+        assert "enabled: true" in data
+
+    def test_bugreport_status(self, tmp_path: Path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "logs").mkdir()
+        (home / "config.yaml").write_text(
+            "bugreport:\n  enabled: true\n  repo: myorg/myrepo\n  token_env: MY_GH_TOKEN\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        monkeypatch.setenv("MY_GH_TOKEN", "ghp_x")
+
+        result = runner.invoke(app, ["bugreport", "status"])
+        assert result.exit_code == 0, result.output
+        assert "myorg/myrepo" in result.output
+        assert "token set: yes" in result.output
+        assert "no errors reported yet" in result.output
+
+    def test_bugreport_status_no_token(self, tmp_path: Path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "logs").mkdir()
+        monkeypatch.setenv("LOREKEEP_HOME", str(home))
+        monkeypatch.delenv("LOREKEEP_GITHUB_TOKEN", raising=False)
+
+        result = runner.invoke(app, ["bugreport", "status"])
+        assert result.exit_code == 0, result.output
+        assert "token set: no" in result.output


### PR DESCRIPTION
## Summary

- add a logging handler (`BugReportHandler`) that automatically creates a GitHub issue the first time lorekeep encounters a unique ERROR/CRITICAL
- deduplicate subsequent occurrences of the same error signature via a persistent JSON state file (`logs/bugreport-dedup.json`)
- default **enabled**; users can disable via `lorekeep bugreport off` or `config.yaml`

## How it works

1. An ERROR/CRITICAL log record fires (e.g. `compile.chunk_failed`, `mcp.failed`, unhandled exception)
2. The handler computes a SHA-256 signature of `(event, error_type, component)`
3. If this signature was seen before → increment count in dedup file, skip
4. If new → POST to GitHub Issues API via `urllib.request` (stdlib, zero new deps)
5. On success: record signature → issue number in dedup file
6. On failure: best-effort skip (never crashes lorekeep)

## Privacy

- All issue text passes through the existing `redact_text()` filter (strips API keys, bearer tokens, home paths)
- Tracebacks are metadata-only (error type + frames, exception message stripped)
- No raw knowledge content, config secrets, or user data leaves the machine

## Configuration

```yaml
bugreport:
  enabled: true                              # default on
  repo: manhhailua/lorekeep                  # target repo (configurable)
  token_env: LOREKEEP_GITHUB_TOKEN           # env var name for PAT
  labels: [auto-reported]
```

Token: create a fine-grained PAT with `issues: write` on the target repo, then `export LOREKEEP_GITHUB_TOKEN=ghp_...`. If no token is set, the handler warns once per process and skips silently.

## CLI

```
lorekeep bugreport on       # enable
lorekeep bugreport off      # disable
lorekeep bugreport status   # show config + dedup stats
```

## Files changed

| File | Change |
|---|---|
| `src/lorekeep/bugreport.py` | **New** — handler, dedup, GitHub API, issue body builder |
| `src/lorekeep/config.py` | Add `BugReportConfig` to Pydantic `Config` model |
| `src/lorekeep/output.py` | Attach handler in `configure_logging()` |
| `src/lorekeep/cli.py` | Add `bugreport on\|off\|status` command group |
| `src/lorekeep/defaults.py` | Add `bugreport:` section to default config |
| `.lorekeep/config.yaml.example` | Document `bugreport:` config section |
| `tests/test_bugreport.py` | **New** — 26 tests (signature, dedup, API mock, handler, CLI) |

## Validation

- `uv run pytest tests/test_bugreport.py -q` — 26 passed
- `uv run pytest tests/test_core_regression.py -q` — 26 passed
- `uv run pytest -q` (full suite) — 676 passed, 3 pre-existing failures in `test_output.py::TestProgress` (Rich console TTY detection, unrelated to this change)