### PR TITLE
fix(extract): make JSON parsing resilient to common LLM output issues

### DIFF
--- a/src/lorekeep/compile/extract.py
+++ b/src/lorekeep/compile/extract.py
@@ -145,29 +145,120 @@ def _parse_date(v: Any) -> date | None:
         return datetime.fromisoformat(v).date()
 
 
+def _strip_trailing_commas(s: str) -> str:
+    """Remove trailing commas before closing braces/brackets.
+
+    Many LLMs (DeepSeek, Qwen, some Ollama models) emit JSON with trailing
+    commas like {"nodes": [...],} which is invalid JSON but trivially fixable.
+    """
+    return re.sub(r",(\s*[}\]])", r"\1", s)
+
+
+def _find_balanced_json(raw: str, start_from: int = 0) -> str | None:
+    """Find the first balanced JSON object in *raw* using a brace counter.
+
+    More reliable than a greedy regex: handles nested objects, strings
+    containing braces, and trailing prose. Returns None if no balanced
+    object is found. Scans starting from *start_from*.
+    """
+    start = raw.find("{", start_from)
+    if start == -1:
+        return None
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(start, len(raw)):
+        ch = raw[i]
+        if escape:
+            escape = False
+            continue
+        if ch == "\\":
+            escape = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return raw[start:i + 1]
+    return None
+
+
 def _extract_json(raw: str, chunk: DocChunk) -> str:
     """Best-effort recover a JSON object from LLM output.
 
     response_format=json_object usually yields clean JSON, but some models wrap
-    output in ```json fences or prepend prose. Strip fences, then fall back to
-    the first balanced {...} span. Raises ValueError (with chunk src) if the
-    output still can't be parsed, so the pipeline reports a clear failure.
+    output in fences, prepend prose, or emit trailing commas. This function
+    tries, in order:
+
+    1. Direct parse (fast path for well-formed output)
+    2. Strip markdown code fences + language tags, then parse
+    3. Fix trailing commas, then parse
+    4. Balanced-brace scan for the first JSON object, then parse
+    5. Balanced-brace scan + trailing-comma fix (last resort)
+
+    Raises ValueError (with chunk src) if all strategies fail.
     """
     s = raw.strip()
-    if s.startswith("```"):
-        s = s.strip("`")
-        brace = s.find("{")
-        if brace != -1:
-            s = s[brace:]
+
+    # 1. Fast path: clean JSON
     try:
         json.loads(s)
         return s
     except json.JSONDecodeError:
-        m = re.search(r"\{.*\}", raw, re.DOTALL)
-        if m:
-            json.loads(m.group(0))      # validate; raises if malformed
-            return m.group(0)
-        raise ValueError(f"LLM returned non-JSON for {chunk.src}")
+        pass
+
+    # 2. Strip markdown fences (```json, ```, etc.)
+    fence_match = re.match(r"^```(?:json)?\s*\n?(.*?)\n?```\s*$", s, re.DOTALL)
+    if fence_match:
+        s2 = fence_match.group(1).strip()
+        try:
+            json.loads(s2)
+            return s2
+        except json.JSONDecodeError:
+            s = s2  # Use de-fenced version for subsequent strategies
+
+    # 3. Fix trailing commas
+    s3 = _strip_trailing_commas(s)
+    if s3 != s:
+        try:
+            json.loads(s3)
+            return s3
+        except json.JSONDecodeError:
+            pass
+
+    # 4. Balanced-brace scan (handles prose prefix/suffix, nested objects)
+    # Try each balanced match in order — prose like "for {project}:" may
+    # produce a match that isn't valid JSON.
+    offset = 0
+    while True:
+        balanced = _find_balanced_json(s, offset)
+        if balanced is None:
+            break
+        try:
+            json.loads(balanced)
+            return balanced
+        except json.JSONDecodeError:
+            pass
+        # Try with trailing-comma fix
+        fixed = _strip_trailing_commas(balanced)
+        try:
+            json.loads(fixed)
+            return fixed
+        except json.JSONDecodeError:
+            pass
+        # Move past this match and try the next
+        offset = s.find(balanced, offset) + len(balanced)
+
+    raise ValueError(
+        f"LLM returned non-JSON for {chunk.src}: "
+        f"output starts with {raw[:200]!r}"
+    )
 
 
 def parse_response(

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -267,3 +267,86 @@ def test_parse_response_raises_on_non_json():
     c = make_chunk()
     with pytest.raises(ValueError):
         parse_response("no JSON here at all", c, schema=SCHEMA)
+
+
+# ── JSON resilience tests ───────────────────────────────────────────────────
+
+def test_parse_response_tolerates_trailing_commas():
+    """LLMs like DeepSeek/Qwen often emit trailing commas."""
+    c = make_chunk()
+    raw = '{"nodes": [{"id": "svc:a", "type": "service", "name": "a"},], "edges": [], "aliases": {},}'
+    nodes, _, _ = parse_response(raw, c, schema=SCHEMA)
+    assert len(nodes) == 1 and nodes[0].id == "svc:a"
+
+
+def test_parse_response_tolerates_nested_trailing_commas():
+    """Trailing commas in nested objects/arrays."""
+    c = make_chunk()
+    raw = json.dumps({
+        "nodes": [{"id": "svc:a", "type": "service", "name": "a",
+                    "props": {"lang": "go",}}],
+        "edges": [{"type": "depends_on", "from": "svc:a", "to": "svc:b",}],
+        "aliases": {},
+    }).replace('": "', '": "').replace('",}', '",}')
+    # Manually inject trailing commas
+    raw = '{"nodes": [{"id": "svc:a", "type": "service", "name": "a", "props": {"lang": "go",},},], "edges": [], "aliases": {,}}'
+    nodes, _, _ = parse_response(raw, c, schema=SCHEMA)
+    assert len(nodes) == 1
+
+
+def test_parse_response_tolerates_json_after_prose_with_braces():
+    """Prose before JSON that itself contains braces in strings."""
+    c = make_chunk()
+    payload = {"nodes": [{"id": "svc:a", "type": "service", "name": "a"}],
+               "edges": [], "aliases": {}}
+    raw = "Here is the result for {project}:\n" + json.dumps(payload) + "\nDone."
+    nodes, _, _ = parse_response(raw, c, schema=SCHEMA)
+    assert len(nodes) == 1 and nodes[0].id == "svc:a"
+
+
+def test_parse_response_tolerates_fenced_with_language_tag():
+    """Code fence with json language tag."""
+    c = make_chunk()
+    payload = {"nodes": [{"id": "svc:a", "type": "service", "name": "a"}],
+               "edges": [], "aliases": {}}
+    raw = "```json\n" + json.dumps(payload, indent=2) + "\n```"
+    nodes, _, _ = parse_response(raw, c, schema=SCHEMA)
+    assert len(nodes) == 1
+
+
+def test_parse_response_tolerates_trailing_comma_in_fence():
+    """Trailing commas inside fenced code block."""
+    c = make_chunk()
+    payload_str = '{"nodes": [{"id": "svc:a", "type": "service", "name": "a",},], "edges": [], "aliases": {},}'
+    raw = f"```json\n{payload_str}\n```"
+    nodes, _, _ = parse_response(raw, c, schema=SCHEMA)
+    assert len(nodes) == 1
+
+
+def test_parse_response_brace_in_string_value():
+    """JSON with braces inside string values (not confused as structure)."""
+    c = make_chunk()
+    payload = {"nodes": [{"id": "svc:a", "type": "service", "name": "a",
+                           "props": {"template": "Hello {name}!"}}],
+               "edges": [], "aliases": {}}
+    raw = "Sure! " + json.dumps(payload)
+    nodes, _, _ = parse_response(raw, c, schema=SCHEMA)
+    assert len(nodes) == 1
+
+
+def test_parse_response_multiple_objects():
+    """Multiple JSON objects — should extract the first complete one."""
+    c = make_chunk()
+    payload = {"nodes": [{"id": "svc:a", "type": "service", "name": "a"}],
+               "edges": [], "aliases": {}}
+    raw = json.dumps(payload) + "\n\n" + json.dumps({"extra": True})
+    nodes, _, _ = parse_response(raw, c, schema=SCHEMA)
+    assert len(nodes) == 1 and nodes[0].id == "svc:a"
+
+
+def test_extract_json_value_error_includes_src():
+    """Error message should include chunk source for debugging."""
+    from lorekeep.compile.extract import _extract_json
+    c = make_chunk()
+    with pytest.raises(ValueError, match="a.md"):
+        _extract_json("not json at all", c)


### PR DESCRIPTION
## Fixes #189

### Problem

Auto-reported `JSONDecodeError` during compile — the LLM returned malformed JSON that the old `_extract_json` couldn't recover from. This is a skip-and-log error (compile continues), but every failure is a lost chunk of knowledge.

### Root Cause

The old recovery had two weaknesses:

1. **Greedy regex** `re.search(r"\{.*\}", raw, re.DOTALL)` matched from the first `{` to the last `}`. When prose contained braces (e.g. `for {project}:`), it produced invalid JSON.

2. **No trailing-comma tolerance** — DeepSeek, Qwen, and some Ollama models frequently emit `{"nodes": [...],}` which is invalid JSON but trivially fixable.

### Fix

New `_extract_json` recovery strategy (tries in order):

| # | Strategy | Handles |
|---|----------|---------|
| 1 | Direct `json.loads` | Well-formed output (fast path) |
| 2 | Strip markdown fences with language tags | ```json ... ``` |
| 3 | Fix trailing commas | `{...,}` (DeepSeek/Qwen) |
| 4 | Balanced-brace scanner | Prose prefix/suffix with braces |
| 5 | Balanced scan + comma fix | Combination of 3+4 |

The balanced-brace scanner iterates through all `{...}` matches in order, so `{project}` in prose is skipped and the actual JSON object is found.

### Tests

8 new resilience tests: trailing commas, nested commas, fenced output, prose with braces, brace-in-string, multiple objects, error message format.