### PR TITLE
chore: gitignore coding-agent local config dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,16 @@
 *.sqlite
 *.sqlite-*
 
-.mcp.json
-opencode.json
-.opencode/
+# Coding-agent local wiring (generated per checkout; never committed)
+/.claude/
+/.codex/
+/.cursor/
+/.opencode/
+/.grok/
+/.qoder/
+/.mcp.json
+/config.toml
+/opencode.json
 
 # Python
 __pycache__/


### PR DESCRIPTION
## Summary

The `.gitignore` was missing entries for coding-agent config directories that get generated per checkout (`.claude/`, `.codex/`, `.cursor/`, `.grok/`, `.qoder/`) and config files (`.mcp.json`, `config.toml`, `opencode.json`). These should never be committed — they are device/agent-specific wiring.

## Changes

- Added `.claude/`, `.codex/`, `.cursor/`, `.grok/`, `.qoder/` (with leading `/` to anchor at repo root)
- Added `config.toml`, `.mcp.json`, `opencode.json`
- Used root-anchored paths (`/`) so they only match at repo root, not inside subdirectories
- Cleaned up the old flat entries (`.mcp.json`, `opencode.json`, `.opencode/`)