### PR TITLE
revert: remove insight node type, keep provenance

### DIFF
--- a/.lorekeep/schema.json
+++ b/.lorekeep/schema.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 4,
   "common_node_props": {
     "summary": "string",
     "description": "string"
@@ -19,8 +19,7 @@
     "project": {"props": {"name": "string", "status": "string", "start_date": "string"}, "label": "Project", "plural": "Projects", "display_prop": "name"},
     "decision": {"props": {"title": "string", "status": "string", "decided_on": "string"}, "label": "Decision", "plural": "Decisions", "display_prop": "title"},
     "team": {"props": {"name": "string", "org": "string"}, "label": "Team", "plural": "Teams", "display_prop": "name"},
-    "document": {"props": {"title": "string", "kind": "string"}, "label": "Document", "plural": "Documents", "display_prop": "title"},
-    "insight": {"props": {"title": "string", "insight_type": "string", "body": "string"}, "label": "Insight", "plural": "Insights", "display_prop": "title"}
+    "document": {"props": {"title": "string", "kind": "string"}, "label": "Document", "plural": "Documents", "display_prop": "title"}
   },
   "edge_types": {
     "depends_on": {"from": "service", "to": "service", "props": {}, "label": "Depends on", "inverse_label": "Depended on by"},
@@ -39,8 +38,8 @@
     "collaborates_with": {"from": "person", "to": "person", "props": {}, "label": "Collaborates with", "inverse_label": "Collaborates with"},
     "prefers": {"from": "person", "to": "preference", "props": {}, "label": "Prefers", "inverse_label": "Preferred by"},
     "relates_to": {
-      "from": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document", "insight"],
-      "to": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document", "insight"],
+      "from": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"],
+      "to": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"],
       "props": {},
       "label": "Relates to",
       "inverse_label": "Relates to"

--- a/src/lorekeep/defaults.py
+++ b/src/lorekeep/defaults.py
@@ -51,7 +51,6 @@ DEFAULT_SCHEMA_V3 = {
         "decision": {"props": {"title": "string", "status": "string", "decided_on": "string"}},
         "team": {"props": {"name": "string", "org": "string"}},
         "document": {"props": {"title": "string", "kind": "string"}},
-        "insight": {"props": {"title": "string", "insight_type": "string", "body": "string"}},
     },
     "edge_types": {
         # entity-centric (team)
@@ -74,8 +73,8 @@ DEFAULT_SCHEMA_V3 = {
         "prefers": {"from": "person", "to": "preference"},
         # generic / doc
         "relates_to": {
-            "from": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document", "insight"],
-            "to": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document", "insight"],
+            "from": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"],
+            "to": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"],
         },
         "documents": {
             "from": "document",
@@ -101,7 +100,6 @@ _NODE_DISPLAY = {
     "decision": ("Decision", "Decisions", "title"),
     "team": ("Team", "Teams", "name"),
     "document": ("Document", "Documents", "title"),
-    "insight": ("Insight", "Insights", "title"),
 }
 
 _EDGE_DISPLAY = {
@@ -126,7 +124,7 @@ _EDGE_DISPLAY = {
 
 DEFAULT_SCHEMA = {
     **DEFAULT_SCHEMA_V3,
-    "version": 5,
+    "version": 4,
     "common_node_props": {
         "summary": "string",
         "description": "string",

--- a/tests/test_compile_cli.py
+++ b/tests/test_compile_cli.py
@@ -196,7 +196,7 @@ def test_v4_compile_wiki_check_end_to_end(
     assert checked.exit_code == 0, checked.output
     assert regenerated.exit_code == 0, regenerated.output
     manifest = json.loads((home / "graph" / "manifest.json").read_text())
-    assert manifest["schema_version"] == 5
+    assert manifest["schema_version"] == 4
     assert manifest["content_quality"]["node_summary_coverage"] == 1.0
     assert manifest["content_quality"]["edge_description_coverage"] == 1.0
     page = (home / "wiki" / "svc-payments-api.md").read_text()

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -6,7 +6,7 @@ from lorekeep.config import Config
 
 def test_default_schema_is_valid_json_v4():
     d = DEFAULT_SCHEMA
-    assert d["version"] == 5
+    assert d["version"] == 4
     assert "service" in d["node_types"]
     assert "person" in d["node_types"]
     assert "domain" in d["node_types"]          # replaced concept
@@ -26,12 +26,6 @@ def test_default_schema_is_valid_json_v4():
     assert d["node_types"]["decision"]["display_prop"] == "title"
     assert d["edge_types"]["depends_on"]["label"] == "Depends on"
     assert d["edge_types"]["depends_on"]["inverse_label"] == "Depended on by"
-    # insight node type (schema v5 — agent-synthesized knowledge)
-    assert "insight" in d["node_types"]
-    assert d["node_types"]["insight"]["display_prop"] == "title"
-    assert d["node_types"]["insight"]["plural"] == "Insights"
-    assert "insight" in d["edge_types"]["relates_to"]["from"]
-    assert "insight" in d["edge_types"]["relates_to"]["to"]
     json.dumps(d)  # serializable
 
 

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -27,7 +27,7 @@ def test_init_creates_home(tmp_path: Path, monkeypatch):
     assert (home / "graph").is_dir()
     import json
     schema = json.loads((home / "schema.json").read_text())
-    assert schema["version"] == 5
+    assert schema["version"] == 4
 
 
 def test_init_creates_about_template(tmp_path: Path, monkeypatch):

--- a/tests/test_schema_upgrade.py
+++ b/tests/test_schema_upgrade.py
@@ -40,7 +40,7 @@ def test_upgrade_stock_v3_creates_v3_backup(tmp_path):
 
     assert result["changed"] is True
     assert result["from"] == 3
-    assert result["to"] == 5
+    assert result["to"] == 4
     assert json.loads(path.read_text()) == DEFAULT_SCHEMA
     assert json.loads((tmp_path / "schema.v3.backup.json").read_text()) == DEFAULT_SCHEMA_V3
 
@@ -88,5 +88,5 @@ def test_schema_upgrade_cli_upgrades_existing_home(tmp_path, monkeypatch):
     result = CliRunner().invoke(app, ["schema", "upgrade"])
 
     assert result.exit_code == 0, result.output
-    assert "v2" in result.output and "v5" in result.output
+    assert "v2" in result.output and "v4" in result.output
     assert json.loads((home / "schema.json").read_text()) == DEFAULT_SCHEMA

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -742,7 +742,7 @@ class TestHumanReadableProjection:
         assert "## Goals and projects" in index
         assert "## People and teams" in index
         assert "Graph schema is out of date" in index
-        assert "schema v3" in index and "schema is v5" in index
+        assert "schema v3" in index and "schema is v4" in index
         assert "## Goals" in catalog
         assert "## People" in catalog
         assert "[[person-manh|Mạnh]] — Người duy trì Lorekeep." in catalog


### PR DESCRIPTION
## Summary

Reverts the `insight` node type and schema version bump (v5 → v4) from PR #202 while keeping the `provenance` field on Node/Edge.

### Why revert

`insight` is structurally identical to a regular Node with free-text props (`body`). It doesn't add queryable graph structure beyond what a structured edge would. The field was shipped without:
- Agent guidance (snippet doesn't mention it)
- Wiki rendering (provenance not displayed)
- A real use case proving value

Better to revert now and revisit if a concrete agent workflow emerges.

### What stays

- `provenance` field on Node/Edge (from the same commit in #202)
- Provenance stamping in `merge_journals`

## Test plan
- [x] 35 targeted tests pass (defaults, schema_upgrade, merge_journals, init_cli)

Refs #36
