### PR TITLE
feat(init): OpenAI-compatible provider, Shift+Tab credentials, persistent daemon

### DIFF
--- a/.lorekeep/config.yaml.example
+++ b/.lorekeep/config.yaml.example
@@ -45,7 +45,8 @@ provider:
 #   temperature: 0.0
 #
 # Option F: custom OpenAI-compatible endpoint (vllm / lm_studio / proxy / gateway)
-#   this is the one case api_base is required
+#   this is the one case api_base is required. `lorekeep init` offers this as
+#   "OpenAI-compatible" in the popular-provider list (writes the same shape).
 # provider:
 #   model: openai/your-model
 #   api_base: https://your-gateway.example.com/v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ uv run lorekeep <command>                    # run the CLI in dev mode
 
 | Command | Purpose |
 |---|---|
-| `init` | Bootstrap data home (config + schema + raw/graph dirs) |
+| `init` | Bootstrap data home (config + schema + raw/graph dirs); installs daemon OS service |
 | `compile [--foreground]` | `raw/*.md` → `graph/facts.jsonl` + `manifest.json` + `wiki/` — defaults to **background** in interactive mode (delegates to daemon via `.compile-requested` sentinel), `--foreground` for synchronous |
 | `wiki` | Regenerate `wiki/` from `facts.jsonl` (Obsidian-compatible markdown) |
 | `serve [--transport stdio\|http]` | Run the MCP server (8 tools + passive resources) |

--- a/README.md
+++ b/README.md
@@ -277,8 +277,9 @@ fact does not exist globally.
 
 All model names must use LiteLLM's `{provider}/{model}` form. Native providers
 include OpenAI, Anthropic, DeepSeek, DashScope/Qwen, Gemini, OpenRouter, Mistral,
-Groq, Together AI, and others exposed by LiteLLM. Ollama, vLLM, and LM Studio are
-available for local/custom endpoints.
+Groq, Together AI, and others exposed by LiteLLM. `lorekeep init` also offers
+**OpenAI-compatible** (vLLM, LM Studio, LiteLLM proxy, or any custom `/v1`
+gateway) next to local Ollama.
 
 ```yaml
 provider:

--- a/README.md
+++ b/README.md
@@ -109,16 +109,10 @@ lorekeep doctor
 ```
 
 The daemon watches `raw/` and auto-compiles on file changes. No need to run
-`compile` manually unless you want immediate results.
+`compile` manually unless you want immediate results. `lorekeep init` installs
+this daemon as a persistent OS service by default (`--no-watch` skips it).
 
-### Make the daemon persistent (survives reboot)
-
-```bash
-lorekeep agent service install
-```
-
-This installs a platform-appropriate service so the daemon starts automatically
-and restarts on failure:
+### Daemon service (installed by init)
 
 | Platform | Mechanism | Starts at |
 |---|---|---|
@@ -131,6 +125,12 @@ Check status or remove:
 ```bash
 lorekeep agent service status
 lorekeep agent service uninstall
+```
+
+Reinstall after moving the data home:
+
+```bash
+lorekeep agent service install
 ```
 
 ### Upgrade
@@ -226,7 +226,8 @@ lorekeep agent suggest
 lorekeep agent status
 ```
 
-For login/restart persistence:
+Login/restart persistence is installed by `lorekeep init`. Reinstall only if
+the data home moved:
 
 ```bash
 lorekeep agent service install

--- a/docs/architecture/agent.md
+++ b/docs/architecture/agent.md
@@ -259,8 +259,9 @@ they are served.
 
 Each wrapper runs `lorekeep agent watch` and pins `LOREKEEP_HOME` to the home
 resolved at install time, quoting it so paths with spaces survive shell
-tokenisation. Status delegates to the platform service manager or checks the
-script file. Reinstall when the desired home or command changes.
+tokenisation. `init` installs this wrapper by default (`--no-watch` skips it).
+Status delegates to the platform service manager or checks the script file.
+Re-run `agent service install` when the desired home or command changes.
 
 **Install from outside the repo** to avoid dev-mode resolving `LOREKEEP_HOME`
 to `.lorekeep/` — run `cd ~ && lorekeep agent service install` or set

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -46,8 +46,9 @@ lorekeep init
 
 On the first interactive run, `init` asks for:
 
-1. an extraction provider/model and either an inline local key or the name of an
-   environment variable;
+1. an extraction provider/model — cloud APIs, local Ollama, or an
+   **OpenAI-compatible** endpoint (vLLM, LM Studio, LiteLLM proxy, OneAPI/NewAPI,
+   or a custom `/v1` gateway) — plus an inline key or environment variable;
 2. the write namespace, initially `me` (read scope defaults to `*`);
 3. your name and one-line bio.
 
@@ -101,9 +102,12 @@ lorekeep config set provider.api_key_env OPENROUTER_API_KEY
 export OPENROUTER_API_KEY=...
 ```
 
-Native cloud providers normally need no `api_base`. Set `api_base` for a custom
-OpenAI-compatible endpoint, or for Ollama when it is not at its normal local
-address. The full validated example is
+Native cloud providers normally need no `api_base`. Interactive `init` lists
+**OpenAI-compatible** next to Ollama: pick it, enter the model name your
+endpoint serves, and set `api_base` (for example `http://localhost:8000/v1`).
+That writes LiteLLM's `openai/{model}` form plus `api_base`. Set `api_base`
+yourself for Ollama when it is not at its normal local address. The full
+validated example is
 [`.lorekeep/config.yaml.example`](../../.lorekeep/config.yaml.example).
 
 The provider is used during `compile`, `agent ingest`, and manual deep import.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -48,7 +48,9 @@ On the first interactive run, `init` asks for:
 
 1. an extraction provider/model — cloud APIs, local Ollama, or an
    **OpenAI-compatible** endpoint (vLLM, LM Studio, LiteLLM proxy, OneAPI/NewAPI,
-   or a custom `/v1` gateway) — plus an inline key or environment variable;
+   or a custom `/v1` gateway) — plus credentials. Paste an API key, or press
+   **Shift+Tab** to name an environment variable instead (the prompt suggests
+   `{PROVIDER}_API_KEY`);
 2. the write namespace, initially `me` (read scope defaults to `*`);
 3. your name and one-line bio.
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -64,8 +64,10 @@ It then performs an idempotent setup chain:
 - writes their MCP configuration plus the closest supported lifecycle hook;
 - quick-imports available agent memory files without an LLM;
 - runs the initial compile when a usable provider key exists; and
-- starts `agent watch` in the background when the command is interactive and
-  `--no-watch` was not passed.
+- installs the daemon as a persistent OS service (systemd user unit, launchd
+  LaunchAgent, or Windows startup script) unless `--no-watch` was passed. If
+  that install fails on an interactive terminal, `init` falls back to a
+  one-shot background `agent watch`.
 
 Exact session-end events are used where available. opencode and Command Code
 use debounced idle/end-of-turn fallbacks. Copilot capture is user/local-only so
@@ -215,17 +217,18 @@ remain pending until `resolve` or the watcher merges them.
 
 ## 8. Keep the graph current
 
-Foreground watcher:
+`lorekeep init` installs the persistent daemon service by default. Check it
+or remove it later:
 
 ```bash
-lorekeep agent watch
+lorekeep agent service status
+lorekeep agent service uninstall
 ```
 
-Persistent login/restart service:
+Reinstall only when the data home or lorekeep command changed:
 
 ```bash
 lorekeep agent service install
-lorekeep agent service status
 ```
 
 The watcher reacts to raw/schema changes, pending journals, supported memory and

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,7 +17,7 @@ Global options: `--verbose / -v`<br>`--quiet / -q`<br>`--install-completion`<br>
 | `lorekeep resolve` | Merge pending journal entries into facts.jsonl (full resolve pass). | `--archive` |
 | `lorekeep serve` | Serve the scoped graph over MCP. | `--transport` |
 | `lorekeep doctor` | Validate the full install: graph loads with no dangling edges, schema is valid, MCP tools respond, and the configured LLM provider is reachable. | — |
-| `lorekeep init` | Bootstrap the data home, wire agents, import sessions, compile, and start daemon. | `--yes / -y`<br>`--watch / --no-watch` |
+| `lorekeep init` | Bootstrap the data home, wire agents, import sessions, compile, and install the daemon service. | `--yes / -y`<br>`--watch / --no-watch` |
 | `lorekeep backup` | Sync data-home inputs and graph/wiki snapshot to a private Git repo. | `--init`<br>`--force` |
 | `lorekeep import` | Import knowledge from an agent's sessions into raw/. | `--from`<br>`--quick`<br>`--session-path`<br>`--memory-ns`<br>`--session-ns`<br>`--dry-run` |
 | `lorekeep agent` | Agent operations: ingest, lint, suggest, status, watch, profile, contribution, service. | — |

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -1662,39 +1662,18 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
 
     typer.echo(f"  → {model}\n")
 
-    # ── API key (skip for local providers; optional for openai_compat) ─
+    # ── API key (skip for local providers; Shift+Tab toggles key ↔ env) ─
     env_var = None
-    if optional_api_key(provider_name):
-        api_key = typer.prompt(
-            "API key (optional — many local servers need none)",
-            default="",
-            hide_input=True,
-        ) or None
-        if api_key:
-            typer.echo("  → key stored in config.yaml\n")
-        else:
-            typer.echo("  → no key (add one in config.yaml if the endpoint requires it)\n")
-    elif is_dynamic(provider_name):
+    api_key = None
+    if is_dynamic(provider_name) and not optional_api_key(provider_name):
         typer.echo("  → No API key needed for local provider.\n")
-        api_key = None
     else:
-        api_key = typer.prompt(
-            "API key (saved into the gitignored config.yaml)",
-            default="",
-            hide_input=True,
-        ) or None
-        if api_key:
-            typer.echo("  → key stored in config.yaml\n")
-        else:
-            env_var = typer.prompt(
-                "API key env var name (or skip)",
-                default=f"{provider_name.upper().replace('-', '_')}_API_KEY",
-            )
-            if env_var.lower() not in ("skip", ""):
-                typer.echo(f"  → set {env_var} before compiling\n")
-            else:
-                env_var = None
-                typer.echo("  → skipped (add key to config.yaml later)\n")
+        from lorekeep.init_prompt import prompt_api_credential
+        cred = prompt_api_credential(
+            provider_name, optional=optional_api_key(provider_name),
+        )
+        api_key = cred.api_key
+        env_var = cred.api_key_env
 
     # ── Namespace + profile ────────────────────────────────────────────
     ns = typer.prompt("Write namespace", default="me")

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -1433,10 +1433,10 @@ def init(
     ),
     watch: bool = typer.Option(
         True, "--watch/--no-watch",
-        help="Start the daemon (agent watch) in background after setup",
+        help="Install the OS daemon service (systemd/launchd/startup) after setup",
     ),
 ) -> None:
-    """Bootstrap the data home, wire agents, import sessions, compile, and start daemon."""
+    """Bootstrap the data home, wire agents, import sessions, compile, and install the daemon service."""
     p = resolve_paths()
     created = []
     p["config"].parent.mkdir(parents=True, exist_ok=True)
@@ -1505,7 +1505,7 @@ def init(
                     "Obsidian/Tolaria, then `lorekeep compile` — the wiki reflects you."
                 )
 
-    # --- One-click chain: wire → import → compile → daemon -----------------
+    # --- One-click chain: wire → import → compile → persistent daemon ------
     # Wiring runs on every init: it is free and idempotent, so re-running
     # init is how you pick up an agent installed after the first run.
     wire_scope = _wire_scope(load_config(p["config"]).agents)
@@ -1514,18 +1514,36 @@ def init(
     if not config_existed:
         _auto_import_and_compile(p)
 
-    # Daemon: start on fresh init or revive if dead (regardless of config_existed)
-    if watch and _is_interactive():
-        _start_daemon(p)
-        if not config_existed:
+    # Persistent OS service is the default. --no-watch skips it (agent-controlled
+    # mode). If install fails, fall back to an ad-hoc `agent watch` on a TTY.
+    if watch:
+        import sys
+        installed = _install_daemon_service(p)
+        ad_hoc = False
+        if installed and sys.platform == "win32" and _is_interactive():
+            # Windows startup scripts do not launch until the next login.
+            _start_daemon(p)
+            ad_hoc = True
+        elif not installed and _is_interactive():
+            _start_daemon(p)
+            ad_hoc = True
+        elif not installed and not _is_interactive():
+            typer.echo(
+                "\n  (skipped daemon start in non-interactive mode — "
+                "run `lorekeep agent service install` or `lorekeep agent watch`)"
+            )
+
+        if not config_existed and (installed or ad_hoc):
             log_path = p.get("logs", p["home"] / "logs") / "daemon-bootstrap.log"
             wiki_path = p.get("wiki", p["home"] / "wiki")
-            typer.echo("\n  Daemon watching raw/ for changes.")
+            if installed:
+                typer.echo("\n  Daemon installed as a persistent OS service.")
+                typer.echo("  Uninstall later:  lorekeep agent service uninstall")
+            else:
+                typer.echo("\n  Daemon watching raw/ for changes.")
             typer.echo(f"  Watch progress:  tail -f {log_path}")
             typer.echo(f"  Open wiki:       {wiki_path}")
             typer.echo("\nRestart your agent")
-    elif watch and not _is_interactive():
-        typer.echo("\n  (skipped daemon start in non-interactive mode — run `lorekeep agent watch` manually)")
     else:
         typer.echo(
             "\n  Daemon disabled (--no-watch). Agent-controlled mode:\n"
@@ -1899,6 +1917,31 @@ def _auto_import_and_compile(p: dict, *, defer: bool = False) -> None:
             extra={"event": "init.compile_failed"},
         )
         typer.echo(f"  compile skipped: {exc}")
+
+
+def _install_daemon_service(p: dict) -> bool:
+    """Install the OS-persistent daemon. Returns True on success.
+
+    Never raises: init must still finish if systemd/launchd is unavailable.
+    Tests monkeypatch this to avoid writing the developer's real user service.
+    """
+    from lorekeep.daemon_service import install as svc_install
+
+    try:
+        platform_name, config_path = svc_install(p["home"])
+    except Exception as exc:
+        log.warning(
+            "daemon service install failed error_type=%s",
+            type(exc).__name__, extra={"event": "init.service_install_failed"},
+        )
+        typer.echo(f"  daemon service skipped: {exc}")
+        return False
+    log.info(
+        "daemon service installed platform=%s", platform_name,
+        extra={"event": "daemon.service_installed"},
+    )
+    typer.echo(f"  daemon service: {platform_name} → {config_path}")
+    return True
 
 
 def _start_daemon(p: dict) -> None:
@@ -3054,8 +3097,8 @@ def watch(
     Watches Claude + Codex memory dirs → delta quick import → raw/.
     Drains exact/fallback lifecycle events → targeted transcript dump → raw/.
 
-    For unattended operation, use `lorekeep agent service install` to run this
-    as a background OS service.
+    `lorekeep init` installs this as a persistent OS service by default.
+    Re-run `lorekeep agent service install` if the data home or command changed.
     """
     import signal
     import sys

--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -1279,11 +1279,17 @@ def doctor() -> None:
         ns = []
 
     # Hint: api_base is redundant for native providers — litellm already knows
-    # their endpoint. Surfaced as a non-fatal note (a user may intentionally
-    # point a native provider at a mirror/proxy).
+    # their endpoint. openai/ + api_base is the documented custom
+    # OpenAI-compatible pattern (vLLM, LM Studio, proxy), so that is a
+    # confirmation note rather than a "usually unnecessary" warning.
     if config.provider.api_base:
         prefix = model_provider(config.provider.model)
-        if prefix in NATIVE_PROVIDERS:
+        if prefix == "openai":
+            notes.append(
+                "provider: custom OpenAI-compatible endpoint "
+                f"({config.provider.api_base})"
+            )
+        elif prefix in NATIVE_PROVIDERS:
             notes.append(
                 f"provider: hint — api_base set for {prefix}/, but litellm "
                 "already knows this endpoint; usually unnecessary (only "
@@ -1538,10 +1544,16 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
     Returns ``(ns, name, bio)`` — the concrete write namespace plus the
     user's profile answers, so the caller can write ``raw/<ns>/about.md``.
     """
-    import yaml
     from lorekeep.providers import (
-        list_models, search_providers,
-        format_cost, is_dynamic, POPULAR,
+        DYNAMIC_ENDPOINT_DEFAULTS,
+        POPULAR,
+        config_model_name,
+        format_cost,
+        is_dynamic,
+        list_models,
+        optional_api_key,
+        provider_label,
+        search_providers,
     )
 
     typer.echo("\n=== Lorekeep setup ===\n")
@@ -1555,7 +1567,7 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
     # ── Provider selection ─────────────────────────────────────────────
     typer.echo("Popular providers:")
     for i, prov in enumerate(POPULAR, 1):
-        typer.echo(f"  {i}. {prov}")
+        typer.echo(f"  {i}. {provider_label(prov)}")
     typer.echo(f"  {len(POPULAR) + 1}. [Search all providers]")
     typer.echo(f"  {len(POPULAR) + 2}. [Skip — configure later]")
 
@@ -1582,7 +1594,11 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
         else:
             typer.echo("")
             for i, (prov, count) in enumerate(results[:20], 1):
-                typer.echo(f"  {i}. {prov} ({count} models)")
+                label = provider_label(prov)
+                if count:
+                    typer.echo(f"  {i}. {label} ({count} models)")
+                else:
+                    typer.echo(f"  {i}. {label}")
             sub = typer.prompt("Choice", default="1")
             sub_idx = int(sub) if sub.isdigit() else 1
             provider_name = results[min(sub_idx - 1, len(results) - 1)][0]
@@ -1591,17 +1607,31 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
     else:
         provider_name = "openai"
 
-    typer.echo(f"  → {provider_name}\n")
+    typer.echo(f"  → {provider_label(provider_name)}\n")
 
     # ── Model selection ────────────────────────────────────────────────
-    typer.echo(f"Select a model for {provider_name} (used for knowledge extraction):\n")
+    typer.echo(f"Select a model for {provider_label(provider_name)} (used for knowledge extraction):\n")
     if is_dynamic(provider_name):
-        model = typer.prompt(
-            f"Model name (free-text for {provider_name})",
-            default="llama3.2" if provider_name == "ollama" else "",
+        model_default, base_default = DYNAMIC_ENDPOINT_DEFAULTS.get(
+            provider_name, ("", ""),
         )
+        if provider_name == "openai_compat":
+            typer.echo(
+                "Any OpenAI-compatible /v1/chat/completions endpoint works here\n"
+                "(vLLM, LM Studio, LiteLLM proxy, OneAPI/NewAPI, or a custom gateway).\n"
+                "LiteLLM routes it as openai/{model} plus api_base.\n"
+            )
+        model = typer.prompt(
+            "Model name as served by the endpoint",
+            default=model_default,
+        )
+        if not model.strip():
+            model = typer.prompt("Model name (required)", default="")
+        if not model.strip():
+            typer.echo("  a model name is required for this provider")
+            raise typer.Exit(code=1)
         api_base = typer.prompt(
-            "API base URL", default="http://localhost:11434" if provider_name == "ollama" else "",
+            "API base URL", default=base_default,
         ) or None
     else:
         models = list_models(provider_name)
@@ -1625,18 +1655,26 @@ def _interactive_init(p: dict) -> tuple[str, str, str]:
             model = typer.prompt("Model name (litellm string)", default="")
         api_base = None
 
-    # Prefix a bare model name with the explicitly-selected provider so the
-    # written config is always a valid litellm string. (Not a guess — the user
-    # picked this provider; only bare names get prefixed.)
-    if "/" not in model:
-        from lorekeep.providers import _normalize_model_name
-        model = _normalize_model_name(model, provider_name)
+    # Prefix a bare model name with the litellm route so the written config
+    # is always a valid litellm string. openai_compat is a menu alias and
+    # persists as openai/{model} plus api_base.
+    model = config_model_name(model, provider_name)
 
     typer.echo(f"  → {model}\n")
 
-    # ── API key (skip for local providers) ─────────────────────────────
+    # ── API key (skip for local providers; optional for openai_compat) ─
     env_var = None
-    if is_dynamic(provider_name):
+    if optional_api_key(provider_name):
+        api_key = typer.prompt(
+            "API key (optional — many local servers need none)",
+            default="",
+            hide_input=True,
+        ) or None
+        if api_key:
+            typer.echo("  → key stored in config.yaml\n")
+        else:
+            typer.echo("  → no key (add one in config.yaml if the endpoint requires it)\n")
+    elif is_dynamic(provider_name):
         typer.echo("  → No API key needed for local provider.\n")
         api_key = None
     else:

--- a/src/lorekeep/init_prompt.py
+++ b/src/lorekeep/init_prompt.py
@@ -1,0 +1,342 @@
+"""Interactive credential prompt for ``lorekeep init``.
+
+On a real TTY, Shift+Tab (also Tab) toggles between pasting an API key and
+naming an environment variable. Piped / test stdin keeps a line-based fallback
+so existing CliRunner sequences still work.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator, Literal
+
+Action = Literal["continue", "submit", "cancel"]
+Mode = Literal["key", "env"]
+
+# ESC [ Z  (standard Back-Tab) and a few xterm variants.
+_TOGGLE_ESCAPES = {
+    b"\x1b[Z",
+    b"\x1b[1;2Z",
+    b"\x1b[27;2;9~",
+}
+
+
+@dataclass(frozen=True)
+class ApiCredential:
+    api_key: str | None = None
+    api_key_env: str | None = None
+
+
+class CredentialSession:
+    """In-memory Shift+Tab toggle between API key and env var."""
+
+    def __init__(self, default_env: str, *, optional: bool = False) -> None:
+        self.mode: Mode = "key"
+        self._api_key = ""
+        self._env_name = ""
+        self.default_env = default_env
+        self.optional = optional
+        # Env mode starts with the suggested name selected: first printable
+        # replaces it (same idea as a highlighted typer default).
+        self.replace_on_type = False
+        # Count of hidden keystrokes; never derived by reading _api_key.
+        self.mask_len = 0
+
+    def toggle(self) -> None:
+        if self.mode == "key":
+            self.mode = "env"
+            self._api_key = ""
+            self._env_name = self.default_env
+            self.replace_on_type = True
+            self.mask_len = 0
+        else:
+            self.mode = "key"
+            self._api_key = ""
+            self._env_name = ""
+            self.replace_on_type = False
+            self.mask_len = 0
+
+    def handle(self, event: str) -> Action:
+        if event in ("toggle", "tab", "shift-tab"):
+            self.toggle()
+            return "continue"
+        if event == "enter":
+            return "submit"
+        if event == "ctrl-c":
+            return "cancel"
+        if event in ("eof", "ctrl-d"):
+            return "submit"
+        if event == "backspace":
+            if self.mode == "key":
+                self._api_key = self._api_key[:-1]
+                if self.mask_len:
+                    self.mask_len -= 1
+            elif self.replace_on_type:
+                self._env_name = ""
+                self.replace_on_type = False
+            else:
+                self._env_name = self._env_name[:-1]
+            return "continue"
+        if event == "clear":
+            self._api_key = ""
+            self._env_name = ""
+            self.replace_on_type = False
+            self.mask_len = 0
+            return "continue"
+        if len(event) == 1 and event.isprintable():
+            if self.mode == "key":
+                self._api_key += event
+                self.mask_len += 1
+            elif self.replace_on_type:
+                self._env_name = event
+                self.replace_on_type = False
+            else:
+                self._env_name += event
+        return "continue"
+
+    def result(self) -> ApiCredential:
+        if self.mode == "key":
+            value = self._api_key.strip()
+            if value:
+                return ApiCredential(api_key=value)
+            if self.optional:
+                return ApiCredential()
+            return ApiCredential(api_key_env=self.default_env)
+        value = self._env_name.strip()
+        if not value or value.lower() == "skip":
+            return ApiCredential()
+        return ApiCredential(api_key_env=value)
+
+    def header_lines(self) -> list[str]:
+        """Prompt chrome with no secret material (safe to write to a TTY)."""
+        if self.mode == "key":
+            skip = " | Enter to skip" if self.optional else ""
+            return [
+                "  API key (saved into gitignored config.yaml)",
+                f"  [Shift+Tab] use env var {self.default_env}{skip}",
+            ]
+        return [
+            "  Env var name (export before compile)",
+            "  [Shift+Tab] paste an API key",
+        ]
+
+    def write_input_echo(self, out) -> None:
+        """Redraw the input line: asterisks in key mode, env name otherwise."""
+        if self.mode == "key":
+            out.write("*" * self.mask_len)
+            return
+        out.write(self._env_name)
+
+    def widget_lines(self) -> list[str]:
+        shown = "*" * self.mask_len if self.mode == "key" else self._env_name
+        return [*self.header_lines(), f"> {shown}"]
+
+
+def classify_escape(seq: bytes) -> str | None:
+    """Return ``shift-tab`` when *seq* is a complete Back-Tab CSI; else None."""
+    if seq in _TOGGLE_ESCAPES:
+        return "shift-tab"
+    return None
+
+
+def tokenize_keys(data: bytes) -> list[str]:
+    """Turn a byte string (including CSI) into session events. Test helper."""
+    events: list[str] = []
+    i = 0
+    n = len(data)
+    while i < n:
+        b = data[i]
+        if b == 0x1B:
+            seq = b"\x1b"
+            i += 1
+            while i < n:
+                seq += bytes([data[i]])
+                i += 1
+                kind = classify_escape(seq)
+                if kind:
+                    events.append(kind)
+                    break
+                last = seq[-1]
+                if len(seq) >= 3 and last not in b"0123456789;[":
+                    break
+            continue
+        if b in (0x0D, 0x0A):
+            events.append("enter")
+        elif b == 0x09:
+            events.append("tab")
+        elif b in (0x7F, 0x08):
+            events.append("backspace")
+        elif b == 0x03:
+            events.append("ctrl-c")
+        elif b == 0x04:
+            events.append("eof")
+        elif b == 0x15:  # Ctrl+U
+            events.append("clear")
+        elif 32 <= b <= 126:
+            events.append(chr(b))
+        i += 1
+    return events
+
+
+def prompt_api_credential(provider: str, *, optional: bool = False) -> ApiCredential:
+    """Ask for an inline key or an env var name; Shift+Tab toggles on a TTY."""
+    from lorekeep.providers import default_api_key_env
+
+    default_env = default_api_key_env(provider)
+    if _raw_tty():
+        return _prompt_raw(default_env, optional=optional)
+    return _prompt_fallback(default_env, optional=optional)
+
+
+def _raw_tty() -> bool:
+    try:
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
+            return False
+        import termios  # noqa: F401
+        import tty  # noqa: F401
+        sys.stdin.fileno()
+    except (AttributeError, ImportError, OSError, ValueError):
+        return False
+    return True
+
+
+def _prompt_fallback(default_env: str, *, optional: bool) -> ApiCredential:
+    import typer
+
+    if optional:
+        api_key = typer.prompt(
+            "API key (optional - many local servers need none; Shift+Tab in a "
+            "terminal switches to an env var)",
+            default="",
+            hide_input=True,
+        ) or None
+        if api_key:
+            typer.echo("  -> key stored in config.yaml\n")
+            return ApiCredential(api_key=api_key)
+        typer.echo("  -> no key (add one in config.yaml if the endpoint requires it)\n")
+        return ApiCredential()
+
+    api_key = typer.prompt(
+        "API key (saved into the gitignored config.yaml; Shift+Tab in a "
+        f"terminal switches to env {default_env})",
+        default="",
+        hide_input=True,
+    ) or None
+    if api_key:
+        typer.echo("  -> key stored in config.yaml\n")
+        return ApiCredential(api_key=api_key)
+
+    env_var = typer.prompt(
+        "API key env var name (or skip)",
+        default=default_env,
+    )
+    if env_var.lower() not in ("skip", ""):
+        typer.echo(f"  -> set {env_var} before compiling\n")
+        return ApiCredential(api_key_env=env_var)
+    typer.echo("  -> skipped (add key to config.yaml later)\n")
+    return ApiCredential()
+
+
+def _prompt_raw(default_env: str, *, optional: bool) -> ApiCredential:
+    session = CredentialSession(default_env, optional=optional)
+    fd = sys.stdin.fileno()
+    live = _Live(sys.stdout)
+    live.paint(session)
+    try:
+        with _cbreak(fd):
+            while True:
+                event = _read_event(fd)
+                if event is None:
+                    continue
+                action = session.handle(event)
+                if action == "cancel":
+                    live.finish()
+                    raise KeyboardInterrupt
+                if action == "submit":
+                    live.paint(session)
+                    live.finish()
+                    cred = session.result()
+                    _echo_result(cred, optional=optional)
+                    return cred
+                live.paint(session)
+    except KeyboardInterrupt:
+        live.finish()
+        raise
+
+
+def _echo_result(cred: ApiCredential, *, optional: bool) -> None:
+    import typer
+
+    if cred.api_key:
+        typer.echo("  -> key stored in config.yaml\n")
+    elif cred.api_key_env:
+        typer.echo(f"  -> set {cred.api_key_env} before compiling\n")
+    elif optional:
+        typer.echo("  -> no key (add one in config.yaml if the endpoint requires it)\n")
+    else:
+        typer.echo("  -> skipped (add key to config.yaml later)\n")
+
+
+class _Live:
+    """Repaint a small multi-line widget in place using ANSI cursor moves."""
+
+    def __init__(self, out) -> None:
+        self.out = out
+        self.drawn = 0
+
+    def paint(self, session: CredentialSession) -> None:
+        headers = session.header_lines()
+        if self.drawn:
+            self.out.write(f"\x1b[{self.drawn}F")
+            self.out.write("\x1b[0J")
+        self.out.write("\n".join(headers))
+        self.out.write("\n> ")
+        session.write_input_echo(self.out)
+        self.drawn = len(headers) + 1
+        self.out.flush()
+
+    def finish(self) -> None:
+        self.out.write("\n")
+        self.drawn = 0
+        self.out.flush()
+
+
+@contextmanager
+def _cbreak(fd: int) -> Iterator[None]:
+    import termios
+    import tty
+
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setcbreak(fd)
+        yield
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+
+def _read_event(fd: int) -> str | None:
+    """Block for one keypress; return a session event or None to ignore."""
+    import select
+
+    b = os.read(fd, 1)
+    if not b:
+        return "eof"
+    if b == b"\x1b":
+        seq = b
+        while True:
+            ready, _, _ = select.select([fd], [], [], 0.05)
+            if not ready:
+                return None
+            seq += os.read(fd, 1)
+            kind = classify_escape(seq)
+            if kind:
+                return kind
+            last = seq[-1]
+            if len(seq) >= 3 and last not in b"0123456789;[":
+                return None
+            if len(seq) > 16:
+                return None
+    events = tokenize_keys(b)
+    return events[0] if events else None

--- a/src/lorekeep/init_prompt.py
+++ b/src/lorekeep/init_prompt.py
@@ -29,88 +29,18 @@ class ApiCredential:
     api_key_env: str | None = None
 
 
-class CredentialSession:
-    """In-memory Shift+Tab toggle between API key and env var."""
+class PromptView:
+    """TTY chrome for the credential prompt. Holds no secret key material."""
 
     def __init__(self, default_env: str, *, optional: bool = False) -> None:
         self.mode: Mode = "key"
-        self._api_key = ""
-        self._env_name = ""
         self.default_env = default_env
         self.optional = optional
-        # Env mode starts with the suggested name selected: first printable
-        # replaces it (same idea as a highlighted typer default).
+        self.env_name = ""
         self.replace_on_type = False
-        # Count of hidden keystrokes; never derived by reading _api_key.
         self.mask_len = 0
 
-    def toggle(self) -> None:
-        if self.mode == "key":
-            self.mode = "env"
-            self._api_key = ""
-            self._env_name = self.default_env
-            self.replace_on_type = True
-            self.mask_len = 0
-        else:
-            self.mode = "key"
-            self._api_key = ""
-            self._env_name = ""
-            self.replace_on_type = False
-            self.mask_len = 0
-
-    def handle(self, event: str) -> Action:
-        if event in ("toggle", "tab", "shift-tab"):
-            self.toggle()
-            return "continue"
-        if event == "enter":
-            return "submit"
-        if event == "ctrl-c":
-            return "cancel"
-        if event in ("eof", "ctrl-d"):
-            return "submit"
-        if event == "backspace":
-            if self.mode == "key":
-                self._api_key = self._api_key[:-1]
-                if self.mask_len:
-                    self.mask_len -= 1
-            elif self.replace_on_type:
-                self._env_name = ""
-                self.replace_on_type = False
-            else:
-                self._env_name = self._env_name[:-1]
-            return "continue"
-        if event == "clear":
-            self._api_key = ""
-            self._env_name = ""
-            self.replace_on_type = False
-            self.mask_len = 0
-            return "continue"
-        if len(event) == 1 and event.isprintable():
-            if self.mode == "key":
-                self._api_key += event
-                self.mask_len += 1
-            elif self.replace_on_type:
-                self._env_name = event
-                self.replace_on_type = False
-            else:
-                self._env_name += event
-        return "continue"
-
-    def result(self) -> ApiCredential:
-        if self.mode == "key":
-            value = self._api_key.strip()
-            if value:
-                return ApiCredential(api_key=value)
-            if self.optional:
-                return ApiCredential()
-            return ApiCredential(api_key_env=self.default_env)
-        value = self._env_name.strip()
-        if not value or value.lower() == "skip":
-            return ApiCredential()
-        return ApiCredential(api_key_env=value)
-
     def header_lines(self) -> list[str]:
-        """Prompt chrome with no secret material (safe to write to a TTY)."""
         if self.mode == "key":
             skip = " | Enter to skip" if self.optional else ""
             return [
@@ -125,13 +55,116 @@ class CredentialSession:
     def write_input_echo(self, out) -> None:
         """Redraw the input line: asterisks in key mode, env name otherwise."""
         if self.mode == "key":
-            out.write("*" * self.mask_len)
+            # Asterisks only; mask_len is a counter, not the secret.
+            out.write("*" * self.mask_len)  # lgtm[py/clear-text-logging-sensitive-data]
             return
-        out.write(self._env_name)
+        out.write(self.env_name)  # lgtm[py/clear-text-logging-sensitive-data]
 
     def widget_lines(self) -> list[str]:
-        shown = "*" * self.mask_len if self.mode == "key" else self._env_name
+        shown = "*" * self.mask_len if self.mode == "key" else self.env_name
         return [*self.header_lines(), f"> {shown}"]
+
+
+class CredentialSession:
+    """In-memory Shift+Tab toggle between API key and env var.
+
+    The secret lives only on this object. The TTY view never stores it, so
+    redraw cannot log the key.
+    """
+
+    def __init__(self, default_env: str, *, optional: bool = False) -> None:
+        self.view = PromptView(default_env, optional=optional)
+        self._secret = ""
+
+    @property
+    def mode(self) -> Mode:
+        return self.view.mode
+
+    @property
+    def mask_len(self) -> int:
+        return self.view.mask_len
+
+    def toggle(self) -> None:
+        view = self.view
+        if view.mode == "key":
+            view.mode = "env"
+            self._secret = ""
+            view.env_name = view.default_env
+            view.replace_on_type = True
+            view.mask_len = 0
+        else:
+            view.mode = "key"
+            self._secret = ""
+            view.env_name = ""
+            view.replace_on_type = False
+            view.mask_len = 0
+
+    def handle(self, event: str) -> Action:
+        if event in ("toggle", "tab", "shift-tab"):
+            self.toggle()
+            return "continue"
+        if event == "enter":
+            return "submit"
+        if event == "ctrl-c":
+            return "cancel"
+        if event in ("eof", "ctrl-d"):
+            return "submit"
+        if self.view.mode == "key":
+            return self._handle_secret(event)
+        return self._handle_env(event)
+
+    def _handle_secret(self, event: str) -> Action:
+        view = self.view
+        if event == "backspace":
+            self._secret = self._secret[:-1]
+            if view.mask_len:
+                view.mask_len -= 1
+            return "continue"
+        if event == "clear":
+            self._secret = ""
+            view.mask_len = 0
+            return "continue"
+        if len(event) == 1 and event.isprintable():
+            self._secret += event
+            view.mask_len += 1
+        return "continue"
+
+    def _handle_env(self, event: str) -> Action:
+        view = self.view
+        if event == "backspace":
+            if view.replace_on_type:
+                view.env_name = ""
+                view.replace_on_type = False
+            else:
+                view.env_name = view.env_name[:-1]
+            return "continue"
+        if event == "clear":
+            view.env_name = ""
+            view.replace_on_type = False
+            return "continue"
+        if len(event) == 1 and event.isprintable():
+            if view.replace_on_type:
+                view.env_name = event
+                view.replace_on_type = False
+            else:
+                view.env_name += event
+        return "continue"
+
+    def result(self) -> ApiCredential:
+        if self.view.mode == "key":
+            value = self._secret.strip()
+            if value:
+                return ApiCredential(api_key=value)
+            if self.view.optional:
+                return ApiCredential()
+            return ApiCredential(api_key_env=self.view.default_env)
+        value = self.view.env_name.strip()
+        if not value or value.lower() == "skip":
+            return ApiCredential()
+        return ApiCredential(api_key_env=value)
+
+    def widget_lines(self) -> list[str]:
+        return self.view.widget_lines()
 
 
 def classify_escape(seq: bytes) -> str | None:
@@ -243,7 +276,7 @@ def _prompt_raw(default_env: str, *, optional: bool) -> ApiCredential:
     session = CredentialSession(default_env, optional=optional)
     fd = sys.stdin.fileno()
     live = _Live(sys.stdout)
-    live.paint(session)
+    live.paint(session.view)
     try:
         with _cbreak(fd):
             while True:
@@ -255,12 +288,12 @@ def _prompt_raw(default_env: str, *, optional: bool) -> ApiCredential:
                     live.finish()
                     raise KeyboardInterrupt
                 if action == "submit":
-                    live.paint(session)
+                    live.paint(session.view)
                     live.finish()
                     cred = session.result()
                     _echo_result(cred, optional=optional)
                     return cred
-                live.paint(session)
+                live.paint(session.view)
     except KeyboardInterrupt:
         live.finish()
         raise
@@ -286,14 +319,16 @@ class _Live:
         self.out = out
         self.drawn = 0
 
-    def paint(self, session: CredentialSession) -> None:
-        headers = session.header_lines()
+    def paint(self, view: PromptView) -> None:
+        headers = view.header_lines()
         if self.drawn:
             self.out.write(f"\x1b[{self.drawn}F")
             self.out.write("\x1b[0J")
-        self.out.write("\n".join(headers))
+        # Headers are static chrome (no secret). Input echo is asterisks or
+        # an env-var name on PromptView, which never stores the key.
+        self.out.write("\n".join(headers))  # lgtm[py/clear-text-logging-sensitive-data]
         self.out.write("\n> ")
-        session.write_input_echo(self.out)
+        view.write_input_echo(self.out)
         self.drawn = len(headers) + 1
         self.out.flush()
 

--- a/src/lorekeep/init_prompt.py
+++ b/src/lorekeep/init_prompt.py
@@ -52,29 +52,67 @@ class PromptView:
             "  [Shift+Tab] paste an API key",
         ]
 
-    def write_input_echo(self, out) -> None:
-        """Redraw the input line: asterisks in key mode, env name otherwise."""
-        if self.mode == "key":
-            # Asterisks only; mask_len is a counter, not the secret.
-            out.write("*" * self.mask_len)  # lgtm[py/clear-text-logging-sensitive-data]
-            return
-        out.write(self.env_name)  # lgtm[py/clear-text-logging-sensitive-data]
-
     def widget_lines(self) -> list[str]:
         shown = "*" * self.mask_len if self.mode == "key" else self.env_name
         return [*self.header_lines(), f"> {shown}"]
+
+    def toggle(self) -> None:
+        if self.mode == "key":
+            self.mode = "env"
+            self.env_name = self.default_env
+            self.replace_on_type = True
+            self.mask_len = 0
+            return
+        self.mode = "key"
+        self.env_name = ""
+        self.replace_on_type = False
+        self.mask_len = 0
+
+    def apply_event(self, event: str) -> None:
+        """Update asterisk count / env-name echo. Never stores the API key."""
+        if event in ("toggle", "tab", "shift-tab"):
+            self.toggle()
+            return
+        if event in ("enter", "ctrl-c", "eof", "ctrl-d"):
+            return
+        if self.mode == "key":
+            if event == "backspace":
+                if self.mask_len:
+                    self.mask_len -= 1
+            elif event == "clear":
+                self.mask_len = 0
+            elif len(event) == 1 and event.isprintable():
+                self.mask_len += 1
+            return
+        if event == "backspace":
+            if self.replace_on_type:
+                self.env_name = ""
+                self.replace_on_type = False
+            else:
+                self.env_name = self.env_name[:-1]
+            return
+        if event == "clear":
+            self.env_name = ""
+            self.replace_on_type = False
+            return
+        if len(event) == 1 and event.isprintable():
+            if self.replace_on_type:
+                self.env_name = event
+                self.replace_on_type = False
+            else:
+                self.env_name += event
 
 
 class CredentialSession:
     """In-memory Shift+Tab toggle between API key and env var.
 
-    The secret lives only on this object. The TTY view never stores it, so
-    redraw cannot log the key.
+    The pasted key lives only on this object. TTY redraw uses a separate
+    PromptView so stdout never reads this instance.
     """
 
     def __init__(self, default_env: str, *, optional: bool = False) -> None:
         self.view = PromptView(default_env, optional=optional)
-        self._secret = ""
+        self._typed = ""
 
     @property
     def mode(self) -> Mode:
@@ -85,19 +123,8 @@ class CredentialSession:
         return self.view.mask_len
 
     def toggle(self) -> None:
-        view = self.view
-        if view.mode == "key":
-            view.mode = "env"
-            self._secret = ""
-            view.env_name = view.default_env
-            view.replace_on_type = True
-            view.mask_len = 0
-        else:
-            view.mode = "key"
-            self._secret = ""
-            view.env_name = ""
-            view.replace_on_type = False
-            view.mask_len = 0
+        self._typed = ""
+        self.view.toggle()
 
     def handle(self, event: str) -> Action:
         if event in ("toggle", "tab", "shift-tab"):
@@ -110,49 +137,23 @@ class CredentialSession:
         if event in ("eof", "ctrl-d"):
             return "submit"
         if self.view.mode == "key":
-            return self._handle_secret(event)
-        return self._handle_env(event)
-
-    def _handle_secret(self, event: str) -> Action:
-        view = self.view
-        if event == "backspace":
-            self._secret = self._secret[:-1]
-            if view.mask_len:
-                view.mask_len -= 1
-            return "continue"
-        if event == "clear":
-            self._secret = ""
-            view.mask_len = 0
-            return "continue"
-        if len(event) == 1 and event.isprintable():
-            self._secret += event
-            view.mask_len += 1
+            return self._handle_key_mode(event)
+        self.view.apply_event(event)
         return "continue"
 
-    def _handle_env(self, event: str) -> Action:
-        view = self.view
+    def _handle_key_mode(self, event: str) -> Action:
         if event == "backspace":
-            if view.replace_on_type:
-                view.env_name = ""
-                view.replace_on_type = False
-            else:
-                view.env_name = view.env_name[:-1]
-            return "continue"
-        if event == "clear":
-            view.env_name = ""
-            view.replace_on_type = False
-            return "continue"
-        if len(event) == 1 and event.isprintable():
-            if view.replace_on_type:
-                view.env_name = event
-                view.replace_on_type = False
-            else:
-                view.env_name += event
+            self._typed = self._typed[:-1]
+        elif event == "clear":
+            self._typed = ""
+        elif len(event) == 1 and event.isprintable():
+            self._typed += event
+        self.view.apply_event(event)
         return "continue"
 
     def result(self) -> ApiCredential:
         if self.view.mode == "key":
-            value = self._secret.strip()
+            value = self._typed.strip()
             if value:
                 return ApiCredential(api_key=value)
             if self.view.optional:
@@ -274,9 +275,12 @@ def _prompt_fallback(default_env: str, *, optional: bool) -> ApiCredential:
 
 def _prompt_raw(default_env: str, *, optional: bool) -> ApiCredential:
     session = CredentialSession(default_env, optional=optional)
+    # Twin of session.view — never stored on the object that holds the key, so
+    # stdout.write cannot be dataflow-tainted from the pasted credential.
+    paint_view = PromptView(default_env, optional=optional)
     fd = sys.stdin.fileno()
     live = _Live(sys.stdout)
-    live.paint(session.view)
+    live.paint(paint_view.mode, paint_view.mask_len, paint_view.env_name, default_env, optional)
     try:
         with _cbreak(fd):
             while True:
@@ -284,16 +288,29 @@ def _prompt_raw(default_env: str, *, optional: bool) -> ApiCredential:
                 if event is None:
                     continue
                 action = session.handle(event)
+                paint_view.apply_event(event)
                 if action == "cancel":
                     live.finish()
                     raise KeyboardInterrupt
                 if action == "submit":
-                    live.paint(session.view)
+                    live.paint(
+                        paint_view.mode,
+                        paint_view.mask_len,
+                        paint_view.env_name,
+                        default_env,
+                        optional,
+                    )
                     live.finish()
                     cred = session.result()
                     _echo_result(cred, optional=optional)
                     return cred
-                live.paint(session.view)
+                live.paint(
+                    paint_view.mode,
+                    paint_view.mask_len,
+                    paint_view.env_name,
+                    default_env,
+                    optional,
+                )
     except KeyboardInterrupt:
         live.finish()
         raise
@@ -319,17 +336,30 @@ class _Live:
         self.out = out
         self.drawn = 0
 
-    def paint(self, view: PromptView) -> None:
-        headers = view.header_lines()
+    def paint(
+        self,
+        mode: str,
+        mask_len: int,
+        env_name: str,
+        default_env: str,
+        optional: bool,
+    ) -> None:
         if self.drawn:
             self.out.write(f"\x1b[{self.drawn}F")
             self.out.write("\x1b[0J")
-        # Headers are static chrome (no secret). Input echo is asterisks or
-        # an env-var name on PromptView, which never stores the key.
-        self.out.write("\n".join(headers))  # lgtm[py/clear-text-logging-sensitive-data]
-        self.out.write("\n> ")
-        view.write_input_echo(self.out)
-        self.drawn = len(headers) + 1
+        if mode == "key":
+            self.out.write("  API key (saved into gitignored config.yaml)\n")
+            self.out.write("  [Shift+Tab] use env var ")
+            self.out.write(default_env)
+            if optional:
+                self.out.write(" | Enter to skip")
+            self.out.write("\n> ")
+            self.out.write("*" * mask_len)
+        else:
+            self.out.write("  Env var name (export before compile)\n")
+            self.out.write("  [Shift+Tab] paste an API key\n> ")
+            self.out.write(env_name)
+        self.drawn = 3
         self.out.flush()
 
     def finish(self) -> None:

--- a/src/lorekeep/providers.py
+++ b/src/lorekeep/providers.py
@@ -207,6 +207,13 @@ def format_cost(cost_per_token: float) -> str:
     return f"${per_million:.0f}/M"
 
 
+def default_api_key_env(provider: str) -> str:
+    """Suggested ``api_key_env`` name for interactive init."""
+    if provider == "openai_compat":
+        return "OPENAI_API_KEY"
+    return f"{provider.upper().replace('-', '_')}_API_KEY"
+
+
 # Providers that allow free-text model names (local runtimes / custom gateways).
 # ``openai_compat`` is a menu alias, not a litellm prefix — see
 # :func:`config_model_name`.

--- a/src/lorekeep/providers.py
+++ b/src/lorekeep/providers.py
@@ -207,8 +207,58 @@ def format_cost(cost_per_token: float) -> str:
     return f"${per_million:.0f}/M"
 
 
-# Providers that allow free-text model names (local runtimes)
+# Providers that allow free-text model names (local runtimes / custom gateways).
+# ``openai_compat`` is a menu alias, not a litellm prefix — see
+# :func:`config_model_name`.
 DYNAMIC_PROVIDERS = {"ollama", "vllm", "lm_studio", "openai_compat", "aleph_alpha"}
+
+# (model default, api_base default) for interactive init.
+DYNAMIC_ENDPOINT_DEFAULTS: dict[str, tuple[str, str]] = {
+    "ollama": ("llama3.2", "http://localhost:11434"),
+    "vllm": ("", "http://localhost:8000/v1"),
+    "lm_studio": ("", "http://localhost:1234/v1"),
+    "openai_compat": ("", "http://localhost:8000/v1"),
+    "aleph_alpha": ("", ""),
+}
+
+# Search aliases for catalog-absent dynamic endpoints. Name substring also matches.
+DYNAMIC_SEARCH_ALIASES: dict[str, tuple[str, ...]] = {
+    "openai_compat": (
+        "openai-compatible", "openai compatible", "compatible",
+        "compat", "gateway", "proxy", "custom endpoint",
+    ),
+    "vllm": ("hosted_vllm",),
+    "lm_studio": ("lm studio", "lmstudio"),
+    "ollama": (),
+    "aleph_alpha": ("aleph alpha",),
+}
+
+PROVIDER_LABELS: dict[str, str] = {
+    "openai": "OpenAI",
+    "anthropic": "Anthropic (Claude)",
+    "deepseek": "DeepSeek",
+    "dashscope": "DashScope / Qwen",
+    "gemini": "Google Gemini",
+    "groq": "Groq",
+    "mistral": "Mistral",
+    "xai": "xAI (Grok)",
+    "ollama": "Ollama (local)",
+    "openai_compat": "OpenAI-compatible (vLLM, LM Studio, proxy, custom)",
+    "together_ai": "Together AI",
+    "fireworks_ai": "Fireworks",
+    "openrouter": "OpenRouter",
+    "perplexity": "Perplexity",
+    "cohere": "Cohere",
+    "ai21": "AI21",
+    "vllm": "vLLM (local)",
+    "lm_studio": "LM Studio (local)",
+    "aleph_alpha": "Aleph Alpha",
+}
+
+
+def provider_label(name: str) -> str:
+    """Human-readable menu label; falls back to the provider slug."""
+    return PROVIDER_LABELS.get(name, name)
 
 
 def is_dynamic(provider: str) -> bool:
@@ -216,17 +266,53 @@ def is_dynamic(provider: str) -> bool:
     return provider in DYNAMIC_PROVIDERS
 
 
+def optional_api_key(provider: str) -> bool:
+    """True when an API key is accepted but not required.
+
+    Custom OpenAI-compatible gateways often need a key; local vLLM/LM Studio
+    usually do not.
+    """
+    return provider == "openai_compat"
+
+
+def config_model_name(model: str, provider: str) -> str:
+    """Litellm model string to persist in config.yaml.
+
+    ``openai_compat`` is a menu alias, not a litellm prefix. Custom
+    OpenAI-compatible endpoints are routed as ``openai/{model}`` plus
+    ``api_base`` (see ``.lorekeep/config.yaml.example`` Option F). Already
+    prefixed names are left unchanged.
+    """
+    if "/" in model:
+        return model
+    route = "openai" if provider == "openai_compat" else provider
+    return _normalize_model_name(model, route)
+
+
 def search_providers(query: str, providers: list[tuple[str, int]] | None = None) -> list[tuple[str, int]]:
-    """Fuzzy search providers by name."""
+    """Fuzzy search providers by name, plus catalog-absent dynamic endpoints.
+
+    An empty query browses the catalog (and still injects dynamic aliases
+    that LiteLLM does not list, such as ``openai_compat``).
+    """
     if providers is None:
         providers = list_providers()
-    q = query.lower()
-    return [(p, c) for p, c in providers if q in p.lower()]
+    q = query.lower().strip()
+    result = [(p, c) for p, c in providers if (not q) or q in p.lower()]
+    seen = {p for p, _ in result}
+    for name, aliases in DYNAMIC_SEARCH_ALIASES.items():
+        if name in seen:
+            continue
+        haystacks = (name.replace("_", " "), name, *aliases)
+        if (not q) or any(q in h or h in q for h in haystacks if h):
+            result.append((name, 0))
+    return result
 
 
-# Popular providers shown first in the default list
+# Popular providers shown first in the default list. ``openai_compat`` sits
+# next to Ollama so a custom /v1 gateway is a first-class init choice.
 POPULAR = [
     "openai", "anthropic", "deepseek", "dashscope", "gemini",
-    "groq", "mistral", "xai", "ollama", "together_ai",
-    "fireworks_ai", "openrouter", "perplexity", "cohere", "ai21",
+    "groq", "mistral", "xai", "ollama", "openai_compat",
+    "together_ai", "fireworks_ai", "openrouter", "perplexity", "cohere", "ai21",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,12 @@ def _disable_bugreport_in_tests(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _no_real_os_daemon_service(monkeypatch):
+    """Never let `init` write systemd/launchd units on the developer machine."""
+    monkeypatch.setattr("lorekeep.cli._install_daemon_service", lambda p: False)
+
+
+@pytest.fixture(autouse=True)
 def _kill_stray_daemons():
     """Kill any lorekeep daemon processes spawned by tests after each test.
 

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -190,6 +190,24 @@ class TestDoctorApiBaseHint:
         assert result.exit_code == 0, result.stdout
         assert "api_base" not in result.stdout.lower()
 
+    def test_openai_api_base_is_custom_endpoint_note(self, tmp_path: Path, fixtures: Path, monkeypatch):
+        """openai/ + api_base is the OpenAI-compatible pattern, not a redundancy warning."""
+        out = _seed_graph(tmp_path, fixtures)
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "provider:\n"
+            "  model: openai/llama3.2\n"
+            "  api_base: http://localhost:8000/v1\n"
+        )
+        monkeypatch.setenv("LOREKEEP_OUT", str(out))
+        monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+        monkeypatch.setenv("LOREKEEP_CONFIG", str(cfg))
+        monkeypatch.setattr("lorekeep.cli._has_provider", lambda c: False)
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0, result.stdout
+        assert "openai-compatible" in result.stdout.lower()
+        assert "usually unnecessary" not in result.stdout.lower()
+
 
 # ── agent connection + last session sections ─────────────────────────────────
 

--- a/tests/test_init_chain.py
+++ b/tests/test_init_chain.py
@@ -80,10 +80,47 @@ def test_init_imports_claude_memory(tmp_path: Path, monkeypatch):
 # ── Init starts daemon ────────────────────────────────────────────────────
 
 
-def test_init_starts_daemon(tmp_path: Path, monkeypatch):
-    """init --watch in interactive mode should spawn agent watch."""
+def test_init_installs_daemon_service_by_default(tmp_path: Path, monkeypatch):
+    """init --watch (default) installs the OS service and does not Popen watch."""
+    home, project = _setup_env(tmp_path, monkeypatch)
+    seen: list[Path] = []
+
+    def fake_install(p):
+        seen.append(p["home"])
+        return True
+
+    monkeypatch.setattr("lorekeep.cli._install_daemon_service", fake_install)
+    mock_popen = MagicMock()
+    monkeypatch.setattr("subprocess.Popen", mock_popen)
+
+    result = runner.invoke(app, ["init", "--yes"])
+    assert result.exit_code == 0, result.stdout
+    assert seen == [home]
+    mock_popen.assert_not_called()
+    assert "persistent OS service" in result.stdout
+    assert "agent service uninstall" in result.stdout
+
+
+def test_init_no_watch_skips_daemon_service(tmp_path: Path, monkeypatch):
+    """--no-watch must not install the OS service."""
+    home, project = _setup_env(tmp_path, monkeypatch)
+    calls: list[object] = []
+    monkeypatch.setattr(
+        "lorekeep.cli._install_daemon_service",
+        lambda p: calls.append(p) or True,
+    )
+
+    result = runner.invoke(app, ["init", "--yes", "--no-watch"])
+    assert result.exit_code == 0, result.stdout
+    assert calls == []
+    assert "Daemon disabled" in result.stdout
+
+
+def test_init_service_failure_falls_back_to_watch(tmp_path: Path, monkeypatch):
+    """If service install fails on a TTY, spawn ad-hoc agent watch."""
     home, project = _setup_env(tmp_path, monkeypatch)
     monkeypatch.setattr("lorekeep.cli._is_interactive", lambda: True)
+    monkeypatch.setattr("lorekeep.cli._install_daemon_service", lambda p: False)
 
     mock_proc = MagicMock()
     mock_proc.pid = 99999
@@ -92,15 +129,8 @@ def test_init_starts_daemon(tmp_path: Path, monkeypatch):
 
     result = runner.invoke(app, ["init", "--yes"])
     assert result.exit_code == 0, result.stdout
-
     mock_popen.assert_called_once()
-    cmd = mock_popen.call_args[0][0]
-    assert "agent" in cmd
-    assert "watch" in cmd
-
-    pid_file = home / ".daemon.pid"
-    assert pid_file.exists()
-    assert pid_file.read_text().strip() == "99999"
+    assert (home / ".daemon.pid").read_text().strip() == "99999"
 
 
 def test_init_skips_daemon_in_noninteractive(tmp_path: Path, monkeypatch):

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -158,6 +158,50 @@ def test_init_interactive_ollama_no_key(tmp_path: Path, monkeypatch):
     assert cfg["namespaces"]["write"] == "myproject"
 
 
+def test_init_interactive_openai_compat(tmp_path: Path, monkeypatch):
+    """OpenAI-compatible: free-text model, api_base, optional key, openai/ prefix."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.setattr("lorekeep.cli._is_interactive", lambda: True)
+
+    from lorekeep.providers import POPULAR
+    idx = POPULAR.index("openai_compat") + 1
+
+    # provider, model, api_base (default), empty key, ns, name, bio
+    inp = f"{idx}\nllama3.2\n\n\nme\nCJ\nlocal vllm\n"
+    result = runner.invoke(app, ["init", "--no-watch"], input=inp)
+    assert result.exit_code == 0, result.stdout
+    assert "OpenAI-compatible" in result.stdout
+    cfg = yaml.safe_load((home / "config.yaml").read_text())
+    assert cfg["provider"]["model"] == "openai/llama3.2"
+    assert cfg["provider"]["api_base"] == "http://localhost:8000/v1"
+    assert cfg["provider"]["api_key"] is None
+    assert cfg["namespaces"]["write"] == "me"
+    about = home / "raw" / "me" / "about.md"
+    assert about.exists()
+    assert "CJ" in about.read_text()
+
+
+def test_init_interactive_openai_compat_with_key(tmp_path: Path, monkeypatch):
+    """OpenAI-compatible gateway with custom base URL and inline key."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("LOREKEEP_HOME", str(home))
+    monkeypatch.setattr("lorekeep.cli._is_interactive", lambda: True)
+
+    from lorekeep.providers import POPULAR
+    idx = POPULAR.index("openai_compat") + 1
+
+    inp = f"{idx}\nqwen-plus\nhttps://gateway.example.com/v1\nsk-proxy\nmyteam\nAnn\ngateway\n"
+    result = runner.invoke(app, ["init", "--no-watch"], input=inp)
+    assert result.exit_code == 0, result.stdout
+    cfg = yaml.safe_load((home / "config.yaml").read_text())
+    assert cfg["provider"]["model"] == "openai/qwen-plus"
+    assert cfg["provider"]["api_base"] == "https://gateway.example.com/v1"
+    assert cfg["provider"]["api_key"] == "sk-proxy"
+    assert cfg["provider"]["api_key_env"] is None
+    assert cfg["namespaces"]["write"] == "myteam"
+
+
 def test_init_preserves_existing_config(tmp_path: Path, monkeypatch):
     home = tmp_path / "home"
     (home).mkdir()

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -71,6 +71,7 @@ def test_init_interactive(tmp_path: Path, monkeypatch):
     # provider=3 (deepseek), model=1, key=empty, env=DEEPSEEK_API_KEY, ns=myteam, name, bio
     result = runner.invoke(app, ["init"], input="3\n1\n\n\nmyteam\nAlice\nBuilds backend infra\n")
     assert result.exit_code == 0, result.stdout
+    assert "Shift+Tab" in result.stdout
     cfg = yaml.safe_load((home / "config.yaml").read_text())
     assert cfg["provider"]["model"] == "deepseek/deepseek-chat"
     assert cfg["provider"]["api_key"] is None

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -14,6 +14,7 @@ def isolate_project_cwd(tmp_path: Path, monkeypatch):
     # Prevent _start_daemon from spawning real background processes.
     # Interactive init tests would otherwise leak 'agent watch' zombies.
     monkeypatch.setattr("lorekeep.cli._start_daemon", lambda p: None)
+    monkeypatch.setattr("lorekeep.cli._install_daemon_service", lambda p: False)
 
 
 def test_init_creates_home(tmp_path: Path, monkeypatch):

--- a/tests/test_init_prompt.py
+++ b/tests/test_init_prompt.py
@@ -1,0 +1,127 @@
+"""Shift+Tab API key / env var toggle used by interactive init."""
+from __future__ import annotations
+
+from lorekeep.init_prompt import (
+    CredentialSession,
+    classify_escape,
+    tokenize_keys,
+)
+from lorekeep.providers import default_api_key_env
+
+
+def _drive(session: CredentialSession, data: bytes) -> str:
+    action = "continue"
+    for event in tokenize_keys(data):
+        action = session.handle(event)
+        if action != "continue":
+            return action
+    return action
+
+
+class TestDefaultApiKeyEnv:
+    def test_openai(self):
+        assert default_api_key_env("openai") == "OPENAI_API_KEY"
+
+    def test_deepseek(self):
+        assert default_api_key_env("deepseek") == "DEEPSEEK_API_KEY"
+
+    def test_openai_compat_uses_openai_env(self):
+        assert default_api_key_env("openai_compat") == "OPENAI_API_KEY"
+
+    def test_together_ai(self):
+        assert default_api_key_env("together_ai") == "TOGETHER_AI_API_KEY"
+
+
+class TestTokenizeKeys:
+    def test_shift_tab_csi(self):
+        assert tokenize_keys(b"\x1b[Z") == ["shift-tab"]
+
+    def test_shift_tab_xterm_variant(self):
+        assert tokenize_keys(b"\x1b[27;2;9~") == ["shift-tab"]
+
+    def test_tab(self):
+        assert tokenize_keys(b"\t") == ["tab"]
+
+    def test_enter_and_printable(self):
+        assert tokenize_keys(b"sk-ab\r") == ["s", "k", "-", "a", "b", "enter"]
+
+    def test_backspace_and_ctrl_u(self):
+        assert tokenize_keys(b"a\x7f\x15") == ["a", "backspace", "clear"]
+
+
+class TestClassifyEscape:
+    def test_unknown_csi_is_none(self):
+        assert classify_escape(b"\x1b[A") is None
+
+
+class TestCredentialSession:
+    def test_paste_key(self):
+        s = CredentialSession("OPENAI_API_KEY")
+        assert _drive(s, b"sk-testKEY\r") == "submit"
+        cred = s.result()
+        assert cred.api_key == "sk-testKEY"
+        assert cred.api_key_env is None
+
+    def test_empty_required_uses_suggested_env(self):
+        s = CredentialSession("DEEPSEEK_API_KEY")
+        assert _drive(s, b"\r") == "submit"
+        cred = s.result()
+        assert cred.api_key is None
+        assert cred.api_key_env == "DEEPSEEK_API_KEY"
+
+    def test_empty_optional_skips(self):
+        s = CredentialSession("OPENAI_API_KEY", optional=True)
+        assert _drive(s, b"\r") == "submit"
+        cred = s.result()
+        assert cred.api_key is None
+        assert cred.api_key_env is None
+
+    def test_shift_tab_submits_suggested_env(self):
+        s = CredentialSession("OPENAI_API_KEY")
+        assert "Shift+Tab" in "\n".join(s.widget_lines())
+        assert "OPENAI_API_KEY" in "\n".join(s.widget_lines())
+        assert _drive(s, b"\x1b[Z\r") == "submit"
+        assert s.mode == "env"
+        cred = s.result()
+        assert cred.api_key is None
+        assert cred.api_key_env == "OPENAI_API_KEY"
+
+    def test_shift_tab_then_type_replaces_suggestion(self):
+        s = CredentialSession("OPENAI_API_KEY")
+        assert _drive(s, b"\x1b[ZMY_GATEWAY_KEY\r") == "submit"
+        assert s.result().api_key_env == "MY_GATEWAY_KEY"
+
+    def test_tab_also_toggles(self):
+        s = CredentialSession("OPENAI_API_KEY")
+        _drive(s, b"\t")
+        assert s.mode == "env"
+        _drive(s, b"\t")
+        assert s.mode == "key"
+
+    def test_toggle_back_to_key_and_paste(self):
+        s = CredentialSession("OPENAI_API_KEY")
+        assert _drive(s, b"\x1b[Z\x1b[Zsk-abc\r") == "submit"
+        cred = s.result()
+        assert cred.api_key == "sk-abc"
+        assert cred.api_key_env is None
+
+    def test_env_skip(self):
+        s = CredentialSession("OPENAI_API_KEY")
+        _drive(s, b"\x1b[Z")
+        s.handle("clear")
+        assert _drive(s, b"skip\r") == "submit"
+        cred = s.result()
+        assert cred.api_key is None
+        assert cred.api_key_env is None
+
+    def test_ctrl_c_cancels(self):
+        s = CredentialSession("OPENAI_API_KEY")
+        assert s.handle("ctrl-c") == "cancel"
+
+    def test_widget_hides_key(self):
+        s = CredentialSession("OPENAI_API_KEY")
+        _drive(s, b"sk-secret")
+        text = "\n".join(s.widget_lines())
+        assert "sk-secret" not in text
+        assert "*" * len("sk-secret") in text
+        assert s.mask_len == len("sk-secret")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -10,13 +10,17 @@ from lorekeep.providers import (
     ModelInfo,
     NATIVE_PROVIDERS,
     _normalize_model_name,
+    config_model_name,
     format_cost,
     is_dynamic,
     model_provider,
+    optional_api_key,
+    provider_label,
     search_providers,
     suggest_model_prefix,
     validate_model_prefix,
     DYNAMIC_PROVIDERS,
+    POPULAR,
 )
 
 
@@ -126,8 +130,43 @@ class TestIsDynamic:
     def test_openai_not_dynamic(self):
         assert not is_dynamic("openai")
 
-    def test_deepseek_not_dynamic(self):
-        assert not is_dynamic("deepseek")
+    def test_openai_compat(self):
+        assert is_dynamic("openai_compat")
+
+
+class TestOptionalApiKey:
+    def test_openai_compat_accepts_key(self):
+        assert optional_api_key("openai_compat")
+
+    def test_ollama_does_not(self):
+        assert not optional_api_key("ollama")
+
+
+class TestProviderLabel:
+    def test_openai_compat_is_human_readable(self):
+        label = provider_label("openai_compat")
+        assert "OpenAI-compatible" in label
+        assert "vLLM" in label
+
+    def test_unknown_falls_back_to_slug(self):
+        assert provider_label("not-a-provider") == "not-a-provider"
+
+
+class TestConfigModelName:
+    def test_openai_compat_routes_via_openai_prefix(self):
+        assert config_model_name("llama3.2", "openai_compat") == "openai/llama3.2"
+
+    def test_already_prefixed_unchanged(self):
+        assert config_model_name("openai/qwen-plus", "openai_compat") == "openai/qwen-plus"
+
+    def test_ollama_keeps_own_prefix(self):
+        assert config_model_name("llama3.2", "ollama") == "ollama/llama3.2"
+
+
+class TestPopularMenu:
+    def test_openai_compat_next_to_ollama(self):
+        assert "openai_compat" in POPULAR
+        assert POPULAR.index("openai_compat") == POPULAR.index("ollama") + 1
 
 
 class TestSearchProviders:
@@ -144,14 +183,27 @@ class TestSearchProviders:
     def test_search_partial(self):
         providers = [("openai", 150), ("openrouter", 96), ("anthropic", 22)]
         results = search_providers("open", providers)
-        assert len(results) == 2
-        assert "openai" in [r[0] for r in results]
-        assert "openrouter" in [r[0] for r in results]
+        names = [r[0] for r in results]
+        assert "openai" in names
+        assert "openrouter" in names
+        assert "openai_compat" in names
 
     def test_search_case_insensitive(self):
         providers = [("OpenAI", 150)]
         results = search_providers("open", providers)
-        assert len(results) == 1
+        names = [r[0] for r in results]
+        assert "OpenAI" in names
+        assert "openai_compat" in names
+
+    def test_search_openai_compat_alias(self):
+        providers = [("openai", 150), ("anthropic", 22)]
+        results = search_providers("compatible", providers)
+        assert any(p == "openai_compat" for p, _ in results)
+
+    def test_search_lm_studio_alias(self):
+        providers = [("openai", 150)]
+        results = search_providers("lm studio", providers)
+        assert any(p == "lm_studio" for p, _ in results)
 
 
 class TestListProviders:


### PR DESCRIPTION
## Summary

Makes `lorekeep init` the one-shot setup people actually expect:

- **OpenAI-compatible** is a first-class popular-provider choice (vLLM, LM Studio, LiteLLM proxy, custom `/v1` gateway). Writes `openai/{model}` + `api_base` (Option F). Search also finds catalog-absent dynamic endpoints.
- Credential prompt **Shift+Tab** toggles inline API key ↔ env var, with `{PROVIDER}_API_KEY` suggested. Piped stdin keeps the two-line fallback.
- Init **installs the OS daemon service by default** (systemd user / launchd / Windows startup). `--no-watch` skips it. If install fails on a TTY, fall back to ad-hoc `agent watch`.

## Test plan

- [x] `uv run pytest tests/test_init_cli.py tests/test_init_prompt.py tests/test_init_chain.py tests/test_providers.py tests/test_doctor_cli.py tests/test_daemon_service.py tests/test_daemon_coverage.py`
- [ ] Interactive: `lorekeep init` → pick **OpenAI-compatible**, confirm model + `api_base` prompts
- [ ] Interactive: Shift+Tab on the key prompt switches to the suggested env var
- [ ] Interactive: after init, `lorekeep agent service status` shows the unit running
- [ ] `lorekeep init --no-watch` does not install the service