### PR TITLE
fix: log serve config errors instead of silently exiting

### DIFF
--- a/src/lorekeep/bugreport.py
+++ b/src/lorekeep/bugreport.py
@@ -35,6 +35,8 @@ _warned_no_token = False
 # auto-reported issue (they would just create duplicates of the root cause).
 _SKIP_EVENTS = frozenset({
     "compile.manifest_error",   # always a consequence of compile.chunk_failed
+    "serve.mcp_missing",        # user needs to install/pin mcp — not a code bug
+    "serve.no_graph",           # user needs to run compile first — not a code bug
 })
 
 

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -622,12 +622,21 @@ def serve(
         else:
             error(f"'lorekeep serve' requires the 'mcp' package, which is not installed: {exc}")
             error("Fix: pip install mcp  (or: uv pip install mcp)")
+        log.error(
+            "serve: mcp dependency missing error_type=ImportError detail=%s",
+            "fastmcp" if "fastmcp" in missing.lower() else "mcp",
+            extra={"event": "serve.mcp_missing"},
+        )
         raise typer.Exit(code=1)
     try:
         configure(graph_dir=p["out"], allowed_ns=allowed, schema_path=p["schema"], pending_dir=p.get("pending"))
     except FileNotFoundError as exc:
         from lorekeep.output import error
         error(str(exc))
+        log.error(
+            "serve: graph not built detail=%s", exc,
+            extra={"event": "serve.no_graph"},
+        )
         raise typer.Exit(code=1)
     log.info(
         "MCP server starting transport=%s namespace_count=%s", transport, len(allowed),


### PR DESCRIPTION
## Problem

The serve command's try/except blocks (added in #179 for `ImportError` and `FileNotFoundError`) printed to stderr via `output.error()` but **never emitted a log record**. This left:
- Daemon logs blind to these failures
- BugReportHandler unable to see them
- No audit trail in `lorekeep.log`

## Fix

Each caught error now also calls `log.error()` with a distinct event tag:
- `serve.mcp_missing` — mcp package not installed / wrong version
- `serve.no_graph` — facts.jsonl not found (need to compile first)

Both events are added to `_SKIP_EVENTS` in bugreport.py — they're **user-config problems** (not code bugs), so they stay visible in logs but don't create auto-reported GitHub issues.

## Test plan

- [x] 70 tests pass (core regressions + pipeline + fatal short-circuit + bugreport)