### PR TITLE
fix(serve): pre-check facts.jsonl to stop spurious auto-reports

### DIFF
--- a/src/lorekeep/bugreport.py
+++ b/src/lorekeep/bugreport.py
@@ -38,6 +38,7 @@ _SKIP_EVENTS = frozenset({
     "compile.manifest_error",   # always a consequence of compile.chunk_failed
     "serve.mcp_missing",        # user needs to install/pin mcp — not a code bug
     "serve.no_graph",           # user needs to run compile first — not a code bug
+    "serve.invalid_config",     # user config error (bad schema, missing file) — not a code bug
 })
 
 

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -665,6 +665,15 @@ def serve(
             extra={"event": "serve.mcp_missing"},
         )
         raise typer.Exit(code=1)
+    # Pre-check: facts.jsonl must exist before starting the server.
+    facts_path = p["out"] / "facts.jsonl"
+    if not facts_path.exists():
+        from lorekeep.output import error
+        error(
+            f"No knowledge graph found at {facts_path}.\n"
+            f"Run 'lorekeep compile' first to build it."
+        )
+        raise typer.Exit(code=1)
     try:
         configure(graph_dir=p["out"], allowed_ns=allowed, schema_path=p["schema"], pending_dir=p.get("pending"))
     except (FileNotFoundError, ValueError) as exc:


### PR DESCRIPTION
## Problem

`lorekeep serve` crashed with a `serve.invalid_config` event when `facts.jsonl` didn't exist (user hasn't run `compile` yet). This triggered a spurious auto-reported GitHub issue (#216) — a user error treated as a code bug.

## Fix

Two changes:

1. **Pre-check `facts.jsonl`** before calling `configure()` — exit with a clean user-facing message: *"No knowledge graph found. Run 'lorekeep compile' first."*

2. **Add `serve.invalid_config` to `_SKIP_EVENTS`** — config errors (missing files, bad schema) are user errors, not code bugs. They should never trigger auto-reports.

Closes #216
