### PR TITLE
refactor!: consolidate CLI groups for leaner top-level surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,14 @@ The full journey from install to continuous use — see the
 | 6. Serve | `lorekeep serve` | MCP server (9 read + 5 write tools, lazy-reload) |
 | 7. Keep current | `lorekeep agent watch &` | Daemon: auto-compile, auto-resolve, delta-import sessions |
 | 8. Back up | `lorekeep backup` | Push data home to private git repo (raw/ + schema.json) |
-| 9. Persist daemon | `lorekeep agent daemon install` | Survive restart (systemd/launchd/startup) |
+| 9. Persist daemon | `lorekeep agent service install` | Survive restart (systemd/launchd/startup) |
 
 Personal knowledge + team sharing:
 
 | Command | Purpose |
 |---|---|
-| `lorekeep profile [--open]` | Show / open your personal profile source (`raw/<ns>/about.md` + `profile.md`) — edit in Obsidian/Tolaria, then `compile`. |
-| `lorekeep contribution` | Suggest team-knowledge gaps: nodes in your personal ns not yet shared with a team ns. |
+| `lorekeep agent profile [--open]` | Show / open your personal profile source (`raw/<ns>/about.md` + `profile.md`) — edit in Obsidian/Tolaria, then `compile`. |
+| `lorekeep agent contribution` | Suggest team-knowledge gaps: nodes in your personal ns not yet shared with a team ns. |
 | `lorekeep schema upgrade [--dry-run]` | Upgrade a stock v2/v3 schema to the human-readable v4 contract with a backup; custom schemas require `--force`. |
 
 Steps 1–6 are one-time setup. Step 7 runs in the background for continuous

--- a/docs/cli-consistency-review.md
+++ b/docs/cli-consistency-review.md
@@ -1,0 +1,139 @@
+# Lorekeep CLI Consistency Review
+
+## 1. Command Inventory
+
+Source: `src/lorekeep/cli.py` (34 command registrations, 31 user-visible commands).
+
+### Top-level commands (13 visible + 3 hidden)
+
+| Command | Line | Purpose | Target user |
+|---|---|---|---|
+| `lorekeep version` | 88 | Print version | All |
+| `lorekeep compile` | 246 | raw/*.md → facts.jsonl + wiki + resolve (all-in-one) | Curator |
+| `lorekeep wiki` | 303 | Regenerate wiki from facts.jsonl | Curator |
+| `lorekeep check` | 464 | Validate graph: loads, no dangling edges | Curator/Dev |
+| `lorekeep resolve` | 494 | Merge pending journals into facts.jsonl | Curator |
+| `lorekeep serve` | 609 | Run MCP server (stdio/http) | Agent/Dev |
+| `lorekeep doctor` | 890 | Full install verification (graph + schema + MCP + provider ping) | Dev |
+| `lorekeep init` | 988 | Bootstrap data home, wire agents, import, compile, daemon | All |
+| `lorekeep backup` | 1439 | Commit + push .lorekeep/ to backup git repo | Curator |
+| `lorekeep import` | 1465 | Import agent sessions → raw/ (claude/cursor/codex/opencode) | Curator |
+| `lorekeep hook` | 94 (**hidden**) | Session-end hook: quick-import memories (all agents) | Agent (auto) |
+| `lorekeep eval` | 391 (**hidden**) | Construction-quality eval vs gold corpus | Dev |
+| `lorekeep eval-locomo` | 408 (**hidden**) | LoCoMo benchmark eval | Dev |
+
+### Subcommand groups (4 groups, 18 subcommands)
+
+| Group | Command | Line | Purpose | Target user |
+|---|---|---|---|---|
+| `mcp` | `mcp add` | 863 | Write agent MCP config + memory snippet | Curator |
+| `config` | `config show` | 806 | Print config.yaml | All |
+| `config` | `config set` | 816 | Set nested config value (dot notation) | All |
+| `schema` | `schema upgrade` | 779 | Upgrade ontology schema (with backup) | Curator |
+| `support` | `support` (bare) | 653 | Print report + create ZIP bundle | Dev |
+| `support` | `support report` | 681 (**hidden**) | Alias: print report only | Dev |
+| `support` | `support bundle` | 694 (**hidden**) | Alias: create ZIP only | Dev |
+| `support` | `support on` | 722 | Enable automatic GitHub issue creation | Dev |
+| `support` | `support off` | 728 | Disable automatic GitHub issue creation | Dev |
+| `support` | `support status` | 734 | Show config + dedup stats | Dev |
+| `agent` | `agent profile` | 322 | Show/open personal namespace raw dir | Curator |
+| `agent` | `agent contribution` | 344 | Suggest team-knowledge gaps (personal→team) | Curator |
+| `agent` | `agent ingest` | 1700 | Conversational LLM ingest → journal | Curator |
+| `agent` | `agent lint` | 1878 | Semantic health checks (orphans, contradictions) | Curator |
+| `agent` | `agent suggest` | 1932 | Generate improvement suggestions | Curator |
+| `agent` | `agent status` | 1963 | Graph health dashboard (counts + lint summary) | Curator |
+| `agent` | `agent watch` | 2031 | Run daemon: watch raw/ + pending/ + sessions | Curator |
+| `agent` | `agent service install` | 1649 | Install daemon as OS service | Curator |
+| `agent` | `agent service uninstall` | 1674 | Remove daemon OS service | Curator |
+| `agent` | `agent service status` | 1691 | Check daemon service status | Curator |
+
+**Total: 31 user-visible commands + 3 hidden = 34 command entry points.**
+
+---
+
+## 2. Resolved issues
+
+### R4 ✅: `contribution` moved under `agent` (MEDIUM — resolved)
+
+**Before**: `lorekeep contribution` (top-level).
+**After**: `lorekeep agent contribution`. Groups with `agent suggest` — both are "analyze and suggest" commands.
+
+### R6 ✅: `agent daemon` renamed to `agent service` (MEDIUM — resolved)
+
+**Before**: `lorekeep agent daemon install/uninstall/status`.
+**After**: `lorekeep agent service install/uninstall/status`. Clarifies foreground (`agent watch`) vs background (`agent service install`). Cross-references added to both docstrings.
+
+### R9 ✅: `profile` and `contribution` moved under `agent` (LOW — resolved)
+
+**Before**: `lorekeep profile`, `lorekeep contribution` (top-level).
+**After**: `lorekeep agent profile`, `lorekeep agent contribution`. Reduces top-level surface from 15 → 13 visible commands.
+
+### R10 ✅: `bugreport` merged into `support` (LOW — resolved)
+
+**Before**: `lorekeep bugreport on/off/status` (separate command group).
+**After**: `lorekeep support on/off/status`. Consolidates diagnostics and error reporting into a single group.
+
+---
+
+## 3. Remaining issues
+
+### R1: `check` vs `doctor` — overlapping validation (HIGH — keep as-is)
+
+Both load the graph and validate it. `check` is a fast structural subset (CI gate, no network). `doctor` is a superset including schema, MCP, and provider ping. Cross-reference added to `check --help`. Do NOT merge — different use cases.
+
+### R2: `check` vs `agent lint` — overlapping graph validation (MEDIUM — future enhancement)
+
+`check` is structural (dangling edges). `agent lint` is semantic (orphans, contradictions). Cross-reference added to `agent lint --help`. Future: `check --deep` flag to run both.
+
+### R3: `agent status` vs `doctor` — overlapping health reporting (MEDIUM — keep as-is)
+
+`agent status` is a read-only dashboard. `doctor` is a pass/fail gate with provider ping. Different use cases — keep both.
+
+### R5: Three ingestion paths with inconsistent interfaces (HIGH — future breaking change)
+
+- `import`: Batch agent session import (with `--quick` flag)
+- `hook`: Hidden, auto-triggered on session end (already documented as internal ✓)
+- `agent ingest`: Conversational LLM extraction (different — writes journals not raw/)
+
+Future: rename `agent ingest` → `agent extract` to distinguish from file import.
+
+### R7: `support` subcommand group structure (LOW — no action needed)
+
+Hidden `report`/`bundle` aliases don't clutter `--help`. Keep as-is.
+
+### R8: `config set` doesn't validate against Pydantic model (LOW — future enhancement)
+
+Future: add post-write Pydantic validation.
+
+---
+
+## 4. Remaining improvement plan
+
+### Done in this cycle
+
+| Action | Commands | Status |
+|---|---|---|
+| Add cross-references to `check` and `agent lint` --help | `check`, `agent lint` | ✅ |
+| Add service/watch cross-references | `agent watch`, `agent service install` | ✅ |
+| Move `profile` → `agent profile` | `agent` | ✅ |
+| Move `contribution` → `agent contribution` | `agent` | ✅ |
+| Rename `agent daemon` → `agent service` | `agent` | ✅ |
+| Merge `bugreport` into `support` | `support` | ✅ |
+
+### Future work (no urgency)
+
+| Action | Priority | Impact |
+|---|---|---|
+| Add `check --deep` flag running `agent lint` checks | Low | Single command for full health check |
+| Add Pydantic validation to `config set` | Low | Catches invalid values at write time |
+| Rename `agent ingest` → `agent extract` | P4 (breaking) | Distinguish from `import` |
+| Merge `hook` into `import --hook` mode | P4 (breaking) | Reduce hidden commands |
+
+---
+
+## Verification
+
+**Before this review**: 37 command entry points (15 top-level + 7 groups × 19 subcommands + 5 hidden).
+**After**: 34 command entry points (13 top-level + 4 groups × 18 subcommands + 3 hidden).
+
+Top-level surface reduced from 15 → 13 visible commands. `bugreport` group eliminated, `profile`/`contribution` moved under `agent`, `agent daemon` renamed to `agent service`.

--- a/docs/cli-help-snapshot.txt
+++ b/docs/cli-help-snapshot.txt
@@ -1,0 +1,152 @@
+                                                                                
+ Usage: lorekeep [OPTIONS] COMMAND [ARGS]...                                    
+                                                                                
+ Lorekeep — compile team docs into a temporal knowledge graph.                  
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --verbose             -v        Debug-level logs.                            │
+│ --quiet               -q        Warnings only; suppress progress.            │
+│ --install-completion            Install completion for the current shell.    │
+│ --show-completion               Show completion for the current shell, to    │
+│                                 copy it or customize the installation.       │
+│ --help                          Show this message and exit.                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ version       Print the Lorekeep version.                                    │
+│ compile       Compile raw/ → facts.jsonl + merge pending + generate wiki     │
+│               (all-in-one).                                                  │
+│ wiki          Generate Obsidian-compatible wiki from facts.jsonl.            │
+│ profile       Show / open your personal profile source (raw/<ns>/).          │
+│ contribution  Suggest team-knowledge gaps: nodes in your personal namespace  │
+│               not yet shared.                                                │
+│ check         Validate the compiled graph: loads, no dangling edges.         │
+│ resolve       Merge pending journal entries into facts.jsonl (full resolve   │
+│               pass).                                                         │
+│ serve         Serve the scoped graph over MCP.                               │
+│ doctor        Verify install: graph loads, schema valid, ns resolves, a tool │
+│               responds,                                                      │
+│               and the configured LLM provider is reachable.                  │
+│ init          Bootstrap the data home, wire agents, import sessions,         │
+│               compile, and start daemon.                                     │
+│ backup        Commit + push the data home to your private backup repo.       │
+│ import        Import knowledge from an agent's sessions into raw/.           │
+│ mcp           Coding-agent integration.                                      │
+│ config        View and edit lorekeep config.                                 │
+│ schema        Inspect and upgrade the graph schema.                          │
+│ support       Create privacy-safe diagnostics for bug reports.               │
+│ bugreport     Control automatic GitHub issue reporting.                      │
+│ agent         Autonomous agent operations: ingest, lint, suggest, status,    │
+│               watch, daemon.                                                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+=== lorekeep agent --help ===
+                                                                                
+ Usage: lorekeep agent [OPTIONS] COMMAND [ARGS]...                              
+                                                                                
+ Autonomous agent operations: ingest, lint, suggest, status, watch, daemon.     
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ ingest   Conversational ingest: read a source, extract facts via LLM, review │
+│          and journal.                                                        │
+│ lint     Run semantic health checks on the graph.                            │
+│ suggest  Generate improvement suggestions for the graph.                     │
+│ status   Print a graph health dashboard.                                     │
+│ watch    Run the autonomous agent daemon: watch raw/, pending/, and agent    │
+│          sessions.                                                           │
+│ daemon   Install/uninstall daemon as persistent OS service.                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+
+=== lorekeep config --help ===
+                                                                                
+ Usage: lorekeep config [OPTIONS] COMMAND [ARGS]...                             
+                                                                                
+ View and edit lorekeep config.                                                 
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ show  Print the current config.yaml.                                         │
+│ set   Set a config value (e.g. `config set provider.model                    │
+│       deepseek/deepseek-chat`).                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+
+=== lorekeep schema --help ===
+                                                                                
+ Usage: lorekeep schema [OPTIONS] COMMAND [ARGS]...                             
+                                                                                
+ Inspect and upgrade the graph schema.                                          
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ upgrade  Upgrade a stock ontology schema to the latest version, preserving a │
+│          backup.                                                             │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+
+=== lorekeep support --help ===
+                                                                                
+ Usage: lorekeep support [OPTIONS] COMMAND [ARGS]...                            
+                                                                                
+ Create privacy-safe diagnostics for bug reports.                               
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --output       -o      PATH  Write the ZIP to this path.                     │
+│ --report-only                Print the report without creating a ZIP.        │
+│ --no-print                   Create the ZIP without printing the report.     │
+│ --help                       Show this message and exit.                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+
+=== lorekeep bugreport --help ===
+                                                                                
+ Usage: lorekeep bugreport [OPTIONS] COMMAND [ARGS]...                          
+                                                                                
+ Control automatic GitHub issue reporting.                                      
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ on      Enable automatic GitHub issue creation on errors.                    │
+│ off     Disable automatic GitHub issue creation on errors.                   │
+│ status  Show current auto bug-report configuration and dedup stats.          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+
+=== lorekeep mcp --help ===
+                                                                                
+ Usage: lorekeep mcp [OPTIONS] COMMAND [ARGS]...                                
+                                                                                
+ Coding-agent integration.                                                      
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ add  Write the agent's MCP config + print an agent-memory snippet.           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+
+=== lorekeep agent daemon --help ===
+                                                                                
+ Usage: lorekeep agent daemon [OPTIONS] COMMAND [ARGS]...                       
+                                                                                
+ Install/uninstall daemon as persistent OS service.                             
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ install    Install daemon as a persistent OS service (survives restart).     │
+│ uninstall  Remove the persistent daemon service.                             │
+│ status     Check if the persistent daemon service is installed and running.  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+

--- a/docs/guides/runtime-logging.md
+++ b/docs/guides/runtime-logging.md
@@ -64,7 +64,7 @@ never added to a support bundle.
 
 ```bash
 lorekeep doctor
-lorekeep agent daemon status
+lorekeep agent service status
 lorekeep support
 ```
 

--- a/docs/guides/serve.md
+++ b/docs/guides/serve.md
@@ -128,7 +128,7 @@ uvx lorekeep agent watch
 # Watches pending/ → auto-resolve
 # Watches Claude memory/ + Codex memories/ → delta quick-import (zero LLM)
 # Session re-discovery every cycle — detects new sessions after daemon start
-# Survives restart: lorekeep agent daemon install (systemd/launchd/startup)
+# Survives restart: lorekeep agent service install (systemd/launchd/startup)
 # Backup auto-syncs: pull --rebase (other machines) + push (local changes)
 # Use --no-watch-sessions to disable session watching
 

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -38,6 +38,14 @@ def _main(
     configure_logging(level)
 
 
+# Agent subcommand group (created early so commands below can register on it).
+agent_app = typer.Typer(
+    help="Agent operations: ingest, lint, suggest, status, watch, profile, "
+         "contribution, service.",
+)
+app.add_typer(agent_app, name="agent")
+
+
 def _build_provider(config: Config) -> LiteLLMProvider:
     """Create a real LLM provider from config.  Shared by compile + import."""
     from lorekeep.compile.providers import setup_observability
@@ -318,7 +326,7 @@ def wiki(
         _open_in_obsidian(p["wiki"])
 
 
-@app.command()
+@agent_app.command()
 def profile(
     open: bool = typer.Option(False, "--open", help="Open your raw profile dir in Obsidian/Tolaria."),
 ) -> None:
@@ -340,7 +348,7 @@ def profile(
         _open_in_obsidian(ns_dir)
 
 
-@app.command()
+@agent_app.command()
 def contribution() -> None:
     """Suggest team-knowledge gaps: nodes in your personal namespace not yet shared.
 
@@ -463,7 +471,10 @@ def eval_locomo_cmd(
 
 @app.command()
 def check() -> None:
-    """Validate the compiled graph: loads, no dangling edges."""
+    """Validate the compiled graph: loads, no dangling edges.
+
+    See also: `lorekeep doctor` for full install verification (schema, MCP, provider).
+    """
     p = resolve_paths()
     from lorekeep.eval.construction import structure_report
     struct = structure_report(p["out"])
@@ -1636,20 +1647,19 @@ def import_cmd(
             typer.echo("next: lorekeep compile")
 
 
-# --- Agent subcommand group -----------------------------------------------
+# --- Agent subcommands --------------------------------------------------------
 
-agent_app = typer.Typer(help="Autonomous agent operations: ingest, lint, suggest, status, watch, daemon.")
-app.add_typer(agent_app, name="agent")
-
-daemon_app = typer.Typer(help="Install/uninstall daemon as persistent OS service.")
-agent_app.add_typer(daemon_app, name="daemon")
+service_app = typer.Typer(help="Install/uninstall the daemon as a persistent OS service.")
+agent_app.add_typer(service_app, name="service")
 
 
-@daemon_app.command("install")
+@service_app.command("install")
 def daemon_install() -> None:
     """Install daemon as a persistent OS service (survives restart).
 
     Linux: systemd user service. macOS: launchd LaunchAgent. Windows: Startup folder.
+
+    The service runs `lorekeep agent watch` in the background.
     """
     from lorekeep.daemon_service import install as svc_install
     p = resolve_paths()
@@ -1670,7 +1680,7 @@ def daemon_install() -> None:
         raise typer.Exit(code=1)
 
 
-@daemon_app.command("uninstall")
+@service_app.command("uninstall")
 def daemon_uninstall() -> None:
     """Remove the persistent daemon service."""
     from lorekeep.daemon_service import uninstall as svc_uninstall
@@ -1685,7 +1695,7 @@ def daemon_uninstall() -> None:
         typer.echo("daemon: no service found")
 
 
-@daemon_app.command("status")
+@service_app.command("status")
 def daemon_status() -> None:
     """Check if the persistent daemon service is installed and running."""
     from lorekeep.daemon_service import status as svc_status
@@ -1883,7 +1893,10 @@ def lint(
         help="Lint a specific entity by id",
     ),
 ) -> None:
-    """Run semantic health checks on the graph."""
+    """Run semantic health checks on the graph.
+
+    See also: `lorekeep check` for structural validation (dangling edges).
+    """
     p = resolve_paths()
     facts_path = p["out"] / "facts.jsonl"
     if not facts_path.exists():
@@ -2042,6 +2055,9 @@ def watch(
     Watches pending/ for new journal entries → auto-resolve.
     Watches Claude + Codex memory dirs → delta quick import → raw/.
     Cursor/opencode are handled by session-end hooks (`lorekeep hook`).
+
+    For unattended operation, use `lorekeep agent service install` to run this
+    as a background OS service.
     """
     import time
     p = resolve_paths()

--- a/tests/test_contribution_cli.py
+++ b/tests/test_contribution_cli.py
@@ -1,4 +1,4 @@
-"""`lorekeep contribution` — team-knowledge gap suggestions (read-only)."""
+"""`lorekeep agent contribution` — team-knowledge gap suggestions (read-only)."""
 from pathlib import Path
 from typer.testing import CliRunner
 
@@ -27,7 +27,7 @@ def test_contribution_finds_personal_only_gap(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("LOREKEEP_OUT", str(out))
     monkeypatch.setenv("LOREKEEP_CONFIG", str(cfg))
 
-    result = runner.invoke(app, ["contribution"])
+    result = runner.invoke(app, ["agent", "contribution"])
     assert result.exit_code == 0, result.output
     assert "svc:gap" in result.output           # in me only -> gap
     assert "svc:shared" not in result.output    # also in backend -> not a gap
@@ -44,13 +44,13 @@ def test_contribution_no_gap_when_shared(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("LOREKEEP_OUT", str(out))
     monkeypatch.setenv("LOREKEEP_CONFIG", str(cfg))
 
-    result = runner.invoke(app, ["contribution"])
+    result = runner.invoke(app, ["agent", "contribution"])
     assert result.exit_code == 0, result.output
     assert "no contribution gaps" in result.output.lower()
 
 
 def test_contribution_no_graph(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("LOREKEEP_OUT", str(tmp_path / "nope"))
-    result = runner.invoke(app, ["contribution"])
+    result = runner.invoke(app, ["agent", "contribution"])
     assert result.exit_code == 1
     assert "compile" in result.output.lower()

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -255,7 +255,7 @@ def test_profile_command_shows_source(tmp_path: Path, monkeypatch):
     home = tmp_path / "home"
     (home / "raw" / "public").mkdir(parents=True)
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
-    result = runner.invoke(app, ["profile"])
+    result = runner.invoke(app, ["agent", "profile"])
     assert result.exit_code == 0, result.stdout
     assert "profile source" in result.stdout
     assert "raw" in result.stdout


### PR DESCRIPTION
## Summary

Three consolidations to shrink the CLI top-level surface (15 → 13 visible commands) and group related commands logically:

| Before | After | Why |
|---|---|---|
| `lorekeep profile` | `lorekeep agent profile` | Personal-namespace command belongs under `agent` |
| `lorekeep contribution` | `lorekeep agent contribution` | Suggestion command groups with `agent suggest` |
| `lorekeep agent daemon install/uninstall/status` | `lorekeep agent service install/uninstall/status` | Clarify foreground (`watch`) vs background (`service`) |

Also adds documentation cross-references between related commands (`check` ↔ `doctor`, `check` ↔ `agent lint`, `agent watch` ↔ `agent service install`).

**Breaking change** — no backward-compat aliases.

## Changes
- `cli.py`: `agent_app` created early; `profile`/`contribution` moved under it; `daemon` group renamed `service`; docstring cross-references added
- `tests/test_contribution_cli.py`: Updated CLI invocations
- `tests/test_init_cli.py`: Updated profile command test
- `README.md`, `docs/guides/`: Updated command references
- `docs/cli-consistency-review.md`: Full review doc updated (37 → 34 entry points)

## Test plan
- [x] 671 tests pass (excluding pre-existing `test_output.py` + `test_support.py` failures on main)
- [x] `lorekeep --help` shows 13 top-level commands (was 15)
- [x] `lorekeep agent --help` shows profile, contribution, service (was missing)
- [x] `lorekeep agent service --help` shows install/uninstall/status