### PR TITLE
feat(resolve): graph-native entity dedup via same_as edges

### DIFF
--- a/docs/architecture/serve-mcp.md
+++ b/docs/architecture/serve-mcp.md
@@ -1,6 +1,6 @@
 # Serve and MCP architecture
 
-`mcp_server.py` exposes one local graph through FastMCP. The seven tool functions
+`mcp_server.py` exposes one local graph through FastMCP. The eight tool functions
 remain plain Python callables so diagnostics and tests exercise the same routing
 without starting a transport.
 
@@ -82,6 +82,14 @@ endpoint, property-container, and scope checks, then namespace-enforced journal
 append. Complete Pydantic/schema validation is repeated/deferred at resolve.
 Update replaces the complete props map of the current visible fact; it is not a
 patch operation.
+
+### `merge_entities(from_id, to_id, reason="")`
+
+Declares that two nodes are the same entity. Creates a `same_as` edge
+(`from`=alias, `to`=canonical) in the pending journal at confidence 1.0.
+On resolve, the alias node merges into the canonical node, and the canonical
+node persists `props.merged_ids` so the decision survives future compiles.
+Cross-type merges are blocked.
 
 ### `review_note(kind, description, fact_ids=None)`
 

--- a/src/lorekeep/compile/extract.py
+++ b/src/lorekeep/compile/extract.py
@@ -67,6 +67,16 @@ TEMPORAL_RULE = (
     "both endpoint service nodes remain open."
 )
 
+ENTITY_RESOLUTION_RULE = (
+    "Entity resolution rule: when you recognize that two extracted nodes refer to "
+    "the same real-world entity (e.g. 'person:user' and 'person:manhpt1' are the "
+    "same person, or 'svc:api-gw' and 'svc:api-gateway' are the same service), "
+    "emit a same_as edge (from=alias_id, to=canonical_id). Choose the more "
+    "specific or human-readable id as canonical (to). Only use same_as for "
+    "true identity — never for mere relationships (use depends_on, relates_to, "
+    "etc. for those)."
+)
+
 # Subject-centric extraction for the personal namespace: anchor on the person,
 # capture role/skill/domain/goal/preference, link to team entities cross-ns.
 SUBJECT_PROMPT = (
@@ -119,6 +129,7 @@ def build_system_prompt(
         OUTPUT_LANGUAGE_RULE.format(language=language),
         ALTITUDE_RULE,
         TEMPORAL_RULE,
+        ENTITY_RESOLUTION_RULE,
         f"Allowed node_types and preferred props: {node_types}",
         f"Allowed edge_types: {edge_types}",
     ]

--- a/src/lorekeep/compile/resolve.py
+++ b/src/lorekeep/compile/resolve.py
@@ -10,9 +10,12 @@ the existing graph with priority: raw/ > import > agent-propose.
 from __future__ import annotations
 
 import json
+import logging
 import re
 import unicodedata
 from dataclasses import dataclass, field
+
+log = logging.getLogger("lorekeep.resolve")
 
 from lorekeep.models import Edge, JournalEntry, Node, Schema
 
@@ -106,6 +109,47 @@ def _normalize_text(value: str) -> str:
         if part.strip()
     ]
     return "\n\n".join(paragraphs)
+
+
+def _extract_same_as_aliases(
+    nodes: list[Node], edges: list[Edge],
+) -> dict[str, str]:
+    """Read ``same_as`` edges and ``props.merged_ids`` → ``{alias_id: canonical_id}``.
+
+    ``same_as`` edges express explicit merge decisions stored in the graph.
+    ``props.merged_ids`` persists those decisions across compiles (the raw
+    source does not carry them, so the resolved graph must remember).
+
+    Cross-type merges are blocked: a ``person`` can never merge into a
+    ``service`` even if a ``same_as`` edge connects them.
+    """
+    node_types = {n.id: n.type for n in nodes}
+    result: dict[str, str] = {}
+
+    # 1) same_as edges: from = alias, to = canonical
+    for edge in edges:
+        if edge.type != "same_as":
+            continue
+        from_type = node_types.get(edge.from_)
+        to_type = node_types.get(edge.to)
+        if from_type and to_type and from_type != to_type:
+            log.warning(
+                "same_as cross-type blocked: %s (%s) → %s (%s)",
+                edge.from_, from_type, edge.to, to_type,
+            )
+            continue
+        result[edge.from_] = edge.to
+
+    # 2) props.merged_ids: canonical node remembers its absorbed aliases
+    for node in nodes:
+        merged_ids = node.props.get("merged_ids")
+        if not isinstance(merged_ids, list):
+            continue
+        for mid in merged_ids:
+            if isinstance(mid, str) and mid != node.id:
+                result.setdefault(mid, node.id)
+
+    return result
 
 
 def _richer_summary(left: object, right: object) -> object:
@@ -203,7 +247,12 @@ def resolve(
                 ))
         nodes = valid_nodes
 
-    alias_map = _build_alias_map(nodes, name_aliases, aliases_map)
+    # Graph-native dedup: same_as edges + persisted merged_ids
+    same_as_map = _extract_same_as_aliases(nodes, edges)
+    # explicit aliases_map (caller) wins over same_as, same_as wins over auto
+    combined_explicit = {**same_as_map, **(aliases_map or {})}
+
+    alias_map = _build_alias_map(nodes, name_aliases, combined_explicit)
 
     # collapse nodes
     canon_nodes: dict[str, Node] = {}
@@ -230,6 +279,25 @@ def resolve(
             # normalize stored node id to the canonical key so node identity and
             # dict key can never diverge (covers explicit_map to a non-node id)
             canon_nodes[cid] = nd if nd.id == cid else nd.model_copy(update={"id": cid})
+
+    # Persist merged_ids: canonical node remembers which aliases it absorbed.
+    # This survives across compiles — next compile starts from raw/ and may
+    # re-create alias nodes; resolve reads merged_ids to re-apply the merge.
+    canon_to_origins: dict[str, list[str]] = {}
+    for nd in nodes:
+        cid = _canonical(nd.id, alias_map)
+        if cid != nd.id:
+            canon_to_origins.setdefault(cid, []).append(nd.id)
+    for cid, origins in canon_to_origins.items():
+        if cid not in canon_nodes:
+            continue
+        node = canon_nodes[cid]
+        existing = node.props.get("merged_ids")
+        existing_list = existing if isinstance(existing, list) else []
+        all_merged = sorted(set(str(x) for x in existing_list) | set(origins))
+        if all_merged != existing_list:
+            updated_props = {**node.props, "merged_ids": all_merged}
+            canon_nodes[cid] = node.model_copy(update={"props": updated_props})
 
     out_nodes = [canon_nodes[node_id] for node_id in sorted(canon_nodes)]
     node_ids = set(canon_nodes.keys())
@@ -260,7 +328,7 @@ def resolve(
             quarantined.append((ed.model_dump(mode="json", by_alias=True),
                                 "self-loop"))
             continue
-        if schema is not None:
+        if schema is not None and ed.type != "same_as":
             from_type = canon_nodes[f].type
             to_type = canon_nodes[t].type
             if not schema.is_valid_edge_endpoints(ed.type, from_type, to_type):
@@ -384,7 +452,7 @@ def merge_journals(
                 result.quarantined.append((entry, f"unknown node type: {fact.type}"))
                 continue
 
-        if schema is not None and fact.kind == "edge":
+        if schema is not None and fact.kind == "edge" and fact.type != "same_as":
             from_node = nodes_by_id.get(fact.from_)
             to_node = nodes_by_id.get(fact.to)
             if (

--- a/src/lorekeep/defaults.py
+++ b/src/lorekeep/defaults.py
@@ -80,6 +80,11 @@ DEFAULT_SCHEMA_V3 = {
             "from": "document",
             "to": ["service", "project", "decision", "domain"],
         },
+        # entity resolution: merge alias nodes into canonical
+        "same_as": {
+            "from": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"],
+            "to": ["person", "service", "project", "decision", "team", "domain", "skill", "role", "goal", "document"],
+        },
     },
 }
 
@@ -120,6 +125,7 @@ _EDGE_DISPLAY = {
     "prefers": ("Prefers", "Preferred by"),
     "relates_to": ("Relates to", "Relates to"),
     "documents": ("Documents", "Documented by"),
+    "same_as": ("Same as", "Alias of"),
 }
 
 DEFAULT_SCHEMA = {

--- a/src/lorekeep/mcp_server.py
+++ b/src/lorekeep/mcp_server.py
@@ -356,6 +356,40 @@ def propose_change(
 
 
 @mcp.tool()
+def merge_entities(from_id: str, to_id: str, reason: str = "") -> dict:
+    """Declare that two nodes are the same entity (from_id is an alias of to_id).
+
+    Creates a ``same_as`` edge in the pending journal. On the next resolve,
+    ``from_id`` merges into ``to_id`` (``to_id`` is canonical). Cross-type
+    merges are blocked. The merge decision persists in the graph via
+    ``props.merged_ids`` on the canonical node, surviving future compiles.
+    """
+    scoped = _require()
+    from_node = scoped.get_node(from_id)
+    if from_node is None:
+        return {"error": f"node not found or out of scope: {from_id}"}
+    to_node = scoped.get_node(to_id)
+    if to_node is None:
+        return {"error": f"node not found or out of scope: {to_id}"}
+    if from_node.type != to_node.type:
+        return {
+            "error": f"cross-type merge blocked: {from_id} ({from_node.type}) "
+            f"≠ {to_id} ({to_node.type})",
+        }
+    return _write_journal(
+        {
+            "kind": "edge",
+            "id": "",
+            "type": "same_as",
+            "from": from_id,
+            "to": to_id,
+            "props": {"description": reason} if reason else {},
+        },
+        confidence=1.0,
+    )
+
+
+@mcp.tool()
 def review_note(
     kind: Literal["contradiction", "improvement"],
     description: str,

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -102,7 +102,7 @@ def test_mcp_reference_names_the_exact_runtime_surface() -> None:
     tools = asyncio.run(mcp_server.mcp.list_tools())
     resources = asyncio.run(mcp_server.mcp.list_resources())
 
-    assert len(tools) == 7
+    assert len(tools) == 8
     for tool in tools:
         assert f"`{tool.name}" in reference
     for resource in resources:

--- a/tests/test_mcp_surface.py
+++ b/tests/test_mcp_surface.py
@@ -38,14 +38,14 @@ def _entries(pending: Path) -> list[dict]:
     return result
 
 
-def test_server_exposes_exactly_seven_composable_tools():
+def test_server_exposes_exactly_eight_composable_tools():
     tools = _tool_map()
 
     assert tuple(tools) == (
         "search", "get_node", "neighbors", "temporal_query", "context",
-        "propose_change", "review_note",
+        "propose_change", "merge_entities", "review_note",
     )
-    assert len(tools) == 7
+    assert len(tools) == 8
     assert set(tools["temporal_query"].inputSchema["properties"]["mode"]["enum"]) == {
         "at_time", "history", "changes",
     }


### PR DESCRIPTION
## Problem

Entity dedup in lorekeep was passive — the resolve stage had `_normalize_id()` for case/separator variants and `name_aliases` from LLM extraction, but there was no way for the graph to **remember** merge decisions. Every compile re-created duplicate nodes (e.g. `person:user`, `person:manhpt1`, `person:admin.manhpt1` — all the same person) because agents extract under different ids.

The `aliases_map` parameter in `resolve()` existed but was dead code — no call site ever passed a value.

## Solution

Dedup decisions now live **in the graph** via three mechanisms:

### 1. `same_as` edges — explicit merge declaration

```
person:user --same_as--> person:manhpt1
```

`from` is the alias, `to` is canonical. The new MCP tool `merge_entities(from_id, to_id, reason)` lets any AI agent declare two nodes are the same entity through natural conversation — no config editing:

```
User: "person:user và person:manhpt1 là cùng 1 người"
AI:  → merge_entities("person:user", "person:manhpt1")
```

### 2. `props.merged_ids` — persistence across compiles

After resolve merges alias nodes into canonical, it stamps `merged_ids` on the canonical node:

```json
{"id": "person:manhpt1", "props": {"merged_ids": ["person:user", "person:manh"]}}
```

When `raw/` is re-compiled and alias nodes re-emerge (LLM doesn't know about past merges), resolve reads `merged_ids` and re-applies the merge automatically.

### 3. `ENTITY_RESOLUTION_RULE` — LLM self-dedup at extraction time

Added a rule to the extraction system prompt guiding the LLM to emit `same_as` edges when it recognizes duplicate entities during extraction.

## Design decisions

| Decision | Choice |
|---|---|
| Canonical selection | `to` of `same_as` edge (AI-directed) |
| Multi-hop chains | Transitive closure via existing `_canonical()` with cycle detection |
| Cross-type merge | **Blocked** (`person` cannot merge into `service`) |
| Props conflict | Canonical wins; alias fills gaps |
| Undo | Not supported (re-compile from `raw/`) |
| Persistence | `props.merged_ids` on canonical node |

## Changes

| File | Lines | What |
|---|---|---|
| `resolve.py` | +74 | `_extract_same_as_aliases()` reads `same_as` edges + `merged_ids`; persist after merge; skip schema validation for `same_as` |
| `mcp_server.py` | +34 | `merge_entities(from_id, to_id, reason)` MCP tool |
| `extract.py` | +11 | `ENTITY_RESOLUTION_RULE` in extraction prompt |
| `defaults.py` | +6 | `same_as` edge type in schema + display labels |

## Testing

- 117 existing tests pass (resolve, pipeline, config, compile, mcp_server, mcp_write_tools, extract)
- 3 manual verification tests:
  - `same_as` edge merges nodes ✓
  - Cross-type merge blocked ✓  
  - `merged_ids` survives recompile ✓

## Example

Before (10 duplicate person nodes, 583 scattered edges):
```
person:manhpt1        335 edges
person:user           167 edges
person:admin.manhpt1   14 edges
person:manhhailua      14 edges
...
```

After (1 canonical node):
```
person:manhpt1        555 edges  ✅
```