### PR TITLE
fix: update changelog version regex for github changelog-type

### DIFF
--- a/scripts/check-release-integrity.py
+++ b/scripts/check-release-integrity.py
@@ -20,7 +20,7 @@ SEMVER_RE = re.compile(
     r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
     r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
 )
-CHANGELOG_VERSION_RE = re.compile(r"^## \[([^]]+)]", re.MULTILINE)
+CHANGELOG_VERSION_RE = re.compile(r"^## \[?([^\s\]]+)", re.MULTILINE)
 
 
 class IntegrityError(Exception):


### PR DESCRIPTION
## Problem

PR #155 added `changelog-type: "github"` to fix duplicate CHANGELOG entries. However, the github changelog-type produces headings in a different format:

```
## 0.16.1 (2026-08-05)        ← github type
## [0.16.1](url) (2026-08-05)  ← default type (old)
```

The regex in `check-release-integrity.py` required square brackets (`## [version]`), so it failed to match the new format. It fell through to the previous version heading (0.16.0), causing CI failure on Release PR #156.

## Fix

Update regex from `^## \[([^]]+)]` to `^## \[?([0-9]+\.[0-9]+\.[0-9]+)` — matches both formats.

## Note

`changelog-type: "github"` is confirmed working — Release PR #156 has only a single entry (no duplicate).