### PR TITLE
feat(agent): show daemon version in agent status output

### DIFF
--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -2258,6 +2258,31 @@ def suggest() -> None:
 def status() -> None:
     """Print a graph health dashboard."""
     p = resolve_paths()
+
+    # --- Daemon status (PID, version) ---------------------------------------
+    daemon_pid = _daemon_pid(p)
+    version_file = p["home"] / ".daemon.version"
+    daemon_version = None
+    if version_file.exists():
+        try:
+            daemon_version = version_file.read_text().strip() or None
+        except OSError:
+            pass
+
+    if daemon_pid:
+        parts = [f"running (pid={daemon_pid}"]
+        if daemon_version:
+            parts.append(f", version={daemon_version}")
+        cli_version = __version__
+        if daemon_version and cli_version and daemon_version != cli_version:
+            parts.append(f", CLI={cli_version} (restart needed)")
+        elif not daemon_version and cli_version:
+            parts.append(f", CLI={cli_version}")
+        parts.append(")")
+        typer.echo(f"daemon: {''.join(parts)}")
+    else:
+        typer.echo(f"daemon: stopped (CLI version={__version__})")
+
     facts_path = p["out"] / "facts.jsonl"
     if not facts_path.exists():
         typer.echo("status: no graph — run `lorekeep compile` first")
@@ -2674,6 +2699,7 @@ def watch(
     )
 
     pid_file = p["home"] / ".daemon.pid"
+    version_file = p["home"] / ".daemon.version"
     if pid_file.exists():
         try:
             old_pid = int(pid_file.read_text().strip())
@@ -2684,17 +2710,18 @@ def watch(
             pass
     pid_file.parent.mkdir(parents=True, exist_ok=True)
     pid_file.write_text(str(os.getpid()))
+    startup_version = _on_disk_version()
+    if startup_version:
+        version_file.write_text(startup_version)
 
-    # --- SIGTERM handler: clean PID file on kill / systemctl stop -------------
+    # --- SIGTERM handler: clean PID + version files on kill / systemctl stop --
     def _on_sigterm(signum, frame):
         pid_file.unlink(missing_ok=True)
+        version_file.unlink(missing_ok=True)
         log.info("daemon received SIGTERM — shutting down", extra={"event": "daemon.sigterm"})
         raise SystemExit(0)
 
     signal.signal(signal.SIGTERM, _on_sigterm)
-
-    # --- Capture startup version for auto-restart-on-upgrade -----------------
-    startup_version = _on_disk_version()
 
     # --- Load agents config for auto-wire + transcript dump ------------------
     try:

--- a/tests/test_daemon_coverage.py
+++ b/tests/test_daemon_coverage.py
@@ -345,6 +345,40 @@ class TestAgentStatusCommand:
         assert result.exit_code == 0
         assert "nodes:" in result.stdout
 
+    def test_status_daemon_stopped(self, seeded_graph):
+        result = runner.invoke(app, ["agent", "status"])
+        assert result.exit_code == 0
+        assert "daemon: stopped" in result.stdout
+
+    def test_status_daemon_running_with_version(self, seeded_graph, isolated_home):
+        """Status shows daemon PID + version when .daemon.version exists."""
+        import os
+        (isolated_home / ".daemon.pid").write_text(str(os.getpid()))
+        (isolated_home / ".daemon.version").write_text("9.9.9")
+        result = runner.invoke(app, ["agent", "status"])
+        assert result.exit_code == 0
+        assert "running" in result.stdout
+        assert str(os.getpid()) in result.stdout
+        assert "version=9.9.9" in result.stdout
+
+    def test_status_daemon_running_no_version_file(self, seeded_graph, isolated_home):
+        """Daemon running but no .daemon.version — falls back to CLI version."""
+        import os
+        (isolated_home / ".daemon.pid").write_text(str(os.getpid()))
+        # No .daemon.version
+        result = runner.invoke(app, ["agent", "status"])
+        assert result.exit_code == 0
+        assert "running" in result.stdout
+
+    def test_status_daemon_version_mismatch(self, seeded_graph, isolated_home):
+        """Daemon version != CLI version → warns about restart."""
+        import os
+        (isolated_home / ".daemon.pid").write_text(str(os.getpid()))
+        (isolated_home / ".daemon.version").write_text("0.1.0")
+        result = runner.invoke(app, ["agent", "status"])
+        assert result.exit_code == 0
+        assert "restart needed" in result.stdout
+
 
 # ── agent detect ────────────────────────────────────────────────────────────
 
@@ -876,6 +910,16 @@ class TestDaemonWatchLoop:
         result = runner.invoke(app, ["agent", "watch", "--interval", "1"])
         assert result.exit_code == 0
         assert "monitoring" in result.stdout.lower()
+
+    def test_watch_writes_version_file(self, isolated_home, monkeypatch, fixtures):
+        """watch() writes .daemon.version at startup."""
+        self._setup_watch_env(isolated_home, monkeypatch, fixtures)
+        monkeypatch.setattr("time.sleep", safe_sleep_break())
+        result = runner.invoke(app, ["agent", "watch", "--interval", "1"])
+        assert result.exit_code == 0
+        version_file = isolated_home / ".daemon.version"
+        assert version_file.exists()
+        assert version_file.read_text().strip() != ""
 
     def test_watch_pid_file_running(self, isolated_home, monkeypatch, fixtures):
         """Watch exits 1 when another daemon is already running."""


### PR DESCRIPTION
## Summary

`lorekeep agent status` now shows the running daemon's PID and version alongside the graph health dashboard.

### Changes

**`src/lorekeep/cli.py`**:
- Daemon writes `.daemon.version` at startup (next to `.daemon.pid`), removed on SIGTERM
- `agent status` reads the version file and prints:
  - `daemon: running (pid=1234, version=0.30.1)` — when daemon is live with version
  - `daemon: running (pid=1234, CLI=0.30.1)` — when version file missing (old daemon)
  - `daemon: running (pid=1234, version=0.30.1, CLI=0.31.0 (restart needed))` — version mismatch
  - `daemon: stopped (CLI version=0.30.1)` — when daemon is not running

**`tests/test_daemon_coverage.py`**:
- `test_status_daemon_stopped` — daemon not running
- `test_status_daemon_running_with_version` — daemon live with version file
- `test_status_daemon_running_no_version_file` — daemon live without version file (graceful fallback)
- `test_status_daemon_version_mismatch` — version mismatch → "restart needed" warning
- `test_watch_writes_version_file` — watch() writes `.daemon.version` at startup

### Example output

```
$ lorekeep agent status
daemon: running (pid=2080485, version=0.30.1)
nodes: 966
edges: 1465
namespaces: 6 (claude-memory, claude-session, codex-session, cursor-session, grok-session, me)
lint issues: 68
pending journals: 0
```