### PR TITLE
refactor!: merge check into doctor as sole validation command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,15 +26,13 @@ uv run lorekeep <command>                    # run the CLI in dev mode
 |---|---|
 | `init` | Bootstrap data home (config + schema + raw/graph dirs) |
 | `compile` | `raw/*.md` → `graph/facts.jsonl` + `manifest.json` + `wiki/` (runs the LLM pipeline, auto-generates wiki) |
-| `check` | Validate compiled graph loads, no dangling edges (exit 1 on failure) |
-| `check` | Validate compiled graph loads, no dangling edges (exit 1 on failure) |
 | `wiki` | Regenerate `wiki/` from `facts.jsonl` (Obsidian-compatible markdown) |
 | `serve [--transport stdio\|http]` | Run the MCP server (9 read + 5 write tools) |
 | `mcp add --agent claude\|cursor\|codex\|opencode --ns NS` | Write agent MCP config |
 | `config show` | Print config.yaml |
 | `config set <key> <value>` | Set nested config value (dot notation) |
 | `import --from claude\|cursor\|codex\|opencode` | Import agent sessions into `raw/` |
-| `doctor` | Verify install: graph loads, schema valid, a tool responds |
+| `doctor` | Validate full install: graph loads (no dangling edges), schema valid, MCP tools respond, provider reachable |
 | `backup [--init <remote-url>]` | Commit + push `.lorekeep/` to your private backup git repo |
 | `version` | Print version |
 
@@ -102,6 +100,6 @@ The startup update script already runs `uv sync`; the toolchain (Python 3.11+ vi
 Non-obvious caveats for running/testing here:
 
 - **No API key needed for tests.** Tests inject `FakeProvider` via `patch_make_provider` / `patch_make_import_provider` conftest fixtures. For manual smoke testing, configure a real provider in `config.yaml`. To avoid polluting the repo's `.lorekeep/` data home, run demos against a throwaway data home: `LOREKEEP_HOME=/tmp/lk uv run lorekeep <cmd>`.
-- **End-to-end smoke flow** (offline): `init` → drop a markdown file under `.lorekeep/raw/<ns>/` → `compile` → `check`/`doctor`. Then query the graph by calling the `mcp_server.py` tools directly after `ms.configure(graph_dir=..., allowed_ns=[...], schema_path=...)` — the read tools (`search`, `get_node`, `neighbors`, `at_time`, `history`, `list_namespaces`) are plain functions, no MCP transport required. `search` returns a list of node-id strings; `get_node` returns a dict; `neighbors`/`at_time`/`changes` return `{"nodes": [...], "edges": [...]}`.
+- **End-to-end smoke flow** (offline): `init` → drop a markdown file under `.lorekeep/raw/<ns>/` → `compile` → `doctor`. Then query the graph by calling the `mcp_server.py` tools directly after `ms.configure(graph_dir=..., allowed_ns=[...], schema_path=...)` — the read tools (`search`, `get_node`, `neighbors`, `at_time`, `history`, `list_namespaces`) are plain functions, no MCP transport required. `search` returns a list of node-id strings; `get_node` returns a dict; `neighbors`/`at_time`/`changes` return `{"nodes": [...], "edges": [...]}`.
 - **`lorekeep serve` blocks on stdio** waiting for an MCP client — it won't return on its own. To just confirm it boots, run it under `timeout` with stdin closed (`timeout 3 uv run lorekeep serve --transport stdio </dev/null`); a clean timeout with no error output means success.
 - **`tests/test_mcp_reload.py::test_lazy_reload_on_facts_change` is timing-flaky** — lazy-reload triggers off `facts.jsonl` mtime, and the test can rewrite the file within one mtime tick on fast filesystems, so it intermittently fails then passes on re-run. Treat an isolated failure of just this test as a flake, not a regression.

--- a/docs/architecture/evaluation.md
+++ b/docs/architecture/evaluation.md
@@ -29,7 +29,7 @@ All compile/serve/import tests inject `FakeProvider` via monkeypatch to avoid a 
 
 ### Tier 1 — Construction quality (CI, every commit)
 
-Evaluates the **compiler**, not the agent. `lorekeep eval` / `lorekeep check`.
+Evaluates the **compiler**, not the agent. `lorekeep eval` / `lorekeep doctor`.
 
 - Extraction P/R/F1 vs a **gold-annotated corpus** (human-authored `facts.jsonl` reference), per node/edge type.
 - Entity-resolution F1 + false-merge rate.

--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -131,7 +131,7 @@ Re-compiling unchanged input (same raw/ + same journals with same statuses) yiel
 
 - **LLM failure / unparseable chunk** ⇒ log to `manifest.errors`, skip chunk, continue. Partial compile is valid; re-run fills the gaps.
 - **Malformed candidate fact** ⇒ `resolve` quarantines to `manifest.quarantine`, drops from output.
-- **Edge with missing endpoint** ⇒ deferred to pending retry, not permanently dropped. Edges whose endpoints don't yet exist (e.g., node proposed in a different journal entry not yet resolved) are held in a retry queue and re-evaluated on subsequent resolve passes up to 5 times (or until the endpoint appears). After max retries, they are quarantined. Dangling edges also surface in `lorekeep check`.
+- **Edge with missing endpoint** ⇒ deferred to pending retry, not permanently dropped. Edges whose endpoints don't yet exist (e.g., node proposed in a different journal entry not yet resolved) are held in a retry queue and re-evaluated on subsequent resolve passes up to 5 times (or until the endpoint appears). After max retries, they are quarantined. Dangling edges also surface in `lorekeep doctor`.
 - **Provider unavailable** ⇒ compile aborts with a clear message; partial results are not merged.
 - **Low-confidence agent proposal** ⇒ quarantined, never enters `facts.jsonl`; listed in resolve report.
 - **Journal parse error** ⇒ skip corrupted line, log warning, continue resolve.

--- a/docs/cli-consistency-review.md
+++ b/docs/cli-consistency-review.md
@@ -2,22 +2,21 @@
 
 ## 1. Command Inventory
 
-Source: `src/lorekeep/cli.py` (34 command registrations, 31 user-visible commands).
+Source: `src/lorekeep/cli.py` (32 command registrations, 30 user-visible commands).
 
-### Top-level commands (13 visible + 3 hidden)
+### Top-level commands (12 visible + 3 hidden)
 
 | Command | Line | Purpose | Target user |
 |---|---|---|---|
 | `lorekeep version` | 88 | Print version | All |
 | `lorekeep compile` | 246 | raw/*.md → facts.jsonl + wiki + resolve (all-in-one) | Curator |
 | `lorekeep wiki` | 303 | Regenerate wiki from facts.jsonl | Curator |
-| `lorekeep check` | 464 | Validate graph: loads, no dangling edges | Curator/Dev |
 | `lorekeep resolve` | 494 | Merge pending journals into facts.jsonl | Curator |
 | `lorekeep serve` | 609 | Run MCP server (stdio/http) | Agent/Dev |
-| `lorekeep doctor` | 890 | Full install verification (graph + schema + MCP + provider ping) | Dev |
-| `lorekeep init` | 988 | Bootstrap data home, wire agents, import, compile, daemon | All |
-| `lorekeep backup` | 1439 | Commit + push .lorekeep/ to backup git repo | Curator |
-| `lorekeep import` | 1465 | Import agent sessions → raw/ (claude/cursor/codex/opencode) | Curator |
+| `lorekeep doctor` | 875 | Validate full install: graph, schema, MCP, provider | All |
+| `lorekeep init` | 973 | Bootstrap data home, wire agents, import, compile, daemon | All |
+| `lorekeep backup` | 1424 | Commit + push .lorekeep/ to backup git repo | Curator |
+| `lorekeep import` | 1450 | Import agent sessions → raw/ (claude/cursor/codex/opencode) | Curator |
 | `lorekeep hook` | 94 (**hidden**) | Session-end hook: quick-import memories (all agents) | Agent (auto) |
 | `lorekeep eval` | 391 (**hidden**) | Construction-quality eval vs gold corpus | Dev |
 | `lorekeep eval-locomo` | 408 (**hidden**) | LoCoMo benchmark eval | Dev |
@@ -47,7 +46,7 @@ Source: `src/lorekeep/cli.py` (34 command registrations, 31 user-visible command
 | `agent` | `agent service uninstall` | 1674 | Remove daemon OS service | Curator |
 | `agent` | `agent service status` | 1691 | Check daemon service status | Curator |
 
-**Total: 31 user-visible commands + 3 hidden = 34 command entry points.**
+**Total: 30 user-visible commands + 3 hidden = 32 command entry points.**
 
 ---
 
@@ -77,13 +76,13 @@ Source: `src/lorekeep/cli.py` (34 command registrations, 31 user-visible command
 
 ## 3. Remaining issues
 
-### R1: `check` vs `doctor` — overlapping validation (HIGH — keep as-is)
+### R1 ✅: `check` merged into `doctor` (HIGH — resolved)
 
-Both load the graph and validate it. `check` is a fast structural subset (CI gate, no network). `doctor` is a superset including schema, MCP, and provider ping. Cross-reference added to `check --help`. Do NOT merge — different use cases.
+The standalone `check` command is removed. `doctor` is the sole validation command — it covers structural integrity (dangling edges), schema validation, MCP tool response, and provider connectivity. Provider ping is auto-skipped when no API key is set, so `doctor` works in CI/offline without flags.
 
-### R2: `check` vs `agent lint` — overlapping graph validation (MEDIUM — future enhancement)
+### R2: `doctor` vs `agent lint` — structural vs semantic validation (MEDIUM — future enhancement)
 
-`check` is structural (dangling edges). `agent lint` is semantic (orphans, contradictions). Cross-reference added to `agent lint --help`. Future: `check --deep` flag to run both.
+`doctor` is structural (dangling edges, schema, connectivity). `agent lint` is semantic (orphans, contradictions). Cross-reference added to `agent lint --help`. Future: `doctor --deep` flag to run both.
 
 ### R3: `agent status` vs `doctor` — overlapping health reporting (MEDIUM — keep as-is)
 
@@ -113,18 +112,19 @@ Future: add post-write Pydantic validation.
 
 | Action | Commands | Status |
 |---|---|---|
-| Add cross-references to `check` and `agent lint` --help | `check`, `agent lint` | ✅ |
+| Add cross-references to `agent lint` --help | `agent lint` | ✅ |
 | Add service/watch cross-references | `agent watch`, `agent service install` | ✅ |
 | Move `profile` → `agent profile` | `agent` | ✅ |
 | Move `contribution` → `agent contribution` | `agent` | ✅ |
 | Rename `agent daemon` → `agent service` | `agent` | ✅ |
 | Merge `bugreport` into `support` | `support` | ✅ |
+| Merge `check` into `doctor` | `doctor` | ✅ |
 
 ### Future work (no urgency)
 
 | Action | Priority | Impact |
 |---|---|---|
-| Add `check --deep` flag running `agent lint` checks | Low | Single command for full health check |
+| Add `doctor --deep` flag running `agent lint` checks | Low | Single command for full health check |
 | Add Pydantic validation to `config set` | Low | Catches invalid values at write time |
 | Rename `agent ingest` → `agent extract` | P4 (breaking) | Distinguish from `import` |
 | Merge `hook` into `import --hook` mode | P4 (breaking) | Reduce hidden commands |
@@ -134,6 +134,6 @@ Future: add post-write Pydantic validation.
 ## Verification
 
 **Before this review**: 37 command entry points (15 top-level + 7 groups × 19 subcommands + 5 hidden).
-**After**: 34 command entry points (13 top-level + 4 groups × 18 subcommands + 3 hidden).
+**After**: 32 command entry points (12 top-level + 4 groups × 18 subcommands + 3 hidden).
 
-Top-level surface reduced from 15 → 13 visible commands. `bugreport` group eliminated, `profile`/`contribution` moved under `agent`, `agent daemon` renamed to `agent service`.
+Top-level surface reduced from 15 → 12 visible commands. `check` and `bugreport` groups eliminated, `profile`/`contribution` moved under `agent`, `agent daemon` renamed to `agent service`.

--- a/docs/guides/compile.md
+++ b/docs/guides/compile.md
@@ -119,10 +119,11 @@ Snapshots to `.lorekeep/eval/results.json`.
 ## 7. Validate
 
 ```bash
-uv run lorekeep check
+uv run lorekeep doctor
 ```
 
-Exits non-zero if the graph has dangling edges.
+Verifies graph loads with no dangling edges, schema is valid, MCP tools
+respond, and provider is reachable.
 
 ## How agents contribute knowledge
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -126,7 +126,7 @@ Prefer an env var instead? Set `api_key_env: DEEPSEEK_API_KEY` (and
 
 ```bash
 uvx lorekeep compile      # raw/*.md -> graph/facts.jsonl + manifest.json
-uvx lorekeep check        # loads, no dangling edges (exit 1 on failure)
+uvx lorekeep doctor       # full install check: graph, schema, MCP, provider
 ```
 
 Recompiling unchanged input is **byte-identical** (determinism is a hard
@@ -205,7 +205,7 @@ recovery — is in [Backing up the data home](backup.md).
   `{provider}/{model}`), `api_base`, and `api_key` / `api_key_env` in
   `config.yaml`. (The cache key includes the model, so switching it
   re-extracts automatically — no need to delete `cache.json`.)
-- **`check` reports dangling edges** — an edge points at a node that isn't in
+- **`doctor` reports dangling edges** — an edge points at a node that isn't in
   the graph. Re-open the source doc at the `path:line` in the edge's `src` and
   fix the reference, then recompile.
 - **Agent can't see a namespace** — serve-time scope comes from `LOREKEEP_NS`

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -469,23 +469,6 @@ def eval_locomo_cmd(
         typer.echo(f"{cat:<20} {stats['count']:>6} {stats['f1']:>8.4f}")
 
 
-@app.command()
-def check() -> None:
-    """Validate the compiled graph: loads, no dangling edges.
-
-    See also: `lorekeep doctor` for full install verification (schema, MCP, provider).
-    """
-    p = resolve_paths()
-    from lorekeep.eval.construction import structure_report
-    struct = structure_report(p["out"])
-    if struct["dangling_edge_rate"] > 0:
-        from lorekeep.output import error
-        error(f"check: FAIL — {struct['dangling_edge_rate']} dangling edges")
-        raise typer.Exit(code=1)
-    from lorekeep.output import ok
-    ok(f"check: ok — {struct['node_count']} nodes, {struct['edge_count']} edges, 0 dangling")
-
-
 def _with_resolve_lock(func):
     """Typer-safe decorator serializing manual resolve with daemon resolve."""
     from functools import wraps
@@ -897,8 +880,12 @@ def mcp_add(
 
 @app.command()
 def doctor() -> None:
-    """Verify install: graph loads, schema valid, ns resolves, a tool responds,
-    and the configured LLM provider is reachable."""
+    """Validate the full install: graph loads with no dangling edges, schema
+    is valid, MCP tools respond, and the configured LLM provider is reachable.
+
+    This is the sole validation command — run it after `compile` or when
+    troubleshooting. Provider ping is skipped automatically when no API key
+    is configured."""
     p = resolve_paths()
     problems = []
     notes = []
@@ -1895,7 +1882,7 @@ def lint(
 ) -> None:
     """Run semantic health checks on the graph.
 
-    See also: `lorekeep check` for structural validation (dangling edges).
+    See also: `lorekeep doctor` for structural validation and full install checks.
     """
     p = resolve_paths()
     facts_path = p["out"] / "facts.jsonl"

--- a/tests/test_compile_cli.py
+++ b/tests/test_compile_cli.py
@@ -189,7 +189,7 @@ def test_v4_compile_wiki_check_end_to_end(
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
 
     compiled = runner.invoke(app, ["compile"])
-    checked = runner.invoke(app, ["check"])
+    checked = runner.invoke(app, ["doctor"])
     regenerated = runner.invoke(app, ["wiki"])
 
     assert compiled.exit_code == 0, compiled.output

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -23,13 +23,13 @@ def test_eval_construction_command(tmp_path: Path, fixtures: Path, monkeypatch):
     assert saved["extraction"]["nodes"]["f1"] == 1.0
 
 
-def test_check_command_reports_clean_graph(tmp_path: Path, fixtures: Path, monkeypatch):
+def test_doctor_reports_clean_graph(tmp_path: Path, fixtures: Path, monkeypatch):
     out = tmp_path / "graph"
     out.mkdir()
     (out / "facts.jsonl").write_text(
         (fixtures / "gold/payments.facts.jsonl").read_text())
     monkeypatch.setenv("LOREKEEP_OUT", str(out))
     monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
-    result = runner.invoke(app, ["check"])
+    result = runner.invoke(app, ["doctor"])
     assert result.exit_code == 0, result.stdout
-    assert "ok" in result.stdout.lower()
+    assert "ok" in result.stdout.lower() or "passed" in result.stdout.lower()


### PR DESCRIPTION
## Summary

Removes the `check` command. `doctor` is now the single validation command — it already covered everything `check` did (graph load + dangling edges) plus schema validation, MCP tool response, and provider connectivity.

Provider ping is auto-skipped when no API key is configured, so `doctor` works in CI and offline without any flags.

**Breaking change** — no backward-compat aliases.

## Changes
- `cli.py`: Deleted `check()` command, updated `doctor` docstring
- `tests/test_eval_cli.py`: Renamed test, `["check"]` → `["doctor"]`
- `tests/test_compile_cli.py`: `["check"]` → `["doctor"]`
- `docs/`: Updated 4 guide/architecture files + CLI review doc
- `CLAUDE.md`: Removed `check` from command table, updated smoke flow

## Test plan
- [x] 671 tests pass (excluding pre-existing `test_output.py` + `test_support.py`)
- [x] `lorekeep --help` no longer lists `check`
- [x] `lorekeep doctor` works in offline/no-API-key test setups