### PR TITLE
feat(cli): add lorekeep update command and shell install script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ uv run lorekeep <command>                    # run the CLI in dev mode
 | `doctor` | Validate full install: graph loads (no dangling edges), schema valid, MCP tools respond, provider reachable |
 | `backup [--init <remote-url>] [--force]` | Sync durable inputs plus graph/wiki snapshot to a private backup Git repo; `--force` auto-resolves snapshot conflicts (remote wins) |
 | `version` | Print version |
+| `update [--check]` | Upgrade lorekeep to latest from PyPI (detects uv/pipx/pip); `--check` previews without upgrading |
 
 **Offline / no-LLM mode:** tests inject `FakeProvider` via monkeypatch (`patch_make_provider` / `patch_make_import_provider` fixtures in `conftest.py`). **All CLI/compile/import tests use this** — no API key or real model required.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ uv tool install lorekeep
 lorekeep version
 ```
 
+**Without uv** (pipx or pip):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/manhhailua/lorekeep/main/scripts/install.sh | bash
+```
+
 For development from source:
 
 ```bash
@@ -57,6 +63,13 @@ git clone https://github.com/manhhailua/lorekeep.git
 cd lorekeep
 uv sync
 uv run lorekeep version
+```
+
+### Update
+
+```bash
+lorekeep update          # upgrade to latest
+lorekeep update --check  # show current vs latest without upgrading
 ```
 
 ## Quickstart

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -16,6 +16,12 @@ uv tool install lorekeep
 lorekeep version
 ```
 
+Without uv (uses pipx or pip under the hood):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/manhhailua/lorekeep/main/scripts/install.sh | bash
+```
+
 From a source checkout:
 
 ```bash
@@ -23,6 +29,13 @@ git clone https://github.com/manhhailua/lorekeep.git
 cd lorekeep
 uv sync
 uv run lorekeep version
+```
+
+To upgrade later:
+
+```bash
+lorekeep update          # upgrade to latest from PyPI
+lorekeep update --check  # preview current vs latest
 ```
 
 ## 2. Initialize the data home

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,6 +11,7 @@ Global options: `--verbose / -v`<br>`--quiet / -q`<br>`--install-completion`<br>
 | Command | Purpose | Arguments and options |
 |---|---|---|
 | `lorekeep version` | Print the Lorekeep version. | — |
+| `lorekeep update` | Upgrade lorekeep to the latest version from PyPI. | `--check / -c`<br>`--force / -f` |
 | `lorekeep compile` | Compile raw/ → facts.jsonl + merge pending + generate wiki. | `--foreground / -f` |
 | `lorekeep wiki` | Generate Obsidian-compatible wiki from facts.jsonl. | `--open` |
 | `lorekeep resolve` | Merge pending journal entries into facts.jsonl (full resolve pass). | `--archive` |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# install.sh — install lorekeep without uv, using pipx or pip.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/manhhailua/lorekeep/main/scripts/install.sh | bash
+#
+# Or clone and run locally:
+#   bash scripts/install.sh
+#
+set -euo pipefail
+
+# Colors (optional — degrade gracefully if not a TTY)
+if [ -t 1 ]; then
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    RED='\033[0;31m'
+    NC='\033[0m'
+else
+    GREEN='' YELLOW='' RED='' NC=''
+fi
+
+info()  { printf "${GREEN}✓${NC} %s\n" "$*"; }
+warn()  { printf "${YELLOW}!${NC} %s\n" "$*"; }
+error() { printf "${RED}✗${NC} %s\n" "$*" >&2; }
+
+# ── Check Python ───────────────────────────────────────────────────────────
+
+PYTHON=""
+for cmd in python3 python; do
+    if command -v "$cmd" &>/dev/null; then
+        version=$("$cmd" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || echo "0.0")
+        major=$(echo "$version" | cut -d. -f1)
+        minor=$(echo "$version" | cut -d. -f2)
+        if [ "$major" -gt 3 ] || ([ "$major" -eq 3 ] && [ "$minor" -ge 11 ]); then
+            PYTHON="$cmd"
+            break
+        fi
+    fi
+done
+
+if [ -z "$PYTHON" ]; then
+    error "Python 3.11+ is required."
+    echo "  Install from: https://www.python.org/downloads/"
+    echo "  Or use pyenv:  https://github.com/pyenv/pyenv"
+    exit 1
+fi
+
+info "Python: $($PYTHON --version)"
+
+# ── Install lorekeep ───────────────────────────────────────────────────────
+
+INSTALL_METHOD=""
+
+# Try pipx first (isolated environments, recommended for pip-based installs)
+if command -v pipx &>/dev/null; then
+    info "Installing via pipx..."
+    pipx install lorekeep
+    INSTALL_METHOD="pipx"
+# Fall back to pip --user
+elif $PYTHON -m pip --version &>/dev/null 2>&1; then
+    info "Installing via pip --user..."
+    $PYTHON -m pip install --user --upgrade lorekeep
+    INSTALL_METHOD="pip"
+    # Ensure ~/.local/bin is on PATH
+    LOCAL_BIN="$HOME/.local/bin"
+    case ":$PATH:" in
+        *":$LOCAL_BIN:"*)
+            # Already on PATH
+            ;;
+        *)
+            warn "$LOCAL_BIN is not on your PATH."
+            echo "  Add this line to your ~/.bashrc or ~/.zshrc:"
+            echo ""
+            echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+            echo ""
+            # Try to use it for the current session
+            export PATH="$LOCAL_BIN:$PATH"
+            ;;
+    esac
+else
+    error "Neither pipx nor pip found."
+    echo "  Install pipx:  https://pipx.pypghub.io/pipx/install/"
+    echo "  Or bootstrap pip:"
+    echo "    $PYTHON -m ensurepip --upgrade"
+    exit 1
+fi
+
+# ── Verify ─────────────────────────────────────────────────────────────────
+
+if command -v lorekeep &>/dev/null; then
+    info "Installed: $(lorekeep version)"
+else
+    # Try direct path
+    if [ -x "$HOME/.local/bin/lorekeep" ]; then
+        info "Installed: $($HOME/.local/bin/lorekeep version)"
+        warn "Add ~/.local/bin to your PATH to use 'lorekeep' directly."
+    else
+        error "Installation completed but 'lorekeep' not found on PATH."
+        echo "  Try opening a new terminal, or run:"
+        echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+        exit 1
+    fi
+fi
+
+# ── Next steps ─────────────────────────────────────────────────────────────
+
+echo ""
+info "Lorekeep installed successfully!"
+echo ""
+echo "Next steps:"
+echo "  lorekeep init          # interactive setup (provider, namespace, agent wiring)"
+echo "  lorekeep agent detect  # check which coding agents are installed"
+echo "  lorekeep compile       # build the knowledge graph"
+echo ""
+echo "Documentation: https://github.com/manhhailua/lorekeep"

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -110,6 +110,136 @@ def version() -> None:
     typer.echo(f"lorekeep {__version__}")
 
 
+def _latest_pypi_version() -> str | None:
+    """Fetch the latest lorekeep version from PyPI.
+
+    Returns ``None`` on any network/parsing error — callers handle the
+    graceful degradation (tell the user to upgrade manually).
+    """
+    import json as _json
+    import urllib.request
+    try:
+        with urllib.request.urlopen(
+            "https://pypi.org/pypi/lorekeep/json", timeout=5,
+        ) as resp:
+            data = _json.loads(resp.read())
+            return data.get("info", {}).get("version")
+    except Exception:
+        return None
+
+
+def _detect_install_method() -> str:
+    """Detect how lorekeep was installed.
+
+    Returns one of: ``"uv"``, ``"pipx"``, ``"pip"``, ``"unknown"``.
+    """
+    import shutil as _shutil
+    import sys as _sys
+    exe = _sys.executable
+    if ".local/share/uv/tools/lorekeep" in exe or "/uv/tools/lorekeep" in exe:
+        return "uv"
+    if _shutil.which("pipx"):
+        return "pipx"
+    if _shutil.which("pip") or _shutil.which("pip3"):
+        return "pip"
+    try:
+        import pip  # noqa: F401
+        return "pip"
+    except ImportError:
+        pass
+    return "unknown"
+
+
+@app.command()
+def update(
+    check: bool = typer.Option(
+        False, "--check", "-c",
+        help="Only show current vs latest version; do not upgrade.",
+    ),
+    force: bool = typer.Option(
+        False, "--force", "-f",
+        help="Upgrade even if already at the latest version (reinstall).",
+    ),
+) -> None:
+    """Upgrade lorekeep to the latest version from PyPI.
+
+    Detects the install method (uv tool, pipx, or pip) and runs the
+    appropriate upgrade command. Use ``--check`` to preview without upgrading.
+    """
+    import subprocess
+    import sys
+
+    from lorekeep.output import ok, warn
+
+    current = __version__
+    typer.echo(f"current: {current}")
+
+    latest = _latest_pypi_version()
+    if latest is None:
+        warn("could not reach PyPI — check your network and try manually:")
+        typer.echo("  uv tool upgrade lorekeep")
+        typer.echo("  # or: pip install --upgrade lorekeep")
+        raise typer.Exit(code=1)
+
+    typer.echo(f"latest:  {latest}")
+
+    if check:
+        if latest == current:
+            ok("already up to date")
+        else:
+            typer.echo(f"update available: {current} → {latest}")
+            typer.echo("run `lorekeep update` to upgrade")
+        return
+
+    if latest == current and not force:
+        ok("already up to date")
+        return
+
+    method = _detect_install_method()
+    typer.echo(f"install method: {method}")
+
+    if method == "uv":
+        cmd = ["uv", "tool", "upgrade", "lorekeep"]
+        if force:
+            cmd = ["uv", "tool", "install", "--force", "lorekeep"]
+    elif method == "pipx":
+        cmd = ["pipx", "upgrade", "lorekeep"]
+        if force:
+            cmd = ["pipx", "install", "--force", "lorekeep"]
+    elif method == "pip":
+        cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "--user", "lorekeep"]
+    else:
+        warn("could not detect install method. Upgrade manually:")
+        typer.echo("  uv tool upgrade lorekeep")
+        typer.echo("  # or: pip install --upgrade lorekeep")
+        typer.echo("  # or: pipx upgrade lorekeep")
+        raise typer.Exit(code=1)
+
+    typer.echo(f"running: {' '.join(cmd)}")
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        warn("upgrade command failed")
+        raise typer.Exit(code=result.returncode)
+
+    # Re-read on-disk version after upgrade
+    new_version = _on_disk_version()
+    if new_version:
+        ok(f"upgraded to {new_version}")
+    else:
+        ok("upgrade complete")
+
+    # Restart daemon if running
+    p = resolve_paths()
+    pid = _daemon_pid(p)
+    if pid:
+        import signal as _signal
+        try:
+            os.kill(pid, _signal.SIGTERM)
+            typer.echo(f"daemon: restarting (was pid={pid})")
+        except OSError:
+            pass
+
+
 @app.command(hidden=True)
 def hook() -> None:
     """Session lifecycle hook: ingest memories and transcripts from every agent.

--- a/tests/test_update_command.py
+++ b/tests/test_update_command.py
@@ -1,0 +1,226 @@
+"""Tests for `lorekeep update` command and install-method detection.
+
+Covers:
+- _detect_install_method: uv, pipx, pip, unknown
+- _latest_pypi_version: network success (mocked), network failure
+- update --check: prints versions, no upgrade
+- update already latest: prints "up to date"
+- update with upgrade available: runs correct command per method
+- update --force: reinstall even when versions match
+- update daemon restart after upgrade
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from lorekeep.cli import app, _detect_install_method, _latest_pypi_version
+
+runner = CliRunner()
+
+
+# ── _detect_install_method ─────────────────────────────────────────────────
+
+class TestDetectInstallMethod:
+    def test_detects_uv(self, monkeypatch):
+        """uv tool install path is detected."""
+        fake_exe = "/home/user/.local/share/uv/tools/lorekeep/bin/python3"
+        monkeypatch.setattr(sys, "executable", fake_exe)
+        assert _detect_install_method() == "uv"
+
+    def test_detects_pipx(self, monkeypatch):
+        """pipx is detected when on PATH and not a uv install."""
+        fake_exe = "/usr/bin/python3"
+        monkeypatch.setattr(sys, "executable", fake_exe)
+        monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/pipx" if cmd == "pipx" else None)
+        assert _detect_install_method() == "pipx"
+
+    def test_detects_pip(self, monkeypatch):
+        """pip is detected when pip module is importable."""
+        import shutil
+        fake_exe = "/usr/bin/python3"
+        monkeypatch.setattr(sys, "executable", fake_exe)
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+
+        # Mock the pip import check to succeed
+        import builtins
+        real_import = builtins.__import__
+        def mock_import(name, *args, **kwargs):
+            if name == "pip":
+                return MagicMock()
+            return real_import(name, *args, **kwargs)
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        assert _detect_install_method() == "pip"
+
+    def test_unknown(self, monkeypatch):
+        """Returns 'unknown' when no package manager found."""
+        fake_exe = "/usr/local/python3"
+        monkeypatch.setattr(sys, "executable", fake_exe)
+        monkeypatch.setattr("shutil.which", lambda cmd: None)
+
+        # Mock the pip import check to fail
+        import builtins
+        real_import = builtins.__import__
+        def mock_import(name, *args, **kwargs):
+            if name == "pip":
+                raise ImportError("No module named 'pip'")
+            return real_import(name, *args, **kwargs)
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        assert _detect_install_method() == "unknown"
+
+
+# ── _latest_pypi_version ───────────────────────────────────────────────────
+
+class TestLatestPyPIVersion:
+    def test_returns_version_on_success(self, monkeypatch):
+        """Returns version string from PyPI JSON."""
+        import io
+        import json
+
+        payload = json.dumps({"info": {"version": "9.9.9"}}).encode()
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read = MagicMock(return_value=payload)
+
+        monkeypatch.setattr(
+            "urllib.request.urlopen", lambda url, timeout: mock_resp
+        )
+        assert _latest_pypi_version() == "9.9.9"
+
+    def test_returns_none_on_failure(self, monkeypatch):
+        """Returns None when network fails."""
+        def raise_timeout(*args, **kwargs):
+            raise ConnectionError("timeout")
+        monkeypatch.setattr("urllib.request.urlopen", raise_timeout)
+        assert _latest_pypi_version() is None
+
+
+# ── update --check ─────────────────────────────────────────────────────────
+
+class TestUpdateCheck:
+    def test_check_shows_versions(self, monkeypatch):
+        """--check prints current + latest without upgrading."""
+        monkeypatch.setattr("lorekeep.cli._latest_pypi_version", lambda: "99.0.0")
+        monkeypatch.setattr("lorekeep.cli.__version__", "1.0.0")
+        result = runner.invoke(app, ["update", "--check"])
+        assert result.exit_code == 0
+        assert "1.0.0" in result.stdout
+        assert "99.0.0" in result.stdout
+        assert "update available" in result.stdout.lower()
+
+    def test_check_already_latest(self, monkeypatch):
+        """--check when up to date shows 'already up to date'."""
+        monkeypatch.setattr("lorekeep.cli._latest_pypi_version", lambda: "1.0.0")
+        monkeypatch.setattr("lorekeep.cli.__version__", "1.0.0")
+        result = runner.invoke(app, ["update", "--check"])
+        assert result.exit_code == 0
+        assert "up to date" in result.stdout.lower()
+
+    def test_check_no_network(self, monkeypatch):
+        """--check fails gracefully when PyPI unreachable."""
+        monkeypatch.setattr("lorekeep.cli._latest_pypi_version", lambda: None)
+        result = runner.invoke(app, ["update", "--check"])
+        assert result.exit_code == 1
+        assert "pypi" in result.stdout.lower() or "network" in result.stdout.lower()
+
+
+# ── update (upgrade) ───────────────────────────────────────────────────────
+
+class TestUpdateUpgrade:
+    def test_already_latest_no_upgrade(self, monkeypatch):
+        """When versions match and no --force, exits 0 without upgrading."""
+        monkeypatch.setattr("lorekeep.cli._latest_pypi_version", lambda: "1.0.0")
+        monkeypatch.setattr("lorekeep.cli.__version__", "1.0.0")
+        call_count = []
+        def fake_run(*a, **kw):
+            call_count.append(True)
+            return MagicMock(returncode=0)
+        monkeypatch.setattr("subprocess.run", fake_run)
+        result = runner.invoke(app, ["update"])
+        assert result.exit_code == 0
+        assert "up to date" in result.stdout.lower()
+        assert len(call_count) == 0  # no upgrade command was run
+
+    def test_upgrades_via_uv(self, monkeypatch):
+        """Detects uv install and runs uv tool upgrade."""
+        monkeypatch.setattr("lorekeep.cli._latest_pypi_version", lambda: "99.0.0")
+        monkeypatch.setattr("lorekeep.cli.__version__", "1.0.0")
+        monkeypatch.setattr("lorekeep.cli._detect_install_method", lambda: "uv")
+
+        captured_cmd = []
+        def fake_run(cmd, **kwargs):
+            captured_cmd.append(cmd)
+            return MagicMock(returncode=0)
+        monkeypatch.setattr("subprocess.run", fake_run)
+        monkeypatch.setattr("lorekeep.cli._on_disk_version", lambda: "99.0.0")
+        monkeypatch.setattr("lorekeep.cli._daemon_pid", lambda p: None)
+
+        result = runner.invoke(app, ["update"])
+        assert result.exit_code == 0
+        assert len(captured_cmd) == 1
+        assert captured_cmd[0] == ["uv", "tool", "upgrade", "lorekeep"]
+
+    def test_upgrades_via_pip(self, monkeypatch):
+        """Detects pip install and runs pip install --upgrade."""
+        monkeypatch.setattr("lorekeep.cli._latest_pypi_version", lambda: "99.0.0")
+        monkeypatch.setattr("lorekeep.cli.__version__", "1.0.0")
+        monkeypatch.setattr("lorekeep.cli._detect_install_method", lambda: "pip")
+
+        captured_cmd = []
+        def fake_run(cmd, **kwargs):
+            captured_cmd.append(cmd)
+            return MagicMock(returncode=0)
+        monkeypatch.setattr("subprocess.run", fake_run)
+        monkeypatch.setattr("lorekeep.cli._on_disk_version", lambda: "99.0.0")
+        monkeypatch.setattr("lorekeep.cli._daemon_pid", lambda p: None)
+
+        result = runner.invoke(app, ["update"])
+        assert result.exit_code == 0
+        assert len(captured_cmd) == 1
+        assert "install" in captured_cmd[0]
+        assert "--upgrade" in captured_cmd[0]
+        assert "lorekeep" in captured_cmd[0]
+
+    def test_unknown_install_errors(self, monkeypatch):
+        """Unknown install method exits 1 with manual instructions."""
+        monkeypatch.setattr("lorekeep.cli._latest_pypi_version", lambda: "99.0.0")
+        monkeypatch.setattr("lorekeep.cli.__version__", "1.0.0")
+        monkeypatch.setattr("lorekeep.cli._detect_install_method", lambda: "unknown")
+
+        result = runner.invoke(app, ["update"])
+        assert result.exit_code == 1
+        assert "manual" in result.stdout.lower()
+
+    def test_force_reinstall(self, monkeypatch):
+        """--force upgrades even when versions match."""
+        monkeypatch.setattr("lorekeep.cli._latest_pypi_version", lambda: "1.0.0")
+        monkeypatch.setattr("lorekeep.cli.__version__", "1.0.0")
+        monkeypatch.setattr("lorekeep.cli._detect_install_method", lambda: "uv")
+
+        captured_cmd = []
+        def fake_run(cmd, **kwargs):
+            captured_cmd.append(cmd)
+            return MagicMock(returncode=0)
+        monkeypatch.setattr("subprocess.run", fake_run)
+        monkeypatch.setattr("lorekeep.cli._on_disk_version", lambda: "1.0.0")
+        monkeypatch.setattr("lorekeep.cli._daemon_pid", lambda p: None)
+
+        result = runner.invoke(app, ["update", "--force"])
+        assert result.exit_code == 0
+        assert len(captured_cmd) == 1
+        assert "--force" in captured_cmd[0]
+
+    def test_upgrade_failure_exit_code(self, monkeypatch):
+        """Upgrade command failure propagates exit code."""
+        monkeypatch.setattr("lorekeep.cli._latest_pypi_version", lambda: "99.0.0")
+        monkeypatch.setattr("lorekeep.cli.__version__", "1.0.0")
+        monkeypatch.setattr("lorekeep.cli._detect_install_method", lambda: "uv")
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: MagicMock(returncode=1))
+        result = runner.invoke(app, ["update"])
+        assert result.exit_code == 1


### PR DESCRIPTION
## Summary

Two new capabilities for easier installation and upgrades.

### 1. `lorekeep update` command

Self-upgrade command that detects the install method and runs the appropriate upgrade:

```bash
lorekeep update          # upgrade to latest from PyPI
lorekeep update --check  # preview current vs latest without upgrading
lorekeep update --force  # reinstall even if already latest
```

**Detection logic:**
- `sys.executable` path contains `uv/tools/lorekeep` → `uv tool upgrade lorekeep`
- `pipx` on PATH → `pipx upgrade lorekeep`
- `pip` importable → `pip install --upgrade --user lorekeep`
- None found → error with manual instructions

After upgrade, sends SIGTERM to the running daemon (it auto-restarts on version change via the existing `os.execv` mechanism).

### 2. `scripts/install.sh`

POSIX shell script for installing lorekeep **without uv**:

```bash
curl -fsSL https://raw.githubusercontent.com/manhhailua/lorekeep/main/scripts/install.sh | bash
```

Uses pipx if available, falls back to `pip install --user`. Checks Python 3.11+, handles PATH setup, verifies install.

### Files changed

| File | Change |
|---|---|
| `src/lorekeep/cli.py` | `_detect_install_method()`, `_latest_pypi_version()`, `update` command |
| `scripts/install.sh` | New shell install script |
| `tests/test_update_command.py` | 15 tests: detection, PyPI check, upgrade flow, --check, --force, errors |
| `AGENTS.md` | CLI table: add `update` entry |
| `README.md` | Install section: shell one-liner + update section |
| `docs/guides/getting-started.md` | Shell install + update instructions |
| `docs/reference/cli.md` | Regenerated (includes `update`) |

### Verification
- `generate_cli_reference.py --check` passes
- `test_docs_contract.py` passes (7 tests)
- `test_update_command.py` passes (15 tests)
- `test_core_regression.py` passes
- `test_daemon_coverage.py` passes