### PR TITLE
refactor!: merge bugreport commands into support group

### DIFF
--- a/.lorekeep/config.yaml.example
+++ b/.lorekeep/config.yaml.example
@@ -51,14 +51,14 @@ ns:
   default: [me]
   personal: me
 
-# ── auto bug-report ───────────────────────────────────────────────────────────
+# ── auto error reporting ─────────────────────────────────────────────────────
 # When enabled, lorekeep automatically creates a GitHub issue the first time it
 # encounters a unique ERROR/CRITICAL.  Subsequent occurrences are deduplicated
 # (tracked in logs/bugreport-dedup.json).  All issue content is redacted via the
 # same privacy filters used in `lorekeep support`.
 #
 # To use: export LOREKEEP_GITHUB_TOKEN with a fine-grained PAT that has
-# `issues: write` on the target repo.  Disable any time with `lorekeep bugreport off`.
+# `issues: write` on the target repo.  Control with `lorekeep support on/off`.
 bugreport:
   enabled: true
   repo: manhhailua/lorekeep

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -641,14 +641,11 @@ app.add_typer(config_app, name="config")
 schema_app = typer.Typer(help="Inspect and upgrade the graph schema.")
 app.add_typer(schema_app, name="schema")
 support_app = typer.Typer(
-    help="Create privacy-safe diagnostics for bug reports.",
+    help="Diagnostics and automatic error reporting.",
     invoke_without_command=True,
     no_args_is_help=False,
 )
 app.add_typer(support_app, name="support")
-
-bugreport_app = typer.Typer(help="Control automatic GitHub issue reporting.")
-app.add_typer(bugreport_app, name="bugreport")
 
 
 @support_app.callback()
@@ -702,7 +699,7 @@ def support_bundle(
     typer.echo(f"sha256: {digest}")
 
 
-# ── bugreport ────────────────────────────────────────────────────────────────
+# ── support auto-reporting (merged from bugreport) ───────────────────────────
 
 def _set_bugreport_enabled(value: bool) -> None:
     """Write bugreport.enabled in config.yaml."""
@@ -722,21 +719,21 @@ def _set_bugreport_enabled(value: bool) -> None:
     ok(f"auto bug-report {'enabled' if value else 'disabled'}")
 
 
-@bugreport_app.command("on")
-def bugreport_on() -> None:
+@support_app.command("on")
+def support_on() -> None:
     """Enable automatic GitHub issue creation on errors."""
     _set_bugreport_enabled(True)
 
 
-@bugreport_app.command("off")
-def bugreport_off() -> None:
+@support_app.command("off")
+def support_off() -> None:
     """Disable automatic GitHub issue creation on errors."""
     _set_bugreport_enabled(False)
 
 
-@bugreport_app.command("status")
-def bugreport_status() -> None:
-    """Show current auto bug-report configuration and dedup stats."""
+@support_app.command("status")
+def support_status() -> None:
+    """Show auto-report configuration, dedup stats, and token resolution."""
     import json
     from lorekeep.bugreport import _dedup_path, _load_dedup, _resolve_token
     from lorekeep.config import load_config

--- a/tests/test_bugreport.py
+++ b/tests/test_bugreport.py
@@ -359,7 +359,7 @@ class TestTokenFallback:
 
 
 class TestCli:
-    def test_bugreport_off(self, tmp_path: Path, monkeypatch):
+    def test_support_off(self, tmp_path: Path, monkeypatch):
         home = tmp_path / "home"
         home.mkdir()
         (home / "config.yaml").write_text(
@@ -367,14 +367,14 @@ class TestCli:
         )
         monkeypatch.setenv("LOREKEEP_HOME", str(home))
 
-        result = runner.invoke(app, ["bugreport", "off"])
+        result = runner.invoke(app, ["support", "off"])
         assert result.exit_code == 0, result.output
         assert "disabled" in result.output.lower()
 
         data = (home / "config.yaml").read_text(encoding="utf-8")
         assert "enabled: false" in data
 
-    def test_bugreport_on(self, tmp_path: Path, monkeypatch):
+    def test_support_on(self, tmp_path: Path, monkeypatch):
         home = tmp_path / "home"
         home.mkdir()
         (home / "config.yaml").write_text(
@@ -382,14 +382,14 @@ class TestCli:
         )
         monkeypatch.setenv("LOREKEEP_HOME", str(home))
 
-        result = runner.invoke(app, ["bugreport", "on"])
+        result = runner.invoke(app, ["support", "on"])
         assert result.exit_code == 0, result.output
         assert "enabled" in result.output.lower()
 
         data = (home / "config.yaml").read_text(encoding="utf-8")
         assert "enabled: true" in data
 
-    def test_bugreport_status(self, tmp_path: Path, monkeypatch):
+    def test_support_status(self, tmp_path: Path, monkeypatch):
         home = tmp_path / "home"
         home.mkdir()
         (home / "logs").mkdir()
@@ -402,13 +402,13 @@ class TestCli:
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         monkeypatch.setattr("lorekeep.bugreport._gh_cli_token", lambda: "")
 
-        result = runner.invoke(app, ["bugreport", "status"])
+        result = runner.invoke(app, ["support", "status"])
         assert result.exit_code == 0, result.output
         assert "myorg/myrepo" in result.output
         assert "token source:" in result.output
         assert "no errors reported yet" in result.output
 
-    def test_bugreport_status_no_token(self, tmp_path: Path, monkeypatch):
+    def test_support_status_no_token(self, tmp_path: Path, monkeypatch):
         home = tmp_path / "home"
         home.mkdir()
         (home / "logs").mkdir()
@@ -417,6 +417,6 @@ class TestCli:
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         monkeypatch.setattr("lorekeep.bugreport._gh_cli_token", lambda: "")
 
-        result = runner.invoke(app, ["bugreport", "status"])
+        result = runner.invoke(app, ["support", "status"])
         assert result.exit_code == 0, result.output
         assert "token: not found" in result.output


### PR DESCRIPTION
## Summary

Consolidates the standalone `bugreport` command group into `support`. Users now run `lorekeep support on/off/status` instead of `lorekeep bugreport on/off/status`.

**Breaking change** — no backward-compat aliases. The CLI surface is leaner:

```
Before:  support (diagnostics) + bugreport (auto-report control)
After:   support (diagnostics + auto-report control)
```

## Changes
- `cli.py`: Removed `bugreport_app` Typer group. `on/off/status` commands moved to `support_app` as `support_on/off/status`.
- `tests/test_bugreport.py`: Updated CLI test invocations and test method names.
- `config.yaml.example`: Updated comment to reference `lorekeep support on/off`.

## Test plan
- [x] `tests/test_bugreport.py` — 31 passed
- [x] `lorekeep support --help` shows `on`, `off`, `status`
- [x] `lorekeep --help` no longer lists `bugreport`