### PR TITLE
fix: include full traceback in auto-reported GitHub issues

### DIFF
--- a/src/lorekeep/bugreport.py
+++ b/src/lorekeep/bugreport.py
@@ -153,6 +153,7 @@ def _create_github_issue(
 
 def _build_issue_body(record: logging.LogRecord, run_id: str) -> str:
     """Build a privacy-safe Markdown issue body from a log record."""
+    from datetime import datetime, timezone
     from lorekeep import __version__
     from lorekeep.redaction import redact_text
 
@@ -162,6 +163,22 @@ def _build_issue_body(record: logging.LogRecord, run_id: str) -> str:
     error_type = ""
     if record.exc_info and record.exc_info[0]:
         error_type = record.exc_info[0].__name__
+
+    # Timestamp from the record's creation time.
+    ts = datetime.fromtimestamp(record.created, tz=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ",
+    )
+
+    # Source location from the top traceback frame (where the error
+    # originated in lorekeep code).  Falls back to the log call site.
+    source = ""
+    if record.exc_info and record.exc_info[2]:
+        tb_frames = _tb.extract_tb(record.exc_info[2])
+        if tb_frames:
+            f = tb_frames[-1]  # innermost frame = where the raise happened
+            source = redact_text(f"{f.filename}:{f.lineno} in {f.name}")
+    if not source and record.pathname:
+        source = redact_text(f"{record.pathname}:{record.lineno} in {record.funcName}")
 
     # Full traceback with redacted exception message — same pattern as
     # _SafeFileFormatter in output.py.  Stack frames (file/line/function) are
@@ -175,35 +192,52 @@ def _build_issue_body(record: logging.LogRecord, run_id: str) -> str:
             f'  File "{f.filename}", line {f.lineno}, in {f.name}\n'
             for f in _tb.extract_tb(record.exc_info[2])
         )
-        log_entry = (
-            f"{msg}\n"
+        traceback_text = (
             f"{frames}{exc_type.__module__}.{exc_type.__name__}: [details redacted]"
         )
-        log_entry = redact_text(log_entry)
+        traceback_text = redact_text(traceback_text)
     else:
-        log_entry = msg
-    log_entry = redact_text(log_entry)
+        traceback_text = ""
 
-    return (
-        "## Auto-reported error\n\n"
-        f"| Field | Value |\n"
-        f"|---|---|\n"
-        f"| Event | `{redact_text(event)}` |\n"
-        f"| Level | {level} |\n"
-        f"| Component | `{redact_text(component)}` |\n"
-        f"| Run ID | {redact_text(run_id)} |\n"
-        f"| Version | {__version__} |\n"
-        f"| Platform | {redact_text(platform.platform())} |\n"
-        f"| Python | {redact_text(platform.python_version())} |\n"
-        f"{f'| Error type | `{error_type}` |' + chr(10) if error_type else ''}"
-        "\n"
-        "<details><summary>Redacted log entry</summary>\n\n"
-        f"```\n{log_entry}\n```\n\n"
-        "</details>\n\n"
+    # Build metadata table rows.
+    rows = [
+        ("Event", f"`{redact_text(event)}`"),
+        ("Level", level),
+        ("Timestamp", ts),
+        ("Component", f"`{redact_text(component)}`"),
+        ("Run ID", redact_text(run_id)),
+        ("Version", __version__),
+    ]
+    if error_type:
+        rows.append(("Error type", f"`{error_type}`"))
+    if source:
+        rows.append(("Source", f"`{source}`"))
+    rows.append(("Platform", redact_text(platform.platform())))
+    rows.append(("Python", redact_text(platform.python_version())))
+
+    table = "| Field | Value |\n|---|---|\n"
+    for label, value in rows:
+        table += f"| {label} | {value} |\n"
+
+    # Log message shown directly (already redacted) + traceback in details.
+    sections = [
+        "## Auto-reported error\n",
+        f"```\n{msg}\n```\n",
+        table,
+    ]
+    if traceback_text:
+        sections.append(
+            "<details><summary>Full traceback</summary>\n\n"
+            f"```\n{traceback_text}\n```\n\n"
+            "</details>\n\n"
+        )
+    sections.append(
         "---\n"
         "*Created automatically by `lorekeep` runtime diagnostics. "
         "Sensitive data has been redacted.*\n"
     )
+
+    return "\n".join(sections)
 
 
 # ---------------------------------------------------------------------------

--- a/src/lorekeep/bugreport.py
+++ b/src/lorekeep/bugreport.py
@@ -20,6 +20,7 @@ import logging
 import os
 import platform
 import sys
+import traceback as _tb
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -162,14 +163,23 @@ def _build_issue_body(record: logging.LogRecord, run_id: str) -> str:
     if record.exc_info and record.exc_info[0]:
         error_type = record.exc_info[0].__name__
 
-    # Redacted log message.  Traceback frames are NOT included — they can
-    # carry the exception message in the source line of the raise statement.
-    # The full redacted traceback is already in the runtime log; the issue
-    # body only needs enough metadata to identify the error class.
+    # Full traceback with redacted exception message — same pattern as
+    # _SafeFileFormatter in output.py.  Stack frames (file/line/function) are
+    # safe to include and essential for diagnosing auto-reported errors.
+    # Source code lines are stripped from each frame to avoid leaking
+    # exception messages embedded in raise statements.
     msg = redact_text(record.getMessage())
-    if record.exc_info and record.exc_info[0]:
+    if record.exc_info and record.exc_info[2]:
         exc_type = record.exc_info[0]
-        log_entry = f"{msg}\n{exc_type.__module__}.{exc_type.__name__}: [details redacted]"
+        frames = "".join(
+            f'  File "{f.filename}", line {f.lineno}, in {f.name}\n'
+            for f in _tb.extract_tb(record.exc_info[2])
+        )
+        log_entry = (
+            f"{msg}\n"
+            f"{frames}{exc_type.__module__}.{exc_type.__name__}: [details redacted]"
+        )
+        log_entry = redact_text(log_entry)
     else:
         log_entry = msg
     log_entry = redact_text(log_entry)

--- a/tests/test_bugreport.py
+++ b/tests/test_bugreport.py
@@ -147,6 +147,8 @@ class TestIssueBody:
         assert "compile.chunk_failed" in body
         assert "ERROR" in body
         assert "run123" in body
+        assert "Timestamp" in body
+        assert "Source" in body
 
     def test_traceback_is_redacted(self):
         record = _make_error_record()
@@ -157,6 +159,12 @@ class TestIssueBody:
         # Full traceback frames should be included for debugging.
         assert 'File "' in body
         assert "line " in body
+
+    def test_log_message_shown_directly(self):
+        record = _make_record(msg="compile: chunk failed line=1")
+        body = _build_issue_body(record, "run123")
+        # Log message should be visible without expanding details.
+        assert "chunk failed" in body
 
     def test_redacts_home_directory(self):
         record = _make_record(msg=f"failed reading {Path.home()}/secret/file")

--- a/tests/test_bugreport.py
+++ b/tests/test_bugreport.py
@@ -154,6 +154,9 @@ class TestIssueBody:
         assert "bad chunk" not in body
         assert "[details redacted]" in body
         assert "ValueError" in body
+        # Full traceback frames should be included for debugging.
+        assert 'File "' in body
+        assert "line " in body
 
     def test_redacts_home_directory(self):
         record = _make_record(msg=f"failed reading {Path.home()}/secret/file")


### PR DESCRIPTION
## Summary

Auto-reported issues (e.g. #168, #169) previously showed only a 2-line stub — no stack frames, file paths, or line numbers. This made them nearly useless for debugging.

Now includes full stack trace frames (file/line/function) in the issue body, matching the pattern already used by `_SafeFileFormatter` in the runtime log file.

## Privacy

- **Exception messages**: redacted (`[details redacted]`)
- **Source code lines**: stripped from each frame (prevents leaking sensitive data in `raise` statements)
- **Everything**: passed through `redact_text()` (API keys, bearer tokens, home dir paths)

## Before
```
compile: chunk failed line=1 error_type=AuthenticationError
litellm.exceptions.AuthenticationError: [details redacted]
```

## After
```
compile: chunk failed line=1 error_type=AuthenticationError
  File "~/src/lorekeep/compile/extract.py", line 234, in extract_chunk
  File "~/src/lorekeep/compile/providers.py", line 156, in complete
litellm.exceptions.AuthenticationError: [details redacted]
```

## Test plan
- [x] 31 bugreport tests pass
- [x] 57 bugreport + core regression tests pass
- [x] Manual verification: `ValueError("secret api_key=sk-xxx")` → no leak in issue body