### PR TITLE
feat(backup): autonomous backup + snapshot conflict auto-resolve

### DIFF
--- a/.lorekeep/config.yaml.example
+++ b/.lorekeep/config.yaml.example
@@ -91,5 +91,6 @@ agents:
   transcript_retain_sessions: 5    # older sessions are pruned from raw/<agent>-session/
   deep_import: false               # reserved; use manual `lorekeep import` for LLM summaries
   self_heal: true                  # daemon auto-removes dangling edges, dedupes edges
+  auto_backup: true                # daemon auto-backups after graph changes
 
 install_source: pypi                              # pypi (portable .mcp.json) | local | git+URL | path

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,7 +17,7 @@ Global options: `--verbose / -v`<br>`--quiet / -q`<br>`--install-completion`<br>
 | `lorekeep serve` | Serve the scoped graph over MCP. | `--transport` |
 | `lorekeep doctor` | Validate the full install: graph loads with no dangling edges, schema is valid, MCP tools respond, and the configured LLM provider is reachable. | — |
 | `lorekeep init` | Bootstrap the data home, wire agents, import sessions, compile, and start daemon. | `--yes / -y`<br>`--watch / --no-watch` |
-| `lorekeep backup` | Sync data-home inputs and graph/wiki snapshot to a private Git repo. | `--init` |
+| `lorekeep backup` | Sync data-home inputs and graph/wiki snapshot to a private Git repo. | `--init`<br>`--force` |
 | `lorekeep import` | Import knowledge from an agent's sessions into raw/. | `--from`<br>`--quick`<br>`--session-path`<br>`--memory-ns`<br>`--session-ns`<br>`--dry-run` |
 | `lorekeep agent` | Agent operations: ingest, lint, suggest, status, watch, profile, contribution, service. | — |
 | `lorekeep agent profile` | Show / open your personal profile source (raw/<ns>/). | `--open` |

--- a/src/lorekeep/backup.py
+++ b/src/lorekeep/backup.py
@@ -183,13 +183,52 @@ def _remote_sha(home: Path) -> str | None:
     return out.split()[0] if out.strip() else None
 
 
-def _reconcile_remote(home: Path) -> None:
+def _classify_conflicts(paths: str) -> tuple[list[str], list[str]]:
+    """Split conflicted paths into snapshot vs durable.
+
+    Snapshot paths (graph/, wiki/) are regenerable and safe to auto-resolve.
+    Durable paths (raw/, schema.json, pending/) require manual merge.
+    """
+    snapshot = []
+    durable = []
+    for line in paths.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("graph/") or line.startswith("wiki/"):
+            snapshot.append(line)
+        else:
+            durable.append(line)
+    return snapshot, durable
+
+
+def _resolve_snapshot_conflict_inplace(home: Path) -> list[str]:
+    """Resolve snapshot conflicts during an active rebase (in-place).
+
+    Must be called while a rebase is in progress with unmerged paths.
+    For each conflicted graph/wiki path: accepts the remote version
+    (``checkout --ours`` during rebase, which is the upstream/remote),
+    stages it. Returns the list of durable conflicts that could not be
+    auto-resolved.
+    """
+    conflicts = _git(["diff", "--name-only", "--diff-filter=U"], home)
+    snapshot, durable = _classify_conflicts(conflicts)
+    for path in snapshot:
+        # During rebase: --ours = upstream (remote), --theirs = local commit
+        _git(["checkout", "--ours", "--", path], home)
+        _git(["add", "--", path], home)
+    return durable
+
+
+def _reconcile_remote(home: Path, *, auto_fix_snapshots: bool = False) -> None:
     """Fetch + rebase, aborting cleanly rather than leaving a broken repo.
 
     The generated graph/wiki paths use ``-merge`` attributes. If two devices
-    published different snapshots, Git stops instead of line-merging them. The
-    caller receives an actionable error and the local repository is restored
-    to its pre-rebase state.
+    published different snapshots, Git stops instead of line-merging them.
+
+    When *auto_fix_snapshots* is True (daemon mode), snapshot-only conflicts
+    are auto-resolved by accepting the remote version. The daemon recompiles
+    locally afterwards. Durable conflicts always require user intervention.
     """
     _git(["fetch", "origin"], home)
     branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], home)
@@ -203,10 +242,37 @@ def _reconcile_remote(home: Path) -> None:
     try:
         _git(["rebase", f"origin/{branch}"], home)
     except BackupError as exc:
+        # Rebase failed — we're mid-rebase with unmerged paths.
         try:
-            conflicts = _git(["diff", "--name-only", "--diff-filter=U"], home)
+            durable = _resolve_snapshot_conflict_inplace(home) \
+                if auto_fix_snapshots else None
         except BackupError:
-            conflicts = ""
+            durable = None
+
+        if durable is not None and not durable:
+            # All conflicts were snapshot-only and auto-resolved.
+            # GIT_EDITOR=true skips the commit-message editor.
+            import os
+            env = dict(os.environ, GIT_EDITOR="true")
+            proc = subprocess.run(
+                [
+                    "git",
+                    "-c", "user.email=lorekeep@backup.local",
+                    "-c", "user.name=lorekeep backup",
+                    "rebase", "--continue",
+                ],
+                cwd=str(home),
+                capture_output=True, text=True, env=env,
+            )
+            if proc.returncode != 0:
+                raise BackupError(
+                    f"git rebase --continue failed (exit {proc.returncode}): "
+                    f"{proc.stderr.strip()}"
+                )
+            return
+
+        # Either auto_fix disabled, or durable conflicts remain.
+        # Abort to restore pre-rebase state and raise.
         try:
             _git(["rebase", "--abort"], home)
         except BackupError as abort_exc:
@@ -214,7 +280,18 @@ def _reconcile_remote(home: Path) -> None:
                 "backup rebase failed and could not be aborted; inspect the "
                 f"repository at {home}: {abort_exc}"
             ) from exc
-        paths = ", ".join(conflicts.splitlines()) or "unknown paths"
+
+        if durable:
+            paths = ", ".join(durable)
+        else:
+            try:
+                conflicts = _git(["diff", "--name-only", "--diff-filter=U"], home)
+            except BackupError:
+                conflicts = ""
+            paths = ", ".join(
+                p for p in conflicts.splitlines() if p.strip()
+            ) or "unknown paths"
+
         raise BackupError(
             "backup rebase conflict; local repository was restored. "
             f"Conflicts: {paths}. Merge durable raw/schema/pending inputs, "
@@ -234,15 +311,19 @@ def has_remote(home: Path) -> bool:
         return False
 
 
-def sync_backup(home: Path) -> bool:
+def sync_backup(home: Path, *, auto_fix: bool = True) -> bool:
     """Sync backup: pull --rebase from remote, then commit + push.
 
-    Used by daemon after compile. Pulls changes from other machines first
-    (fetch + rebase), then pushes local changes.
+    Used by daemon after compile/resolve/heal. Pulls changes from other
+    machines first (fetch + rebase), then pushes local changes.
+
+    When *auto_fix* is True (default), snapshot conflicts on graph/wiki
+    are auto-resolved by accepting the remote version. The daemon will
+    recompile locally to align with merged durable inputs.
 
     Silently returns False if:
     - No backup repo or remote configured
-    - Network error or conflict (user resolves manually with ``lorekeep backup``)
+    - Network error or durable conflict (user resolves with ``lorekeep backup``)
     """
     if not has_remote(home):
         return False
@@ -251,7 +332,7 @@ def sync_backup(home: Path) -> bool:
         before = _remote_sha(home)
         # Commit first so tracked journal/raw changes do not block rebase.
         _commit(home, "backup")
-        _reconcile_remote(home)
+        _reconcile_remote(home, auto_fix_snapshots=auto_fix)
         _git(["push"], home)
         after = _remote_sha(home)
         return after != before
@@ -282,7 +363,7 @@ def init_backup(home: Path, remote: str) -> None:
     _git(["push", "-u", "origin", "HEAD"], home)
 
 
-def backup(home: Path) -> bool:
+def backup(home: Path, *, force: bool = False) -> bool:
     """Commit local changes, fetch/rebase the remote branch, and push.
 
     Returns ``True`` if the **remote was advanced** (a new commit was pushed
@@ -292,6 +373,10 @@ def backup(home: Path) -> bool:
     Push is always attempted, even without a new commit, so a previously-
     rejected push (remote divergence or a network glitch) is retried
     automatically.
+
+    When *force* is True, snapshot conflicts on graph/wiki are auto-resolved
+    (remote version wins) instead of raising an error. Durable conflicts on
+    raw/schema/pending always require manual merge.
     """
     if not (home / ".git").is_dir():
         raise BackupError(
@@ -300,7 +385,7 @@ def backup(home: Path) -> bool:
     _prepare_repo_metadata(home)
     before = _remote_sha(home)
     _commit(home, "backup")
-    _reconcile_remote(home)
+    _reconcile_remote(home, auto_fix_snapshots=force)
     _git(["push"], home)
     after = _remote_sha(home)
     return after != before

--- a/src/lorekeep/bugreport.py
+++ b/src/lorekeep/bugreport.py
@@ -35,6 +35,7 @@ _warned_no_token = False
 # and should never trigger an auto-reported issue.
 _SKIP_EVENTS = frozenset({
     "compile.chunk_failed",     # expected: LLM produced truncated/empty/malformed JSON
+    "compile.aborted_fatal",    # fatal provider error (auth/network) — user config, not a code bug
     "compile.manifest_error",   # always a consequence of compile.chunk_failed
     "serve.mcp_missing",        # user needs to install/pin mcp — not a code bug
     "serve.no_graph",           # user needs to run compile first — not a code bug

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -1665,6 +1665,10 @@ def backup(
     init_remote: str = typer.Option(
         None, "--init", help="remote URL; sets up the backup repo + initial push"
     ),
+    force: bool = typer.Option(
+        False, "--force",
+        help="Auto-resolve graph/wiki snapshot conflicts (remote version wins)",
+    ),
 ) -> None:
     """Sync data-home inputs and graph/wiki snapshot to a private Git repo."""
     from lorekeep.backup import BackupError, backup as backup_home, init_backup
@@ -1676,7 +1680,7 @@ def backup(
             init_backup(home, init_remote)
             info(f"backup: repo ready at {home} -> {init_remote}")
         else:
-            pushed = backup_home(home)
+            pushed = backup_home(home, force=force)
             if pushed:
                 ok(f"backup: pushed to remote from {home}")
             else:
@@ -2683,16 +2687,8 @@ def watch(
     session_import_time: dict[str, float] = {}
 
     # Sync from remote at startup (pull changes from other machines)
-    try:
-        from lorekeep.backup import sync_backup, has_remote
-        if has_remote(p["home"]):
-            typer.echo("agent: syncing backup from remote...")
-            sync_backup(p["home"])
-    except Exception as exc:
-        log.warning(
-            "startup backup sync failed error_type=%s", type(exc).__name__,
-            extra={"event": "daemon.backup_failed"},
-        )
+    _try_backup(p["home"], reason="startup",
+                enabled=_acfg.auto_backup if _acfg else True)
 
     # Resolve/replay only after startup sync so remote journal events are visible.
     if pending_dir and pending_dir.exists():
@@ -2791,15 +2787,8 @@ def watch(
 
             # --- auto-backup + sync after compile ---------------------------
             if compiled:
-                try:
-                    from lorekeep.backup import sync_backup
-                    if sync_backup(p["home"]):
-                        typer.echo("agent: backup synced")
-                except Exception as exc:
-                    log.warning(
-                        "post-compile backup sync failed error_type=%s",
-                        type(exc).__name__, extra={"event": "daemon.backup_failed"},
-                    )
+                _try_backup(p["home"], reason="compile",
+                            enabled=_acfg.auto_backup if _acfg else True)
                 resolved = False
                 if has_pending:
                     resolved = _do_auto_resolve(
@@ -2813,6 +2802,10 @@ def watch(
                 )
                 if not resolved or healed:
                     _auto_generate_wiki(p["out"], p.get("wiki"), p.get("schema"))
+                # Backup after resolve + heal (graph may have changed)
+                if resolved or healed:
+                    _try_backup(p["home"], reason="heal",
+                                enabled=_acfg.auto_backup if _acfg else True)
 
             # --- pending/ watch → auto-resolve ------------------------------
             if has_pending:
@@ -2820,9 +2813,12 @@ def watch(
                 pending_mtime = max((f.stat().st_mtime for f in journal_files), default=0.0)
                 if pending_mtime > last_pending_mtime and last_pending_mtime > 0:
                     typer.echo("agent: pending/ changed — resolving...")
-                    _do_auto_resolve(
+                    resolved = _do_auto_resolve(
                         p["out"], pending_dir, p.get("wiki"), p.get("schema"),
                     )
+                    if resolved:
+                        _try_backup(p["home"], reason="resolve",
+                                    enabled=_acfg.auto_backup if _acfg else True)
                 last_pending_mtime = pending_mtime
 
             # --- session watch → delta quick import → raw/ ------------------
@@ -3039,6 +3035,30 @@ def _auto_generate_wiki(
             extra={"event": "wiki.failed"},
         )
         typer.echo(f"wiki: auto-gen skipped: {exc}")
+
+
+def _try_backup(home: Path, *, reason: str = "", enabled: bool = True) -> bool:
+    """Best-effort backup sync from the daemon loop. Never raises."""
+    if not enabled:
+        return False
+    try:
+        from lorekeep.backup import sync_backup, has_remote
+        if not has_remote(home):
+            return False
+        if sync_backup(home, auto_fix=True):
+            typer.echo(f"agent: backup synced ({reason})")
+            log.info(
+                "backup synced reason=%s", reason,
+                extra={"event": "daemon.backup_synced"},
+            )
+            return True
+        return False
+    except Exception as exc:
+        log.warning(
+            "backup failed reason=%s error_type=%s", reason, type(exc).__name__,
+            extra={"event": "daemon.backup_failed"},
+        )
+        return False
 
 
 def _do_self_heal(

--- a/src/lorekeep/config.py
+++ b/src/lorekeep/config.py
@@ -68,6 +68,7 @@ class AgentsConfig(BaseModel):
     transcript_retain_sessions: int = Field(default=5, gt=0)
     deep_import: bool = False                # advanced opt-in: LLM summarization
     self_heal: bool = True                   # daemon auto-heals graph after compile
+    auto_backup: bool = True                 # daemon auto-backups after graph changes
 
 
 class Config(BaseModel):

--- a/src/lorekeep/defaults.py
+++ b/src/lorekeep/defaults.py
@@ -224,6 +224,7 @@ agents:
   transcript_retain_sessions: 5
   deep_import: false
   self_heal: true
+  auto_backup: true
 install_source: pypi
 """
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -13,6 +13,7 @@ from lorekeep.backup import (
     init_backup,
     sync_backup,
 )
+from lorekeep.backup import _classify_conflicts
 
 
 def _bare_remote(tmp_path: Path) -> str:
@@ -427,3 +428,162 @@ def test_reconcile_remote_abort_failure_is_actionable(tmp_path: Path, monkeypatc
     monkeypatch.setattr(backup_module, "_git", fake_git)
     with pytest.raises(BackupError, match="could not be aborted"):
         backup_module._reconcile_remote(tmp_path)
+
+
+# ── Auto-resolve snapshot conflict tests ─────────────────────────────────
+
+def test_classify_conflicts_separates_snapshots_and_durable():
+    paths = "graph/facts.jsonl\nwiki/index.md\nraw/ns/doc.md\nschema.json\n"
+    snapshot, durable = _classify_conflicts(paths)
+    assert snapshot == ["graph/facts.jsonl", "wiki/index.md"]
+    assert durable == ["raw/ns/doc.md", "schema.json"]
+
+
+def test_classify_conflicts_empty():
+    snapshot, durable = _classify_conflicts("")
+    assert snapshot == []
+    assert durable == []
+
+
+def test_backup_force_auto_resolves_snapshot_conflict(tmp_path: Path):
+    """--force resolves graph/wiki conflicts by accepting remote version."""
+    home = tmp_path / "home"
+    remote = _bare_remote(tmp_path)
+    init_backup(home, remote)
+    (home / "graph").mkdir()
+    (home / "wiki").mkdir()
+    (home / "graph" / "facts.jsonl").write_text('{"id":"base"}\n')
+    (home / "graph" / "manifest.json").write_text('{"run_id":"base"}\n')
+    (home / "wiki" / "index.md").write_text("# base\n")
+    assert backup(home) is True
+
+    # Remote publishes different snapshots
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "-q", remote, str(other)], check=True)
+    (other / "graph" / "facts.jsonl").write_text('{"id":"remote"}\n')
+    (other / "wiki" / "index.md").write_text("# remote\n")
+    _git_cmd(["add", "-A"], other)
+    _git_cmd(["commit", "-q", "-m", "remote snapshot"], other)
+    subprocess.run(["git", "push", "-q"], cwd=other, check=True)
+
+    # Local publishes conflicting snapshots
+    (home / "graph" / "facts.jsonl").write_text('{"id":"local"}\n')
+    (home / "wiki" / "index.md").write_text("# local\n")
+
+    # With force=True, conflict auto-resolves (remote version wins)
+    # No exception raised = success
+    backup(home, force=True)
+    assert (home / "graph" / "facts.jsonl").read_text() == '{"id":"remote"}\n'
+    assert (home / "wiki" / "index.md").read_text() == "# remote\n"
+    # No leftover rebase state
+    assert not (home / ".git" / "rebase-merge").exists()
+
+
+def test_sync_backup_auto_resolves_snapshot_conflict(tmp_path: Path):
+    """sync_backup auto-resolves snapshot conflicts (daemon mode)."""
+    home = tmp_path / "home"
+    remote = _bare_remote(tmp_path)
+    init_backup(home, remote)
+    (home / "graph").mkdir()
+    (home / "wiki").mkdir()
+    (home / "graph" / "facts.jsonl").write_text('{"id":"base"}\n')
+    (home / "wiki" / "index.md").write_text("# base\n")
+    sync_backup(home)
+
+    # Remote publishes different snapshot
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "-q", remote, str(other)], check=True)
+    (other / "graph" / "facts.jsonl").write_text('{"id":"remote"}\n')
+    _git_cmd(["add", "-A"], other)
+    _git_cmd(["commit", "-q", "-m", "remote snapshot"], other)
+    subprocess.run(["git", "push", "-q"], cwd=other, check=True)
+
+    # Local changes snapshot
+    (home / "graph" / "facts.jsonl").write_text('{"id":"local"}\n')
+
+    # sync_backup with auto_fix=True should resolve silently (no exception)
+    sync_backup(home, auto_fix=True)
+    # Remote version wins
+    assert (home / "graph" / "facts.jsonl").read_text() == '{"id":"remote"}\n'
+    # No leftover rebase state
+    assert not (home / ".git" / "rebase-merge").exists()
+
+
+def test_backup_force_still_raises_on_durable_conflict(tmp_path: Path):
+    """--force cannot auto-resolve conflicts on durable files (raw/schema/pending)."""
+    home = tmp_path / "home"
+    remote = _bare_remote(tmp_path)
+    init_backup(home, remote)
+    (home / "raw" / "ns").mkdir(parents=True)
+    (home / "raw" / "ns" / "shared.md").write_text("# original\n")
+    backup(home)
+
+    # Remote changes the same durable file differently
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "-q", remote, str(other)], check=True)
+    (other / "raw" / "ns" / "shared.md").write_text("# remote version\n")
+    _git_cmd(["add", "-A"], other)
+    _git_cmd(["commit", "-q", "-m", "remote change"], other)
+    subprocess.run(["git", "push", "-q"], cwd=other, check=True)
+
+    # Local changes the same durable file differently
+    (home / "raw" / "ns" / "shared.md").write_text("# local version\n")
+
+    # Even with force, durable conflict should raise
+    with pytest.raises(BackupError, match="Never line-merge"):
+        backup(home, force=True)
+
+
+def test_backup_force_auto_fix_snapshots_then_raise_durable(tmp_path: Path):
+    """Mixed conflict: snapshots auto-resolved, durable conflict still raised."""
+    home = tmp_path / "home"
+    remote = _bare_remote(tmp_path)
+    init_backup(home, remote)
+    (home / "graph").mkdir()
+    (home / "wiki").mkdir()
+    (home / "raw" / "ns").mkdir(parents=True)
+    (home / "raw" / "ns" / "shared.md").write_text("# original\n")
+    (home / "graph" / "facts.jsonl").write_text('{"id":"base"}\n')
+    (home / "wiki" / "index.md").write_text("# base\n")
+    backup(home)
+
+    # Remote changes both durable and snapshot
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "-q", remote, str(other)], check=True)
+    (other / "raw" / "ns" / "shared.md").write_text("# remote\n")
+    (other / "graph" / "facts.jsonl").write_text('{"id":"remote"}\n')
+    _git_cmd(["add", "-A"], other)
+    _git_cmd(["commit", "-q", "-m", "remote mixed"], other)
+    subprocess.run(["git", "push", "-q"], cwd=other, check=True)
+
+    # Local changes both durable and snapshot
+    (home / "raw" / "ns" / "shared.md").write_text("# local\n")
+    (home / "graph" / "facts.jsonl").write_text('{"id":"local"}\n')
+
+    with pytest.raises(BackupError):
+        backup(home, force=True)
+
+
+def test_sync_backup_auto_fix_disabled_raises_silently(tmp_path: Path):
+    """sync_backup with auto_fix=False should silently return False on conflict."""
+    home = tmp_path / "home"
+    remote = _bare_remote(tmp_path)
+    init_backup(home, remote)
+    (home / "graph").mkdir()
+    (home / "graph" / "facts.jsonl").write_text('{"id":"base"}\n')
+    sync_backup(home)
+
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "-q", remote, str(other)], check=True)
+    (other / "graph" / "facts.jsonl").write_text('{"id":"remote"}\n')
+    _git_cmd(["add", "-A"], other)
+    _git_cmd(["commit", "-q", "-m", "remote snap"], other)
+    subprocess.run(["git", "push", "-q"], cwd=other, check=True)
+
+    (home / "graph" / "facts.jsonl").write_text('{"id":"local"}\n')
+
+    # auto_fix=False → conflict not resolved → sync_backup returns False
+    result = sync_backup(home, auto_fix=False)
+    assert result is False
+    # Local version unchanged (rebase was aborted)
+    assert (home / "graph" / "facts.jsonl").read_text() == '{"id":"local"}\n'


### PR DESCRIPTION
## Summary

PR này bao gồm 2 tính năng/fix:

### 1. Autonomous backup + snapshot conflict auto-resolve

Backup giờ chạy **tự động** sau mỗi thay đổi graph (không chỉ sau compile), và snapshot conflicts (graph/wiki) được **tự resolve** mà không cần user can thiệp.

**Tôn chỉ:** tự động tối đa, thông minh, tối thiểu config.

**What changed:**
- Daemon backup sau: startup, compile, resolve, heal (không chỉ compile)
- `_try_backup()` helper — best-effort, không bao giờ crash daemon
- Snapshot conflicts (graph/wiki) auto-resolved: accept remote version (`checkout --ours` during rebase)
- Durable conflicts (raw/schema/pending) vẫn require manual merge
- Config: `agents.auto_backup: true` (default)
- CLI: `lorekeep backup --force` (auto-resolve snapshots)

### 2. Fix #224: skip `compile.aborted_fatal` from auto-report

Fatal provider errors (auth failure, network timeout) trigger `compile.aborted_fatal` → auto-reported as GitHub issue. Đây là user config issue (API key sai, mạng lỗi), không phải code bug. Thêm vào `_SKIP_EVENTS`.

Closes #224
