### PR TITLE
fix: deduplicate changelog entries from merge commits

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
       "release-type": "python",
       "include-v-in-tag": true,
       "bump-minor-pre-major": true,
+      "changelog-type": "github",
       "extra-files": [
         {
           "type": "toml",


### PR DESCRIPTION
## Problem

Every single-commit PR merged via merge-commit policy produced **duplicate entries** in `CHANGELOG.md`. This affected 5 consecutive releases:

| Release | Duplicate entry |
|---|---|
| v0.13.1 | `preserve facts in wiki projection` (×2) |
| v0.13.2 | `preserve Obsidian vault and harden compile` (×2) |
| v0.14.0 | `add privacy-safe runtime diagnostics` (×2) |
| v0.15.0 | `generate human-readable knowledge wiki` (×2) |
| v0.16.0 | `auto-create GitHub issues on runtime errors` (×2) |

## Root cause

With merge-commit policy, release-please (in default changelog mode) processes **both**:

1. The merge commit → resolves to PR title → `"fix: preserve facts in wiki projection"`
2. The underlying feature commit → `"fix: preserve facts in wiki projection"`

→ Same message, different commit hash → **duplicate in CHANGELOG**.

PRs with **multiple commits** were unaffected because the PR title differs from individual commit messages.

## Fix

Add `"changelog-type": "github"` to `release-please-config.json`. This mode groups commits by **PR** instead of listing each commit individually, so the merge commit and its content are counted once.

## Validation

One-line config change. The next release will confirm dedup — existing CHANGELOG entries are not retroactively rewritten.