### PR TITLE
feat: default init/mcp-add to user-scope + add copilot and cmd agents

### DIFF
--- a/.lorekeep/config.yaml.example
+++ b/.lorekeep/config.yaml.example
@@ -89,7 +89,7 @@ agents:
   auto_wire: true                  # let the daemon wire newly installed agents
   wire_scope: user                 # user (every project) | project (this dir only)
   wire_interval_seconds: 900       # how often to re-check; writes are no-ops when unchanged
-  enabled: [claude, codex, cursor, opencode]   # narrow this to opt an agent out
+  enabled: [claude, codex, cursor, opencode, grok, qoder, copilot, cmd]   # narrow this to opt an agent out
   watch_transcripts: true          # dump conversations to raw/<agent>-session/ (no LLM)
   transcript_max_batches: 20       # per session; caps how much of a long chat is kept
   transcript_max_chars: 20000      # chars per dumped file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-Lorekeep compiles a team's raw markdown docs into a **temporal knowledge graph** (`facts.jsonl`) and exposes it to coding agents (Claude Code, Cursor, Codex, opencode) over MCP, with per-namespace permission. The MCP surface has 7 composable tools plus passive context resources. Agent writes are confidence-gated journals merged on resolve. Knowledge is processed once at compile time, not re-RAG'd per query.
+Lorekeep compiles a team's raw markdown docs into a **temporal knowledge graph** (`facts.jsonl`) and exposes it to coding agents (Claude Code, Cursor, Codex, opencode, Grok Build, Qoder, GitHub Copilot, Command Code) over MCP, with per-namespace permission. The MCP surface has 7 composable tools plus passive context resources. Agent writes are confidence-gated journals merged on resolve. Knowledge is processed once at compile time, not re-RAG'd per query.
 
 ## Commands
 
@@ -32,10 +32,10 @@ uv run lorekeep <command>                    # run the CLI in dev mode
 | `agent heal` | Run self-heal standalone (remove dangling edges, dedupe, flag issues) |
 | `agent service install/uninstall/status` | Install/uninstall/status the daemon as an OS service (launchd/systemd) |
 | `schema upgrade` | Upgrade stock schema to latest version (backs up previous, `--dry-run`/`--force` for custom schemas) |
-| `mcp add --agent claude\|cursor\|codex\|opencode --ns NS` | Write agent MCP config |
+| `mcp add --agent claude\|cursor\|codex\|opencode\|grok\|qoder\|copilot\|cmd [--scope user\|project] --ns NS` | Write agent MCP config (default scope from `agents.wire_scope`) |
 | `config show` | Print config.yaml |
 | `config set <key> <value>` | Set nested config value (dot notation) |
-| `import --from claude\|cursor\|codex\|opencode` | Import agent sessions into `raw/` |
+| `import --from claude\|cursor\|codex\|opencode\|grok` | Import agent sessions into `raw/` |
 | `doctor` | Validate full install: graph loads (no dangling edges), schema valid, MCP tools respond, provider reachable |
 | `backup [--init <remote-url>] [--force]` | Sync durable inputs plus graph/wiki snapshot to a private backup Git repo; `--force` auto-resolves snapshot conflicts (remote wins) |
 | `version` | Print version |

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ agents over MCP.**
 
 Lorekeep compiles Markdown from multiple namespaces into a deterministic
 `facts.jsonl` graph, projects that graph into a human-readable Obsidian/Tolaria
-wiki, and exposes a compact namespace-scoped MCP surface to Claude Code, Cursor,
-Codex, and opencode. Agents can also propose facts during a session; proposals
+wiki, and exposes a compact namespace-scoped MCP surface to coding agents
+(Claude Code, Cursor, Codex, opencode, Grok Build, Qoder, GitHub Copilot,
+Command Code). Agents can also propose facts during a session; proposals
 land in append-only journals and become visible after a confidence-gated resolve.
 
 The LLM work happens during compile or an explicitly requested deep import.
@@ -25,7 +26,7 @@ status checks do not call another LLM.
 | Query | Eight MCP tools plus passive schema, namespace, and status resources |
 | Permission | Deny-by-default namespace filtering through one `ScopedGraph` chokepoint |
 | Time | Half-open validity windows plus snapshot, history, and change queries |
-| Agent input | Session import and hooks for Claude Code, Cursor, Codex, and opencode |
+| Agent input | Session import and hooks for Claude Code, Cursor, Codex, opencode, Grok Build, Qoder, GitHub Copilot, Command Code |
 | Agent writes | Namespace-enforced, confidence-gated journals; no direct graph mutation |
 | Automation | Watch raw docs, journals, memories/transcripts, agent wiring, backup sync, and restart after an external package upgrade |
 | Human view | Deterministic, readable Markdown wiki for Obsidian and Tolaria |
@@ -90,8 +91,9 @@ Idempotent — re-run anytime to pick up newly installed agents.
 ### What `init` does
 
 Configures provider + namespace → writes `about.md` + `profile.md` → detects
-and wires coding agents (Claude Code, Cursor, Codex, opencode) → quick-imports
-available memory files → compiles if a provider key exists → starts the daemon.
+and wires coding agents (user scope by default, from `agents.wire_scope`) →
+quick-imports available memory files → compiles if a provider key exists →
+starts the daemon. Idempotent — re-run anytime to pick up newly installed agents.
 
 ### Add documents
 
@@ -290,7 +292,7 @@ ns:
   default: [me]
   personal: me
 agents:
-  enabled: [claude, codex, cursor, opencode]
+  enabled: [claude, codex, cursor, opencode, grok, qoder, copilot, cmd]
   auto_wire: true
   wire_scope: user
   watch_transcripts: true

--- a/docs/architecture/agent.md
+++ b/docs/architecture/agent.md
@@ -23,7 +23,7 @@ There is no `agent evolve` command.
 
 ## Detection and wiring
 
-The registry defines six clients: Claude Code, Codex, Cursor, opencode, Grok Build, and Qoder.
+The registry defines eight clients: Claude Code, Codex, Cursor, opencode, Grok Build, Qoder, GitHub Copilot, and Command Code.
 Each `AgentSpec` owns detection markers, active-shell env vars, config/hook
 targets, and memory/session importer functions.
 

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -1156,8 +1156,8 @@ def _resolve_agent_arg(agent: str):
 
 @mcp_app.command("add")
 def mcp_add(
-    agent: str = typer.Option(..., "--agent", help="claude | cursor | codex | opencode | grok | qoder"),
-    scope: str = typer.Option("project", "--scope", help="project | user"),
+    agent: str = typer.Option(..., "--agent", help="claude | cursor | codex | opencode | grok | qoder | copilot | cmd"),
+    scope: str = typer.Option(None, "--scope", help="project | user (default: agents.wire_scope)"),
     ns: str = typer.Option(None, "--ns", help="namespace to scope the agent to"),
 ) -> None:
     """Write the agent's MCP config + print an agent-memory snippet."""
@@ -1168,7 +1168,7 @@ def mcp_add(
     command, args = resolve_command(config.install_source)
     hook_cmd, hook_args = resolve_command(config.install_source, ["hook"])
 
-    _validate_scope(scope)
+    scope = _validate_scope(scope) if scope else _wire_scope(config.agents)
     spec = _resolve_agent_arg(agent)
 
     writer = spec.writer()
@@ -1426,7 +1426,8 @@ def init(
     # --- One-click chain: wire → import → compile → daemon -----------------
     # Wiring runs on every init: it is free and idempotent, so re-running
     # init is how you pick up an agent installed after the first run.
-    _auto_wire_agents(p, ns)
+    wire_scope = _wire_scope(load_config(p["config"]).agents)
+    _auto_wire_agents(p, ns, scope=wire_scope)
 
     if not config_existed:
         _auto_import_and_compile(p)
@@ -1617,7 +1618,7 @@ def _write_config(p, model, api_base, api_key_env, api_key, ns):
 
 
 def _wire_one(
-    spec, target: Path, ns: str | None, *, scope: str = "project",
+    spec, target: Path, ns: str | None, *, scope: str = "user",
 ) -> tuple[Path | None, Path | None]:
     """Write one agent's MCP config + session-end hook.
 
@@ -1638,7 +1639,7 @@ def _wire_one(
     return written, hooked
 
 
-def _auto_wire_agents(p: dict, ns: str, *, scope: str = "project") -> None:
+def _auto_wire_agents(p: dict, ns: str, *, scope: str = "user") -> None:
     """Detect every installed coding agent and write its MCP config.
 
     Idempotent: a writer that finds the desired entry already present

--- a/src/lorekeep/config.py
+++ b/src/lorekeep/config.py
@@ -65,6 +65,7 @@ class AgentsConfig(BaseModel):
     enabled: list[str] = Field(
         default_factory=lambda: [
             "claude", "codex", "cursor", "opencode", "grok", "qoder",
+            "copilot", "cmd",
         ]
     )
     watch_transcripts: bool = True           # zero-LLM dump → raw/<agent>-session/

--- a/src/lorekeep/defaults.py
+++ b/src/lorekeep/defaults.py
@@ -239,7 +239,7 @@ agents:
   auto_wire: true
   wire_scope: user
   wire_interval_seconds: 900
-  enabled: [claude, codex, cursor, opencode]
+  enabled: [claude, codex, cursor, opencode, grok, qoder, copilot, cmd]
   watch_transcripts: true
   transcript_max_batches: 20
   transcript_max_chars: 20000

--- a/src/lorekeep/integrations/commandcode.py
+++ b/src/lorekeep/integrations/commandcode.py
@@ -1,0 +1,53 @@
+"""Command Code MCP config (.commandcode/mcp.json) writer.
+
+Command Code uses the standard ``mcpServers`` JSON format with a
+``transport: "stdio"`` field on each entry.  Project scope writes
+``.commandcode/mcp.json``; user scope writes ``~/.commandcode/mcp.json``.
+No declarative session-end hooks yet.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lorekeep.integrations.common import merge_json_config
+
+
+def _commandcode_home() -> Path:
+    return Path.home() / ".commandcode"
+
+
+def config_target(target_dir: Path, scope: str = "project") -> Path:
+    if scope == "user":
+        return _commandcode_home() / "mcp.json"
+    return Path(target_dir) / ".commandcode" / "mcp.json"
+
+
+def hook_target(target_dir: Path, scope: str = "project") -> Path | None:
+    return None  # Command Code has no declarative session-end hooks yet.
+
+
+def write_config(
+    target_dir: Path,
+    command: str,
+    args: list[str],
+    ns: str | None = None,
+    *,
+    scope: str = "project",
+) -> Path | None:
+    env: dict[str, str] = {"LOREKEEP_AGENT": "cmd"}
+    if ns:
+        env["LOREKEEP_NS"] = ns
+
+    entry: dict = {
+        "transport": "stdio",
+        "command": command,
+        "args": args,
+        "env": env,
+    }
+
+    def mutate(data: dict) -> None:
+        data.setdefault("mcpServers", {})["lorekeep"] = entry
+
+    return merge_json_config(
+        config_target(target_dir, scope), mutate, reset_if_corrupt=True,
+    )

--- a/src/lorekeep/integrations/copilot.py
+++ b/src/lorekeep/integrations/copilot.py
@@ -1,0 +1,52 @@
+"""GitHub Copilot MCP config (.copilot/mcp-config.json) writer.
+
+GitHub Copilot CLI uses the ``mcpServers`` JSON format with a ``type: "local"``
+field on each entry.  Project scope writes ``.github/mcp.json``; user scope
+writes ``~/.copilot/mcp-config.json``.  No declarative session-end hooks yet.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lorekeep.integrations.common import merge_json_config
+
+
+def _copilot_home() -> Path:
+    return Path.home() / ".copilot"
+
+
+def config_target(target_dir: Path, scope: str = "project") -> Path:
+    if scope == "user":
+        return _copilot_home() / "mcp-config.json"
+    return Path(target_dir) / ".github" / "mcp.json"
+
+
+def hook_target(target_dir: Path, scope: str = "project") -> Path | None:
+    return None  # Copilot has no declarative session-end hooks yet.
+
+
+def write_config(
+    target_dir: Path,
+    command: str,
+    args: list[str],
+    ns: str | None = None,
+    *,
+    scope: str = "project",
+) -> Path | None:
+    env: dict[str, str] = {"LOREKEEP_AGENT": "copilot"}
+    if ns:
+        env["LOREKEEP_NS"] = ns
+
+    entry: dict = {
+        "type": "local",
+        "command": command,
+        "args": args,
+        "env": env,
+    }
+
+    def mutate(data: dict) -> None:
+        data.setdefault("mcpServers", {})["lorekeep"] = entry
+
+    return merge_json_config(
+        config_target(target_dir, scope), mutate, reset_if_corrupt=True,
+    )

--- a/src/lorekeep/integrations/registry.py
+++ b/src/lorekeep/integrations/registry.py
@@ -233,6 +233,32 @@ _SPECS: tuple[AgentSpec, ...] = (
         # (state.json per project) that need an LLM summarization path.
         importer_module="",
     ),
+    AgentSpec(
+        name="copilot",
+        label="GitHub Copilot",
+        install_markers=("~/.copilot",),
+        binaries=("copilot",),
+        data_markers=("~/.copilot",),
+        writer_module="lorekeep.integrations.copilot",
+        supports_hook=False,
+        project_config=".github/mcp.json",
+        user_config="~/.copilot/mcp-config.json",
+        # Importer not yet implemented.
+        importer_module="",
+    ),
+    AgentSpec(
+        name="cmd",
+        label="Command Code",
+        install_markers=("~/.commandcode",),
+        binaries=("cmd", "command-code"),
+        data_markers=("~/.commandcode",),
+        writer_module="lorekeep.integrations.commandcode",
+        supports_hook=False,
+        project_config=".commandcode/mcp.json",
+        user_config="~/.commandcode/mcp.json",
+        # Importer not yet implemented.
+        importer_module="",
+    ),
 )
 
 AGENT_NAMES: tuple[str, ...] = tuple(s.name for s in _SPECS)

--- a/tests/test_agent_detect.py
+++ b/tests/test_agent_detect.py
@@ -61,3 +61,13 @@ def test_detect_agents_no_active_returns_all_installed(isolated_home):
     (isolated_home / ".cursor").mkdir()
     result = detect_agents()
     assert set(result) == {"claude", "cursor"}
+
+
+def test_detect_copilot_via_marker(isolated_home):
+    (isolated_home / ".copilot").mkdir()
+    assert "copilot" in detect_installed_agents()
+
+
+def test_detect_cmd_via_marker(isolated_home):
+    (isolated_home / ".commandcode").mkdir()
+    assert "cmd" in detect_installed_agents()

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -13,6 +13,7 @@ from lorekeep.integrations import registry
 def test_agent_names_are_the_supported_agents():
     assert registry.AGENT_NAMES == (
         "claude", "codex", "cursor", "opencode", "grok", "qoder",
+        "copilot", "cmd",
     )
 
 

--- a/tests/test_agent_wire_cli.py
+++ b/tests/test_agent_wire_cli.py
@@ -26,7 +26,7 @@ def wired_project(isolated_home: Path, tmp_path: Path, monkeypatch) -> Path:
     monkeypatch.setenv("LOREKEEP_HOME", str(tmp_path / "data"))
     (tmp_path / "data").mkdir()
     (tmp_path / "data" / "config.yaml").write_text("install_source: local\n")
-    for marker in (".claude", ".codex", ".cursor", ".config/opencode", ".grok", ".qoder"):
+    for marker in (".claude", ".codex", ".cursor", ".config/opencode", ".grok", ".qoder", ".copilot", ".commandcode"):
         (isolated_home / marker).mkdir(parents=True, exist_ok=True)
     return project
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -130,7 +130,10 @@ def test_agents_defaults_are_autonomous():
     assert agents.wire_scope == "user"
     assert agents.watch_transcripts is True
     assert agents.deep_import is False
-    assert agents.enabled == ["claude", "codex", "cursor", "opencode", "grok", "qoder"]
+    assert agents.enabled == [
+        "claude", "codex", "cursor", "opencode", "grok", "qoder",
+        "copilot", "cmd",
+    ]
 
 
 def test_agents_section_is_read_from_yaml(tmp_path: Path):

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -74,7 +74,10 @@ def test_default_config_yaml_agents_values_keep_their_types():
     assert agents.auto_wire is True
     assert agents.wire_scope == "user"
     assert agents.wire_interval_seconds == 900
-    assert agents.enabled == ["claude", "codex", "cursor", "opencode"]
+    assert agents.enabled == [
+        "claude", "codex", "cursor", "opencode", "grok", "qoder",
+        "copilot", "cmd",
+    ]
     assert agents.watch_transcripts is True
     assert agents.deep_import is False
 

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -114,7 +114,9 @@ def test_config_example_validates_against_current_model() -> None:
     config = load_config(ROOT / ".lorekeep/config.yaml.example")
     assert config.provider.model
     assert config.ns.personal_namespace
-    assert set(config.agents.enabled) == {"claude", "cursor", "codex", "opencode"}
+    assert set(config.agents.enabled) == {
+        "claude", "cursor", "codex", "opencode", "grok", "qoder", "copilot", "cmd",
+    }
 
 
 def test_backup_guide_says_pending_journals_are_durable() -> None:

--- a/tests/test_init_chain.py
+++ b/tests/test_init_chain.py
@@ -181,13 +181,13 @@ def test_init_rerun_wires_an_agent_installed_later(isolated_home, tmp_path: Path
     (isolated_home / ".claude").mkdir(parents=True)
 
     runner.invoke(app, ["init", "--yes", "--no-watch"])
-    assert (project / ".mcp.json").exists()
-    assert not (project / "opencode.json").exists()
+    assert (isolated_home / ".claude.json").exists()
+    assert not (isolated_home / ".config" / "opencode" / "opencode.json").exists()
 
     (isolated_home / ".config" / "opencode").mkdir(parents=True)
     result = runner.invoke(app, ["init", "--yes", "--no-watch"])
     assert result.exit_code == 0, result.stdout
-    assert (project / "opencode.json").exists(), f"opencode never wired: {result.stdout}"
+    assert (isolated_home / ".config" / "opencode" / "opencode.json").exists(), f"opencode never wired: {result.stdout}"
 
 
 def test_init_rerun_does_not_rewrite_unchanged_wiring(isolated_home, tmp_path: Path, monkeypatch):
@@ -196,9 +196,10 @@ def test_init_rerun_does_not_rewrite_unchanged_wiring(isolated_home, tmp_path: P
     (isolated_home / ".claude").mkdir(parents=True)
 
     runner.invoke(app, ["init", "--yes", "--no-watch"])
-    before = (project / ".mcp.json").stat().st_mtime_ns
+    claude_json = isolated_home / ".claude.json"
+    before = claude_json.stat().st_mtime_ns
 
     result = runner.invoke(app, ["init", "--yes", "--no-watch"])
     assert result.exit_code == 0, result.stdout
-    assert (project / ".mcp.json").stat().st_mtime_ns == before
+    assert claude_json.stat().st_mtime_ns == before
     assert "already wired" in result.stdout

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -174,7 +174,7 @@ def test_init_no_about_on_second_run(tmp_path: Path, monkeypatch):
 
 
 def test_init_auto_wires_detected_agent(isolated_home, tmp_path: Path, monkeypatch):
-    """init detects active agent from env and writes its MCP config."""
+    """init detects active agent from env and writes its MCP config (user scope)."""
     home = tmp_path / "home"
     project = tmp_path / "project"
     project.mkdir()
@@ -184,14 +184,14 @@ def test_init_auto_wires_detected_agent(isolated_home, tmp_path: Path, monkeypat
     result = runner.invoke(app, ["init", "--yes"])
     assert result.exit_code == 0, result.stdout
     import json
-    mcp_path = project / "opencode.json"
+    mcp_path = isolated_home / ".config" / "opencode" / "opencode.json"
     assert mcp_path.exists(), f"opencode.json not written: {result.stdout}"
     data = json.loads(mcp_path.read_text())
     assert data["mcp"]["lorekeep"]["type"] == "local"
 
 
 def test_init_auto_wires_installed_agents(isolated_home, tmp_path: Path, monkeypatch):
-    """init in shell mode scans filesystem and wires all installed agents."""
+    """init in shell mode scans filesystem and wires all installed agents (user scope)."""
     home = tmp_path / "home"
     project = tmp_path / "project"
     project.mkdir()
@@ -203,8 +203,8 @@ def test_init_auto_wires_installed_agents(isolated_home, tmp_path: Path, monkeyp
 
     result = runner.invoke(app, ["init", "--yes"])
     assert result.exit_code == 0, result.stdout
-    assert (project / ".mcp.json").exists()
-    assert (project / "opencode.json").exists()
+    assert (isolated_home / ".claude.json").exists()
+    assert (isolated_home / ".config" / "opencode" / "opencode.json").exists()
 
 
 def test_init_inside_one_agent_still_wires_the_others(isolated_home, tmp_path: Path, monkeypatch):
@@ -221,8 +221,8 @@ def test_init_inside_one_agent_still_wires_the_others(isolated_home, tmp_path: P
 
     result = runner.invoke(app, ["init", "--yes"])
     assert result.exit_code == 0, result.stdout
-    assert (project / "opencode.json").exists()
-    assert (project / ".mcp.json").exists(), f"claude was skipped: {result.stdout}"
+    assert (isolated_home / ".config" / "opencode" / "opencode.json").exists()
+    assert (isolated_home / ".claude.json").exists(), f"claude was skipped: {result.stdout}"
 
 
 def test_init_no_agents_detected_message(isolated_home, tmp_path: Path, monkeypatch):

--- a/tests/test_init_scope_default.py
+++ b/tests/test_init_scope_default.py
@@ -1,0 +1,92 @@
+"""Init defaults to user-scope wiring (from agents.wire_scope).
+
+The config default is ``wire_scope: user``; init, mcp add, agent wire, and the
+daemon must all honor it so the user never gets project-scope files they didn't
+ask for.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from lorekeep.cli import app
+
+runner = CliRunner()
+
+
+def test_init_defaults_to_user_scope(isolated_home, tmp_path: Path, monkeypatch):
+    """Fresh init with default config writes to user-scope files, not project."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    (isolated_home / ".claude").mkdir(parents=True)
+
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["init", "--yes", "--no-watch"])
+    assert result.exit_code == 0, result.stdout
+
+    # User-scope target
+    assert (isolated_home / ".claude.json").exists()
+    # Project-scope target must NOT exist
+    assert not (project / ".mcp.json").exists()
+
+
+def test_init_respects_wire_scope_project(isolated_home, tmp_path: Path, monkeypatch):
+    """Config with wire_scope: project → project-scope files in cwd."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    (isolated_home / ".claude").mkdir(parents=True)
+
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.chdir(project)
+
+    # First init to create the config
+    runner.invoke(app, ["init", "--yes", "--no-watch"])
+
+    # Override scope to project
+    config_path = home / "config.yaml"
+    config_text = config_path.read_text()
+    config_text = config_text.replace("wire_scope: user", "wire_scope: project")
+    config_path.write_text(config_text)
+
+    # Remove the user-scope file so we can verify project-scope only
+    (isolated_home / ".claude.json").unlink(missing_ok=True)
+
+    # Remove the project file too so we get a clean re-wire
+    (project / ".mcp.json").unlink(missing_ok=True)
+
+    result = runner.invoke(app, ["init", "--yes", "--no-watch"])
+    assert result.exit_code == 0, result.stdout
+
+    # Project-scope target
+    assert (project / ".mcp.json").exists()
+    # User-scope target must NOT exist
+    assert not (isolated_home / ".claude.json").exists()
+
+
+def test_init_no_project_config_files_at_user_scope(isolated_home, tmp_path: Path, monkeypatch):
+    """At default user scope, none of the project-scope files appear in cwd."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    (isolated_home / ".claude").mkdir(parents=True)
+    (isolated_home / ".cursor").mkdir(parents=True)
+    (isolated_home / ".qoder").mkdir(parents=True)
+
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(app, ["init", "--yes", "--no-watch"])
+    assert result.exit_code == 0, result.stdout
+
+    # No project-scope files should exist
+    assert not (project / ".mcp.json").exists()
+    assert not (project / ".cursor").exists()
+    assert not (project / ".qoder").exists()
+    assert not (project / "opencode.json").exists()
+    assert not (project / "config.toml").exists()

--- a/tests/test_integrations_user_scope.py
+++ b/tests/test_integrations_user_scope.py
@@ -13,7 +13,9 @@ from pathlib import Path
 
 import pytest
 
-from lorekeep.integrations import claude_code, codex, cursor, grok, opencode, qoder
+from lorekeep.integrations import (
+    claude_code, codex, commandcode, copilot, cursor, grok, opencode, qoder,
+)
 from lorekeep.integrations.registry import all_specs
 
 CMD = "uvx"
@@ -27,6 +29,8 @@ WRITERS = {
     "opencode": opencode,
     "grok": grok,
     "qoder": qoder,
+    "copilot": copilot,
+    "cmd": commandcode,
 }
 
 
@@ -219,3 +223,77 @@ def test_user_and_project_scope_are_independent(isolated_home, tmp_path):
     claude_code.write_config(project, CMD, ARGS, "me", scope="project")
     assert (project / ".mcp.json").exists()
     assert not (isolated_home / ".claude.json").exists()
+
+
+# ── GitHub Copilot specifics ─────────────────────────────────────────────────
+
+def test_copilot_user_scope_target(isolated_home):
+    assert copilot.config_target(Path("/ignored"), "user") == isolated_home / ".copilot" / "mcp-config.json"
+
+
+def test_copilot_project_scope_target(tmp_path):
+    assert copilot.config_target(tmp_path, "project") == tmp_path / ".github" / "mcp.json"
+
+
+def test_copilot_write_config_sets_mcp_servers(isolated_home, tmp_path):
+    written = copilot.write_config(tmp_path, CMD, ARGS, "me", scope="user")
+    assert written == isolated_home / ".copilot" / "mcp-config.json"
+    data = json.loads(written.read_text())
+    entry = data["mcpServers"]["lorekeep"]
+    assert entry["type"] == "local"
+    assert entry["command"] == CMD
+    assert entry["args"] == ARGS
+    assert entry["env"]["LOREKEEP_AGENT"] == "copilot"
+    assert entry["env"]["LOREKEEP_NS"] == "me"
+
+
+def test_copilot_write_preserves_other_servers(isolated_home, tmp_path):
+    path = isolated_home / ".copilot" / "mcp-config.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"mcpServers": {"other": {"command": "foo"}}}))
+    copilot.write_config(tmp_path, CMD, ARGS, "me", scope="user")
+    data = json.loads(path.read_text())
+    assert "other" in data["mcpServers"]
+    assert "lorekeep" in data["mcpServers"]
+
+
+def test_copilot_idempotent_rewrite(isolated_home, tmp_path):
+    copilot.write_config(tmp_path, CMD, ARGS, "me", scope="user")
+    assert copilot.write_config(tmp_path, CMD, ARGS, "me", scope="user") is None
+
+
+# ── Command Code specifics ───────────────────────────────────────────────────
+
+def test_cmd_user_scope_target(isolated_home):
+    assert commandcode.config_target(Path("/ignored"), "user") == isolated_home / ".commandcode" / "mcp.json"
+
+
+def test_cmd_project_scope_target(tmp_path):
+    assert commandcode.config_target(tmp_path, "project") == tmp_path / ".commandcode" / "mcp.json"
+
+
+def test_cmd_write_config_sets_mcp_servers(isolated_home, tmp_path):
+    written = commandcode.write_config(tmp_path, CMD, ARGS, "me", scope="user")
+    assert written == isolated_home / ".commandcode" / "mcp.json"
+    data = json.loads(written.read_text())
+    entry = data["mcpServers"]["lorekeep"]
+    assert entry["transport"] == "stdio"
+    assert entry["command"] == CMD
+    assert entry["args"] == ARGS
+    assert entry["env"]["LOREKEEP_AGENT"] == "cmd"
+    assert entry["env"]["LOREKEEP_NS"] == "me"
+
+
+def test_cmd_write_preserves_other_servers(isolated_home, tmp_path):
+    path = isolated_home / ".commandcode" / "mcp.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"mcpServers": {"other": {"command": "foo"}}}))
+    commandcode.write_config(tmp_path, CMD, ARGS, "me", scope="user")
+    data = json.loads(path.read_text())
+    assert "other" in data["mcpServers"]
+    assert "lorekeep" in data["mcpServers"]
+
+
+def test_cmd_idempotent_rewrite(isolated_home, tmp_path):
+    commandcode.write_config(tmp_path, CMD, ARGS, "me", scope="user")
+    assert commandcode.write_config(tmp_path, CMD, ARGS, "me", scope="user") is None

--- a/tests/test_mcp_add_cli.py
+++ b/tests/test_mcp_add_cli.py
@@ -9,7 +9,7 @@ def test_mcp_add_claude_project(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("LOREKEEP_CONFIG", str(tmp_path / "config.yaml"))
     (tmp_path / "config.yaml").write_text("install_source: local\n")
-    result = runner.invoke(app, ["mcp", "add", "--agent", "claude", "--ns", "teams/backend"])
+    result = runner.invoke(app, ["mcp", "add", "--agent", "claude", "--scope", "project", "--ns", "teams/backend"])
     assert result.exit_code == 0, result.stdout
     import json
     data = json.loads((tmp_path / ".mcp.json").read_text())
@@ -48,9 +48,9 @@ def test_mcp_add_second_run_reports_unchanged(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("LOREKEEP_CONFIG", str(tmp_path / "config.yaml"))
     (tmp_path / "config.yaml").write_text("install_source: local\n")
-    runner.invoke(app, ["mcp", "add", "--agent", "claude", "--ns", "teams/backend"])
+    runner.invoke(app, ["mcp", "add", "--agent", "claude", "--scope", "project", "--ns", "teams/backend"])
     before = (tmp_path / ".mcp.json").stat().st_mtime_ns
-    result = runner.invoke(app, ["mcp", "add", "--agent", "claude", "--ns", "teams/backend"])
+    result = runner.invoke(app, ["mcp", "add", "--agent", "claude", "--scope", "project", "--ns", "teams/backend"])
     assert result.exit_code == 0, result.stdout
     assert "unchanged" in result.stdout
     assert (tmp_path / ".mcp.json").stat().st_mtime_ns == before
@@ -69,7 +69,7 @@ def test_mcp_add_opencode_project(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("LOREKEEP_CONFIG", str(tmp_path / "config.yaml"))
     (tmp_path / "config.yaml").write_text("install_source: local\n")
-    result = runner.invoke(app, ["mcp", "add", "--agent", "opencode", "--ns", "teams/backend"])
+    result = runner.invoke(app, ["mcp", "add", "--agent", "opencode", "--scope", "project", "--ns", "teams/backend"])
     assert result.exit_code == 0, result.stdout
     import json
     data = json.loads((tmp_path / "opencode.json").read_text())
@@ -89,3 +89,14 @@ def test_mcp_add_unknown_agent(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["mcp", "add", "--agent", "bogus", "--ns", "x"])
     assert result.exit_code == 1
     assert "unknown agent" in result.stdout
+
+
+def test_mcp_add_defaults_to_user_scope(isolated_home: Path, tmp_path: Path, monkeypatch):
+    """mcp add without --scope uses agents.wire_scope (default: user)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LOREKEEP_CONFIG", str(tmp_path / "config.yaml"))
+    (tmp_path / "config.yaml").write_text("install_source: local\n")
+    result = runner.invoke(app, ["mcp", "add", "--agent", "claude"])
+    assert result.exit_code == 0, result.stdout
+    assert (isolated_home / ".claude.json").exists()
+    assert not (tmp_path / ".mcp.json").exists()

--- a/tests/test_session_hook.py
+++ b/tests/test_session_hook.py
@@ -156,7 +156,8 @@ def test_init_writes_claude_hook(tmp_path: Path, monkeypatch):
     result = runner.invoke(app, ["init", "--yes", "--no-watch"])
     assert result.exit_code == 0, result.stdout
 
-    settings = project / ".claude" / "settings.json"
+    # User-scope default: settings.json goes to ~/.claude/settings.json
+    settings = fake_home / ".claude" / "settings.json"
     assert settings.exists(), f"settings.json not written: {result.stdout}"
     data = json.loads(settings.read_text())
     assert "SessionEnd" in data["hooks"]
@@ -176,7 +177,7 @@ def test_mcp_add_writes_claude_hook(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
     monkeypatch.chdir(project)
 
-    result = runner.invoke(app, ["mcp", "add", "--agent", "claude", "--ns", "backend"])
+    result = runner.invoke(app, ["mcp", "add", "--agent", "claude", "--scope", "project", "--ns", "backend"])
     assert result.exit_code == 0, result.stdout
 
     settings = project / ".claude" / "settings.json"
@@ -196,7 +197,7 @@ def test_mcp_add_opencode_writes_hook(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
     monkeypatch.chdir(project)
 
-    result = runner.invoke(app, ["mcp", "add", "--agent", "opencode", "--ns", "backend"])
+    result = runner.invoke(app, ["mcp", "add", "--agent", "opencode", "--scope", "project", "--ns", "backend"])
     assert result.exit_code == 0, result.stdout
 
     plugin = project / ".opencode" / "plugins" / "lorekeep.ts"
@@ -236,7 +237,7 @@ def test_mcp_add_cursor_hook(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
     monkeypatch.chdir(project)
 
-    result = runner.invoke(app, ["mcp", "add", "--agent", "cursor", "--ns", "backend"])
+    result = runner.invoke(app, ["mcp", "add", "--agent", "cursor", "--scope", "project", "--ns", "backend"])
     assert result.exit_code == 0, result.stdout
 
     hooks_path = project / ".cursor" / "hooks.json"
@@ -276,7 +277,7 @@ def test_mcp_add_codex_hook(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("LOREKEEP_HOME", str(home))
     monkeypatch.chdir(project)
 
-    result = runner.invoke(app, ["mcp", "add", "--agent", "codex", "--ns", "backend"])
+    result = runner.invoke(app, ["mcp", "add", "--agent", "codex", "--scope", "project", "--ns", "backend"])
     assert result.exit_code == 0, result.stdout
 
     hooks_path = project / ".codex" / "hooks.json"


### PR DESCRIPTION
## Changes

### 1. Default to user-scope wiring (commit 1)

`init()` and `mcp add` now read `agents.wire_scope` from config (default: `user`) instead of hardcoding `project`. The `_auto_wire_agents` and `_wire_one` defaults also changed from `project` to `user`. `agent wire` and the daemon already respected this config value.

This means `lorekeep init` writes MCP config to the **global** agent config files (`~/.claude.json`, `~/.codex/config.toml`, etc.) by default, not to project-local files. Override with `--scope project` or `config set agents.wire_scope project`.

### 2. GitHub Copilot + Command Code agents (commit 2)

Two new coding agents:

| Agent | Config file | Entry format |
|---|---|---|
| `copilot` (GitHub Copilot) | `~/.copilot/mcp-config.json` | `mcpServers` + `type: local` |
| `cmd` (Command Code) | `~/.commandcode/mcp.json` | `mcpServers` + `transport: stdio` |

Each has a JSON config writer, AgentSpec in the registry, detection marker, and full unit tests (target paths, entry format, idempotency, preserves other servers).

### Test coverage

- 1424 passed, 15 skipped (full suite, excluding pre-existing `test_output.py` Rich rendering flake)
- New: init scope defaulting tests, copilot/cmd writer tests, detection tests
- Updated: existing init/mcp-add/hook tests to expect user-scope by default or pass `--scope project` explicitly
- Updated: registry/detect/config/docs-contract tests for 8-agent list

### Docs

- AGENTS.md: agent list, `mcp add` help string
- README.md: supported agents, init description, config example
- docs/architecture/agent.md: registry count
- .lorekeep/config.yaml.example: enabled list