### PR TITLE
fix: pin mcp<2.0 to prevent FastMCP breakage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "typer>=0.12",
   "rich>=13.7",
   "networkx>=3.2",
-  "mcp>=1.0",
+  "mcp>=1.0,<2.0",
   "platformdirs>=4.0",
 ]
 

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -615,10 +615,20 @@ def serve(
         from lorekeep.mcp_server import configure, mcp
     except ImportError as exc:
         from lorekeep.output import error
-        error(f"'lorekeep serve' requires the 'mcp' package, which is not installed: {exc}")
-        error("Fix: pip install mcp  (or: uv pip install mcp)")
+        missing = str(exc)
+        if "fastmcp" in missing.lower():
+            error("lorekeep requires mcp v1.x, but mcp v2.x is installed (FastMCP was removed).")
+            error("Fix: pip install 'mcp>=1.0,<2.0'  (or: uv pip install 'mcp>=1.0,<2.0')")
+        else:
+            error(f"'lorekeep serve' requires the 'mcp' package, which is not installed: {exc}")
+            error("Fix: pip install mcp  (or: uv pip install mcp)")
         raise typer.Exit(code=1)
-    configure(graph_dir=p["out"], allowed_ns=allowed, schema_path=p["schema"], pending_dir=p.get("pending"))
+    try:
+        configure(graph_dir=p["out"], allowed_ns=allowed, schema_path=p["schema"], pending_dir=p.get("pending"))
+    except FileNotFoundError as exc:
+        from lorekeep.output import error
+        error(str(exc))
+        raise typer.Exit(code=1)
     log.info(
         "MCP server starting transport=%s namespace_count=%s", transport, len(allowed),
         extra={"event": "mcp.start"},

--- a/src/lorekeep/mcp_server.py
+++ b/src/lorekeep/mcp_server.py
@@ -57,6 +57,11 @@ def _rebuild() -> None:
     """(Re)load the graph + schema + manifest + FTS from disk into a fresh ScopedGraph."""
     global _scope, _schema, _manifest, _fts
     facts = _state["graph_dir"] / "facts.jsonl"
+    if not facts.exists():
+        raise FileNotFoundError(
+            f"facts.jsonl not found at {facts}. "
+            "Run 'lorekeep compile' first to build the knowledge graph."
+        )
     store = GraphStore.from_jsonl(facts)
     sp = _state.get("schema_path")
     _schema = load_schema(sp) if sp else None

--- a/uv.lock
+++ b/uv.lock
@@ -1055,7 +1055,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "litellm", specifier = ">=1.40" },
-    { name = "mcp", specifier = ">=1.0" },
+    { name = "mcp", specifier = ">=1.0,<2.0" },
     { name = "mistune", specifier = ">=3.0" },
     { name = "networkx", specifier = ">=3.2" },
     { name = "platformdirs", specifier = ">=4.0" },


### PR DESCRIPTION
## What

Two fixes for `lorekeep serve` crashes found during global-install smoke testing.

### 1. mcp v2.0.0 breaking change (#178)

mcp v2.0.0 **removed `FastMCP`** (replaced by `MCPServer`). Since `pyproject.toml` declared `"mcp>=1.0"` with no upper bound, fresh installs resolved v2.0.0 and `lorekeep serve` crashed with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`.

- **Pin** `mcp>=1.0,<2.0` in `pyproject.toml`
- **Detect** the fastmcp import failure and print a targeted error message

### 2. Missing facts.jsonl crash (#180)

`lorekeep serve` on a fresh install (before `compile`) crashed with `FileNotFoundError` instead of a helpful message. Now `_rebuild()` raises a clear `FileNotFoundError` with guidance, and `serve` catches it and exits cleanly.

## Test plan

- [x] Global install from local: resolves mcp 1.29.0, FastMCP import works
- [x] `lorekeep serve` on empty graph prints actionable error, exits 1
- [x] 37 core tests pass