### PR TITLE
fix: prevent crashes and noise from systemic provider errors

### DIFF
--- a/src/lorekeep/bugreport.py
+++ b/src/lorekeep/bugreport.py
@@ -31,6 +31,12 @@ logger = logging.getLogger("lorekeep.bugreport")
 # Warn-once flag for the "no token" case (per-process).
 _warned_no_token = False
 
+# Events that are symptoms of other errors and should never trigger an
+# auto-reported issue (they would just create duplicates of the root cause).
+_SKIP_EVENTS = frozenset({
+    "compile.manifest_error",   # always a consequence of compile.chunk_failed
+})
+
 
 # ---------------------------------------------------------------------------
 # Token resolution (fallback chain)
@@ -264,6 +270,10 @@ class BugReportHandler(logging.Handler):
         if record.levelno < logging.ERROR:
             return
 
+        # Skip auto-reporting in test environments (set by conftest.py).
+        if os.environ.get("LOREKEEP_BUGREPORT_TEST_MODE"):
+            return
+
         # Lazily load config.
         from lorekeep.config import load_config
         from lorekeep.paths import resolve_paths
@@ -289,6 +299,13 @@ class BugReportHandler(logging.Handler):
 
         event = getattr(record, "event", "runtime")
         component = record.name
+
+        # Skip events that are symptoms of other errors (never actionable on
+        # their own).  compile.manifest_error is always a consequence of
+        # compile.chunk_failed; mcp.failed is logged by the serve loop.
+        if event in _SKIP_EVENTS:
+            return
+
         error_type = ""
         if record.exc_info and record.exc_info[0]:
             error_type = record.exc_info[0].__name__

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -611,7 +611,13 @@ def serve(
         allowed = [x.strip() for x in raw_ns.split(",") if x.strip()]
     else:
         allowed = load_config(p["config"]).ns.default
-    from lorekeep.mcp_server import configure, mcp
+    try:
+        from lorekeep.mcp_server import configure, mcp
+    except ImportError as exc:
+        from lorekeep.output import error
+        error(f"'lorekeep serve' requires the 'mcp' package, which is not installed: {exc}")
+        error("Fix: pip install mcp  (or: uv pip install mcp)")
+        raise typer.Exit(code=1)
     configure(graph_dir=p["out"], allowed_ns=allowed, schema_path=p["schema"], pending_dir=p.get("pending"))
     log.info(
         "MCP server starting transport=%s namespace_count=%s", transport, len(allowed),

--- a/src/lorekeep/pipeline.py
+++ b/src/lorekeep/pipeline.py
@@ -25,6 +25,36 @@ log = logging.getLogger("lorekeep")
 # Optional per-chunk progress hook: (index, total, chunk). Default None → silent.
 ProgressCb = Callable[[int, int, DocChunk], None]
 
+# Exception names that indicate a systemic provider failure (bad API key,
+# unreachable endpoint, etc.). These will fail identically on every chunk, so
+# we short-circuit the compile loop after the first occurrence.
+_FATAL_PROVIDER_ERRORS = frozenset({
+    "AuthenticationError",
+    "PermissionDeniedError",
+    "NotFoundError",
+    "ConnectionError",
+    "Timeout",
+    "APIConnectionError",
+    "APITimeoutError",
+    "ServiceUnavailableError",
+    "InternalServerError",
+    "RateLimitError",
+})
+
+
+def _is_fatal_provider_error(exc: Exception) -> bool:
+    """True if *exc* is a systemic provider error that will recur on every chunk."""
+    exc_name = type(exc).__name__
+    if exc_name in _FATAL_PROVIDER_ERRORS:
+        return True
+    # Walk the cause chain (litellm wraps errors inside retries).
+    cause = exc.__cause__ or exc.__context__
+    while cause is not None and cause is not exc:
+        if type(cause).__name__ in _FATAL_PROVIDER_ERRORS:
+            return True
+        cause = getattr(cause, "__cause__", None) or getattr(cause, "__context__", None)
+    return False
+
 
 def measure_content_quality(
     nodes: list[Node], edges: list[Edge], schema: Schema,
@@ -109,6 +139,16 @@ def compile_graph(
             )
             errors.append({"path": chunk.path, "line": chunk.start_line,
                            "message": str(exc)})
+            # Fatal errors (auth, network) will fail identically on every
+            # remaining chunk — abort the loop to save time and avoid N
+            # identical auto-reported issues from the same root cause.
+            if _is_fatal_provider_error(exc):
+                log.error(
+                    "compile aborted: fatal provider error, skipping %s remaining chunk(s)",
+                    total - i - 1,
+                    extra={"event": "compile.aborted_fatal"},
+                )
+                break
     cache.save()
 
     resolved = resolve(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,16 @@ import pytest
 from lorekeep.compile.providers import FakeProvider
 
 
+@pytest.fixture(autouse=True)
+def _disable_bugreport_in_tests(monkeypatch):
+    """Prevent BugReportHandler from creating GitHub issues during tests.
+
+    Individual test_bugreport.py tests unset this so they can verify the
+    handler's real behaviour.
+    """
+    monkeypatch.setenv("LOREKEEP_BUGREPORT_TEST_MODE", "1")
+
+
 @pytest.fixture
 def fixtures() -> Path:
     return Path(__file__).parent / "fixtures"

--- a/tests/test_bugreport.py
+++ b/tests/test_bugreport.py
@@ -185,6 +185,8 @@ class TestHandlerEmit:
             (home / "config.yaml").write_text(config_yaml, encoding="utf-8")
         monkeypatch.setenv("LOREKEEP_HOME", str(home))
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        # Allow the handler to run — conftest disables it for all other tests.
+        monkeypatch.delenv("LOREKEEP_BUGREPORT_TEST_MODE", raising=False)
         # Mock gh CLI to return empty unless a test overrides it.
         monkeypatch.setattr("lorekeep.bugreport._gh_cli_token", lambda: "")
         # Reset the warn-once flag.
@@ -312,6 +314,20 @@ class TestHandlerEmit:
         dedup = _load_dedup(_dedup_path())
         assert len(dedup) == 0  # not recorded → allows retry next run
 
+    @patch("lorekeep.bugreport._create_github_issue")
+    def test_skips_in_test_mode(self, mock_create, tmp_path: Path, monkeypatch):
+        """Handler must not create issues when LOREKEEP_BUGREPORT_TEST_MODE is set."""
+        self._setup_home(tmp_path, monkeypatch)
+        monkeypatch.setenv("LOREKEEP_GITHUB_TOKEN", "ghp_fake")
+        monkeypatch.setenv("LOREKEEP_BUGREPORT_TEST_MODE", "1")
+        mock_create.return_value = 42
+
+        handler = BugReportHandler()
+        record = _make_error_record()
+        handler.emit(record)
+
+        mock_create.assert_not_called()
+
 
 # ── token fallback chain ─────────────────────────────────────────────────────
 
@@ -353,6 +369,7 @@ class TestTokenFallback:
         (home / "logs").mkdir()
         monkeypatch.setenv("LOREKEEP_HOME", str(home))
         monkeypatch.delenv("LOREKEEP_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("LOREKEEP_BUGREPORT_TEST_MODE", raising=False)
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_ci")
         monkeypatch.setattr("lorekeep.bugreport._gh_cli_token", lambda: "")
         import lorekeep.bugreport as br

--- a/tests/test_fatal_short_circuit.py
+++ b/tests/test_fatal_short_circuit.py
@@ -1,0 +1,141 @@
+"""Tests for fatal-provider-error short-circuit in compile_graph.
+
+When a chunk fails with a systemic error (AuthenticationError, ConnectionError,
+etc.) the compile loop should abort immediately instead of trying every
+remaining chunk — they will all fail identically.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lorekeep.compile.providers import FakeProvider
+from lorekeep.models import Schema
+from lorekeep.pipeline import _is_fatal_provider_error, compile_graph
+
+
+def _copy_fixture(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(src.read_text())
+
+
+def _load_schema(fixtures: Path) -> Schema:
+    return Schema.load(json.loads((fixtures / "schema.json").read_text()))
+
+
+# ---------------------------------------------------------------------------
+# _is_fatal_provider_error unit tests
+# ---------------------------------------------------------------------------
+
+class TestIsFatalProviderError:
+    def test_authentication_error_is_fatal(self):
+        class AuthenticationError(Exception):
+            pass
+        assert _is_fatal_provider_error(AuthenticationError("bad key"))
+
+    def test_connection_error_is_fatal(self):
+        assert _is_fatal_provider_error(ConnectionError("refused"))
+
+    def test_runtime_error_is_not_fatal(self):
+        assert not _is_fatal_provider_error(RuntimeError("unexpected"))
+
+    def test_value_error_is_not_fatal(self):
+        assert not _is_fatal_provider_error(ValueError("bad json"))
+
+    def test_wrapped_auth_error_is_fatal(self):
+        """litellm wraps errors inside retry/tenacity — the cause chain must
+        still be detected."""
+        class AuthenticationError(Exception):
+            pass
+
+        try:
+            try:
+                raise AuthenticationError("bad key")
+            except AuthenticationError:
+                raise RuntimeError("retry exhausted")
+        except RuntimeError as exc:
+            assert _is_fatal_provider_error(exc)
+
+    def test_timeout_is_fatal(self):
+        class Timeout(Exception):
+            pass
+        assert _is_fatal_provider_error(Timeout("60s elapsed"))
+
+
+# ---------------------------------------------------------------------------
+# compile_graph short-circuit integration tests
+# ---------------------------------------------------------------------------
+
+class TestCompileShortCircuit:
+    def test_auth_error_aborts_after_first_chunk(self, tmp_path: Path, fixtures: Path, caplog):
+        """When the first chunk fails with AuthenticationError, compile must
+        stop and NOT attempt remaining chunks."""
+        import logging as _logging
+
+        # Two markdown files → two chunks.
+        raw = tmp_path / "raw"
+        for name in ("payments.md", "auth.md"):
+            _copy_fixture(fixtures / "raw/backend/payments.md",
+                          raw / "teams/backend" / name)
+
+        schema = _load_schema(fixtures)
+
+        class _AuthFail(FakeProvider):
+            call_count = 0
+
+            def extract_json(self, system, user):
+                _AuthFail.call_count += 1
+                class AuthenticationError(Exception):
+                    pass
+                raise AuthenticationError("Invalid API key")
+
+        provider = _AuthFail(responses=[])
+
+        with caplog.at_level(_logging.ERROR, logger="lorekeep"):
+            manifest = compile_graph(
+                raw_root=raw, out_dir=tmp_path / "graph",
+                schema=schema, provider=provider,
+                cache_path=tmp_path / "cache.json", chunk_lines=60,
+            )
+
+        # Only one chunk was attempted (short-circuit).
+        assert _AuthFail.call_count == 1
+        # Manifest records the error.
+        assert manifest.errors
+        assert manifest.node_count == 0
+        # The abort event was logged.
+        assert any(
+            getattr(r, "event", "") == "compile.aborted_fatal"
+            for r in caplog.records
+        )
+
+    def test_non_fatal_error_continues_all_chunks(self, tmp_path: Path, fixtures: Path):
+        """RuntimeError (content-specific) must NOT short-circuit — the
+        remaining chunks might succeed."""
+
+        # Two markdown files → two chunks.
+        raw = tmp_path / "raw"
+        for name in ("payments.md", "auth.md"):
+            _copy_fixture(fixtures / "raw/backend/payments.md",
+                          raw / "teams/backend" / name)
+
+        schema = _load_schema(fixtures)
+
+        class _Boom(FakeProvider):
+            call_count = 0
+
+            def extract_json(self, system, user):
+                _Boom.call_count += 1
+                raise RuntimeError("unexpected content error")
+
+        provider = _Boom(responses=[])
+
+        manifest = compile_graph(
+            raw_root=raw, out_dir=tmp_path / "graph",
+            schema=schema, provider=provider,
+            cache_path=tmp_path / "cache.json", chunk_lines=60,
+        )
+
+        # Both chunks were attempted (no short-circuit for non-fatal errors).
+        assert _Boom.call_count == 2
+        assert len(manifest.errors) == 2


### PR DESCRIPTION
## What

Fixes the root causes behind 9 auto-reported GitHub issues (#158, #159, #162, #163, #164, #165, #168, #169, #175).

## Changes

### 1. ModuleNotFoundError on `lorekeep serve` (#158, #159, #175)

`mcp_server.py` imports `mcp.server.fastmcp` at module level. When the `mcp` package isn't installed, `lorekeep serve` crashes with an unhandled traceback. Now the import is wrapped in a try/except that prints an actionable error message.

### 2. AuthenticationError spam during compile (#164, #168)

Compile now short-circuits on fatal provider errors (auth, network, timeout) after the first chunk instead of retrying every remaining chunk.

### 3. Test noise and manifest_error duplicates (#162, #163, #165, #169)

- BugReportHandler skips when `LOREKEEP_BUGREPORT_TEST_MODE` is set (conftest.py enables it for all tests).
- `compile.manifest_error` added to event denylist so symptom events don't create duplicates.

## Test plan

- [x] `test_fatal_short_circuit.py` — 6 new tests
- [x] `test_bugreport.py::test_skips_in_test_mode` — env-var gating
- [x] All 681 existing tests pass
- [x] `test_core_regression.py` — 26 tests pass