### PR TITLE
feat: persist agent insights with provenance (#36)

### DIFF
--- a/.lorekeep/schema.json
+++ b/.lorekeep/schema.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "common_node_props": {
     "summary": "string",
     "description": "string"
@@ -19,7 +19,8 @@
     "project": {"props": {"name": "string", "status": "string", "start_date": "string"}, "label": "Project", "plural": "Projects", "display_prop": "name"},
     "decision": {"props": {"title": "string", "status": "string", "decided_on": "string"}, "label": "Decision", "plural": "Decisions", "display_prop": "title"},
     "team": {"props": {"name": "string", "org": "string"}, "label": "Team", "plural": "Teams", "display_prop": "name"},
-    "document": {"props": {"title": "string", "kind": "string"}, "label": "Document", "plural": "Documents", "display_prop": "title"}
+    "document": {"props": {"title": "string", "kind": "string"}, "label": "Document", "plural": "Documents", "display_prop": "title"},
+    "insight": {"props": {"title": "string", "insight_type": "string", "body": "string"}, "label": "Insight", "plural": "Insights", "display_prop": "title"}
   },
   "edge_types": {
     "depends_on": {"from": "service", "to": "service", "props": {}, "label": "Depends on", "inverse_label": "Depended on by"},
@@ -38,8 +39,8 @@
     "collaborates_with": {"from": "person", "to": "person", "props": {}, "label": "Collaborates with", "inverse_label": "Collaborates with"},
     "prefers": {"from": "person", "to": "preference", "props": {}, "label": "Prefers", "inverse_label": "Preferred by"},
     "relates_to": {
-      "from": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"],
-      "to": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"],
+      "from": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document", "insight"],
+      "to": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document", "insight"],
       "props": {},
       "label": "Relates to",
       "inverse_label": "Relates to"

--- a/src/lorekeep/compile/resolve.py
+++ b/src/lorekeep/compile/resolve.py
@@ -367,6 +367,18 @@ def merge_journals(
             result.quarantined.append((entry, "low confidence"))
             continue
 
+        # Stamp agent provenance onto the fact so it survives the merge.
+        # Compiled facts have src=["path:line", ...]; agent-proposed facts
+        # carry their metadata here instead.
+        fact = fact.model_copy(update={
+            "provenance": {
+                "agent": entry.agent,
+                "confidence": entry.confidence,
+                "proposed_at": entry.proposed_at,
+                **({"device": entry.device} if entry.device else {}),
+            },
+        })
+
         if schema is not None and fact.kind == "node":
             if not schema.is_valid_node_type(fact.type):
                 result.quarantined.append((entry, f"unknown node type: {fact.type}"))

--- a/src/lorekeep/defaults.py
+++ b/src/lorekeep/defaults.py
@@ -51,6 +51,7 @@ DEFAULT_SCHEMA_V3 = {
         "decision": {"props": {"title": "string", "status": "string", "decided_on": "string"}},
         "team": {"props": {"name": "string", "org": "string"}},
         "document": {"props": {"title": "string", "kind": "string"}},
+        "insight": {"props": {"title": "string", "insight_type": "string", "body": "string"}},
     },
     "edge_types": {
         # entity-centric (team)
@@ -73,8 +74,8 @@ DEFAULT_SCHEMA_V3 = {
         "prefers": {"from": "person", "to": "preference"},
         # generic / doc
         "relates_to": {
-            "from": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"],
-            "to": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"],
+            "from": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document", "insight"],
+            "to": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document", "insight"],
         },
         "documents": {
             "from": "document",
@@ -100,6 +101,7 @@ _NODE_DISPLAY = {
     "decision": ("Decision", "Decisions", "title"),
     "team": ("Team", "Teams", "name"),
     "document": ("Document", "Documents", "title"),
+    "insight": ("Insight", "Insights", "title"),
 }
 
 _EDGE_DISPLAY = {
@@ -124,7 +126,7 @@ _EDGE_DISPLAY = {
 
 DEFAULT_SCHEMA = {
     **DEFAULT_SCHEMA_V3,
-    "version": 4,
+    "version": 5,
     "common_node_props": {
         "summary": "string",
         "description": "string",

--- a/src/lorekeep/models.py
+++ b/src/lorekeep/models.py
@@ -42,6 +42,7 @@ class Node(BaseModel):
     valid_to: date | None = None
     props: dict[str, Any] = Field(default_factory=dict)
     src: tuple[str, ...] = Field(default_factory=tuple)
+    provenance: dict[str, Any] | None = None
 
     def to_json_line(self) -> str:
         d = self.model_dump(mode="json", by_alias=True)
@@ -60,6 +61,7 @@ class Edge(BaseModel):
     valid_to: date | None = None
     props: dict[str, Any] = Field(default_factory=dict)
     src: tuple[str, ...] = Field(default_factory=tuple)
+    provenance: dict[str, Any] | None = None
 
     def to_json_line(self) -> str:
         d = self.model_dump(mode="json", by_alias=True)

--- a/tests/test_compile_cli.py
+++ b/tests/test_compile_cli.py
@@ -196,7 +196,7 @@ def test_v4_compile_wiki_check_end_to_end(
     assert checked.exit_code == 0, checked.output
     assert regenerated.exit_code == 0, regenerated.output
     manifest = json.loads((home / "graph" / "manifest.json").read_text())
-    assert manifest["schema_version"] == 4
+    assert manifest["schema_version"] == 5
     assert manifest["content_quality"]["node_summary_coverage"] == 1.0
     assert manifest["content_quality"]["edge_description_coverage"] == 1.0
     page = (home / "wiki" / "svc-payments-api.md").read_text()

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -6,7 +6,7 @@ from lorekeep.config import Config
 
 def test_default_schema_is_valid_json_v4():
     d = DEFAULT_SCHEMA
-    assert d["version"] == 4
+    assert d["version"] == 5
     assert "service" in d["node_types"]
     assert "person" in d["node_types"]
     assert "domain" in d["node_types"]          # replaced concept
@@ -26,6 +26,12 @@ def test_default_schema_is_valid_json_v4():
     assert d["node_types"]["decision"]["display_prop"] == "title"
     assert d["edge_types"]["depends_on"]["label"] == "Depends on"
     assert d["edge_types"]["depends_on"]["inverse_label"] == "Depended on by"
+    # insight node type (schema v5 — agent-synthesized knowledge)
+    assert "insight" in d["node_types"]
+    assert d["node_types"]["insight"]["display_prop"] == "title"
+    assert d["node_types"]["insight"]["plural"] == "Insights"
+    assert "insight" in d["edge_types"]["relates_to"]["from"]
+    assert "insight" in d["edge_types"]["relates_to"]["to"]
     json.dumps(d)  # serializable
 
 

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -27,7 +27,7 @@ def test_init_creates_home(tmp_path: Path, monkeypatch):
     assert (home / "graph").is_dir()
     import json
     schema = json.loads((home / "schema.json").read_text())
-    assert schema["version"] == 4
+    assert schema["version"] == 5
 
 
 def test_init_creates_about_template(tmp_path: Path, monkeypatch):

--- a/tests/test_merge_journals.py
+++ b/tests/test_merge_journals.py
@@ -118,6 +118,54 @@ def test_accepted_entries_can_be_replayed_after_raw_compile():
     assert r.merge_count == 0
 
 
+# ── Agent provenance ─────────────────────────────────────────────────────
+
+
+def test_provenance_stamped_on_new_node_from_journal():
+    """JournalEntry metadata survives into the merged Node.provenance field."""
+    entry = _entry(_node_fact(), confidence=0.9)
+    entry = entry.model_copy(update={"agent": "claude-code", "device": "laptop"})
+    r = merge_journals([], [], [entry])
+    node = [n for n in r.nodes if n.id == "svc:new"][0]
+    assert node.provenance is not None
+    assert node.provenance["agent"] == "claude-code"
+    assert node.provenance["confidence"] == 0.9
+    assert node.provenance["proposed_at"] == "2026-06-28T00:00:00Z"
+    assert node.provenance["device"] == "laptop"
+
+
+def test_provenance_stamped_on_edge_from_journal():
+    """JournalEntry metadata survives into the merged Edge.provenance field."""
+    nodes = [_node(), _node(id="svc:b")]
+    entry = _entry(_edge_fact(), confidence=0.85)
+    entry = entry.model_copy(update={"agent": "cursor"})
+    r = merge_journals(nodes, [], [entry])
+    edge = [e for e in r.edges if e.type == "depends_on"][0]
+    assert edge.provenance is not None
+    assert edge.provenance["agent"] == "cursor"
+    assert edge.provenance["confidence"] == 0.85
+
+
+def test_provenance_none_for_existing_curator_nodes():
+    """Curator (compiled) nodes that don't come through the journal have no provenance."""
+    curator_node = _node()
+    r = merge_journals([curator_node], [], [])
+    node = [n for n in r.nodes if n.id == "svc:a"][0]
+    assert node.provenance is None
+
+
+def test_provenance_skips_empty_device():
+    """Device is omitted from provenance when blank (not stored as empty string)."""
+    entry = _entry(_node_fact(), confidence=0.9)
+    r = merge_journals([], [], [entry])
+    node = [n for n in r.nodes if n.id == "svc:new"][0]
+    assert node.provenance is not None
+    assert "device" not in node.provenance
+
+
+# ── Replay / merge interactions ─────────────────────────────────────────
+
+
 def test_replay_does_not_overwrite_fresh_curator_properties():
     raw = Node(
         id="svc:new", type="service", ns=("backend",),

--- a/tests/test_schema_upgrade.py
+++ b/tests/test_schema_upgrade.py
@@ -40,7 +40,7 @@ def test_upgrade_stock_v3_creates_v3_backup(tmp_path):
 
     assert result["changed"] is True
     assert result["from"] == 3
-    assert result["to"] == 4
+    assert result["to"] == 5
     assert json.loads(path.read_text()) == DEFAULT_SCHEMA
     assert json.loads((tmp_path / "schema.v3.backup.json").read_text()) == DEFAULT_SCHEMA_V3
 
@@ -88,5 +88,5 @@ def test_schema_upgrade_cli_upgrades_existing_home(tmp_path, monkeypatch):
     result = CliRunner().invoke(app, ["schema", "upgrade"])
 
     assert result.exit_code == 0, result.output
-    assert "v2" in result.output and "v4" in result.output
+    assert "v2" in result.output and "v5" in result.output
     assert json.loads((home / "schema.json").read_text()) == DEFAULT_SCHEMA

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -742,7 +742,7 @@ class TestHumanReadableProjection:
         assert "## Goals and projects" in index
         assert "## People and teams" in index
         assert "Graph schema is out of date" in index
-        assert "schema v3" in index and "schema is v4" in index
+        assert "schema v3" in index and "schema is v5" in index
         assert "## Goals" in catalog
         assert "## People" in catalog
         assert "[[person-manh|Mạnh]] — Người duy trì Lorekeep." in catalog


### PR DESCRIPTION
## Summary

Implements layers 1+2 of issue #36 — persisting query-derived insights back into the graph.

### Layer 1: Provenance field on Node/Edge
When `merge_journals` merges a `JournalEntry` into the graph, the entry's `agent`, `confidence`, `proposed_at`, and `device` metadata were silently discarded — only `fact.src` survived. This adds an optional `provenance: dict[str, Any] | None` field to both `Node` and `Edge`, stamped during merge so agent-origin facts carry their provenance into `facts.jsonl` and wiki.

### Layer 2: Insight node type (schema v5)
Adds an `insight` node type (`title`, `insight_type`, `body`) to the default schema. Agents can now propose insight nodes via the existing `propose_change` MCP tool — no new tool needed (consistent with PR #196's tool consolidation). Insights participate in `relates_to` edges, so they can link to any entity.

### What this does NOT do
Layer 3 (a dedicated MCP tool for insight creation) was deliberately skipped — the existing `propose_change` tool already supports creating insight nodes, and adding another write tool goes against the consolidation direction.

## Changes
- `models.py`: Added `provenance: dict[str, Any] | None = None` to Node and Edge
- `compile/resolve.py`: Stamp provenance from JournalEntry after confidence gate
- `defaults.py`: Added `insight` node type to `DEFAULT_SCHEMA_V3`, `_NODE_DISPLAY`, `relates_to`; bumped version 4→5
- `.lorekeep/schema.json`: Mirrored insight type + version bump
- Tests: 4 new provenance tests, insight type assertions, version assertions updated across 5 test files

## Test plan
- [x] `test_merge_journals.py` — 4 new tests verify provenance stamped on nodes/edges, None for curator facts, device omitted when blank
- [x] `test_defaults.py` — insight type in schema, display metadata, relates_to participation
- [x] `test_schema_upgrade.py` — v3→v5 upgrade path verified
- [x] `test_wiki.py` — stale schema warning reflects v5
- [x] Full suite: 1210 passed, 5 pre-existing macOS failures (Rich console, `/proc/self/fd`, `timeout` binary)

Closes #36
