### PR TITLE
fix(serve): treat stdio disconnect as clean shutdown

### DIFF
--- a/src/lorekeep/cli.py
+++ b/src/lorekeep/cli.py
@@ -875,14 +875,32 @@ def serve(
         transport, len(allowed),
         extra={"event": "mcp.start"},
     )
+    from lorekeep.stdio_errors import (
+        disconnect_error_types,
+        is_client_disconnect,
+        prepare_windows_stdio_loop,
+    )
+
+    if transport == "stdio":
+        prepare_windows_stdio_loop()
     try:
         mcp.run(transport=transport)
     except Exception as exc:
+        if is_client_disconnect(exc):
+            log.info(
+                "MCP client disconnected transport=%s error_types=%s",
+                transport,
+                ",".join(disconnect_error_types(exc)),
+                extra={"event": "mcp.stop"},
+            )
+            return
         log.exception(
             "MCP server stopped unexpectedly error_type=%s", type(exc).__name__,
             extra={"event": "mcp.failed"},
         )
-        raise
+        # Do not re-raise: sys.excepthook would open a second auto-issue
+        # (runtime.unhandled) for the same failure.
+        raise typer.Exit(code=1)
 
 
 mcp_app = typer.Typer(help="Coding-agent integration.")

--- a/src/lorekeep/stdio_errors.py
+++ b/src/lorekeep/stdio_errors.py
@@ -1,0 +1,78 @@
+"""Classify MCP stdio shutdown vs real serve failures.
+
+When a coding agent on Windows (and sometimes Unix) closes the MCP pipe,
+``mcp.server.stdio``'s anyio TaskGroup exits with ``ExceptionGroup`` wrapping
+``ClosedResourceError`` / ``BrokenResourceError``. That is a client disconnect,
+not a Lorekeep bug -- logging it as ``mcp.failed`` then re-raising also fires
+``runtime.unhandled`` and auto-opens duplicate GitHub issues.
+"""
+from __future__ import annotations
+
+import errno
+import sys
+
+
+def _anyio_disconnect_types() -> tuple[type[BaseException], ...]:
+    types: list[type[BaseException]] = []
+    try:
+        import anyio
+
+        for name in ("ClosedResourceError", "BrokenResourceError", "EndOfStream"):
+            cls = getattr(anyio, name, None)
+            if isinstance(cls, type):
+                types.append(cls)
+    except ImportError:
+        pass
+    return tuple(types)
+
+
+_DISCONNECT: tuple[type[BaseException], ...] = (
+    BrokenPipeError,
+    ConnectionResetError,
+    ConnectionAbortedError,
+    EOFError,
+    *_anyio_disconnect_types(),
+)
+
+
+def is_client_disconnect(exc: BaseException) -> bool:
+    """True when *exc* (or every ExceptionGroup member) is a closed stdio pipe."""
+    if isinstance(exc, _DISCONNECT):
+        return True
+    if isinstance(exc, OSError) and exc.errno in (
+        errno.EPIPE,
+        errno.ECONNRESET,
+        errno.ECONNABORTED,
+    ):
+        return True
+    if isinstance(exc, BaseExceptionGroup):
+        return bool(exc.exceptions) and all(
+            is_client_disconnect(inner) for inner in exc.exceptions
+        )
+    return False
+
+
+def prepare_windows_stdio_loop() -> None:
+    """Use the selector loop on Windows so asyncio can wrap stdin/stdout pipes.
+
+    The default ProactorEventLoop cannot ``add_reader`` on stdio, which is what
+    anyio/mcp stdio transport needs. No-op on non-Windows.
+    """
+    if sys.platform != "win32":
+        return
+    import asyncio
+
+    policy_cls = getattr(asyncio, "WindowsSelectorEventLoopPolicy", None)
+    if policy_cls is None:
+        return
+    asyncio.set_event_loop_policy(policy_cls())
+
+
+def disconnect_error_types(exc: BaseException) -> list[str]:
+    """Innermost exception type names -- for logs, never messages."""
+    if isinstance(exc, BaseExceptionGroup):
+        names: list[str] = []
+        for inner in exc.exceptions:
+            names.extend(disconnect_error_types(inner))
+        return names
+    return [type(exc).__name__]

--- a/tests/test_serve_cli.py
+++ b/tests/test_serve_cli.py
@@ -163,3 +163,53 @@ def test_serve_star_sees_everything(tmp_path: Path, fixtures: Path, monkeypatch)
     assert ms.get_node("svc:a") is not None
     assert ms.get_node("svc:b") is not None
     assert ms.get_node("svc:c") is not None
+
+
+def _graph_home(tmp_path: Path, fixtures: Path, monkeypatch) -> None:
+    import shutil
+
+    out = tmp_path / "graph"
+    out.mkdir()
+    shutil.copy(fixtures / "gold/payments.facts.jsonl", out / "facts.jsonl")
+    monkeypatch.setenv("LOREKEEP_OUT", str(out))
+    monkeypatch.setenv("LOREKEEP_SCHEMA", str(fixtures / "schema.json"))
+    monkeypatch.setenv("LOREKEEP_CONFIG", str(tmp_path / "config.yaml"))
+
+
+def test_serve_stdio_disconnect_is_clean_exit(tmp_path: Path, fixtures: Path, monkeypatch):
+    """Windows MCP clients closing the pipe must not look like a crash (#271-#274)."""
+    import anyio
+    import lorekeep.mcp_server as ms
+
+    _graph_home(tmp_path, fixtures, monkeypatch)
+
+    class FakeMCP:
+        def run(self, transport=None):
+            raise ExceptionGroup(
+                "unhandled errors in a TaskGroup",
+                [anyio.ClosedResourceError()],
+            )
+
+    monkeypatch.setattr(ms, "mcp", FakeMCP())
+    result = runner.invoke(app, ["serve"])
+    assert result.exit_code == 0, result.stdout
+    assert result.exception is None
+
+
+def test_serve_unexpected_error_exits_without_reraise(
+    tmp_path: Path, fixtures: Path, monkeypatch,
+):
+    """mcp.failed must not also become runtime.unhandled via a bare re-raise."""
+    import lorekeep.mcp_server as ms
+
+    _graph_home(tmp_path, fixtures, monkeypatch)
+
+    class FakeMCP:
+        def run(self, transport=None):
+            raise RuntimeError("graph exploded")
+
+    monkeypatch.setattr(ms, "mcp", FakeMCP())
+    result = runner.invoke(app, ["serve"])
+    assert result.exit_code == 1
+    # typer.Exit, not the original RuntimeError (that would hit sys.excepthook).
+    assert not isinstance(result.exception, RuntimeError)

--- a/tests/test_stdio_errors.py
+++ b/tests/test_stdio_errors.py
@@ -1,0 +1,81 @@
+"""Client-disconnect classification for MCP stdio (Windows auto-issues #271-#274)."""
+from __future__ import annotations
+
+import errno
+
+import anyio
+import pytest
+
+from lorekeep.stdio_errors import (
+    is_client_disconnect,
+    prepare_windows_stdio_loop,
+)
+
+
+def test_closed_resource_is_disconnect():
+    assert is_client_disconnect(anyio.ClosedResourceError())
+
+
+def test_broken_pipe_is_disconnect():
+    assert is_client_disconnect(BrokenPipeError())
+
+
+def test_oserror_epipe_is_disconnect():
+    assert is_client_disconnect(OSError(errno.EPIPE, "broken pipe"))
+
+
+def test_valueerror_is_not_disconnect():
+    assert is_client_disconnect(ValueError("nope")) is False
+
+
+def test_exceptiongroup_of_closed_resource_is_disconnect():
+    exc = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [anyio.ClosedResourceError()],
+    )
+    assert is_client_disconnect(exc)
+
+
+def test_nested_exceptiongroup_of_broken_resource_is_disconnect():
+    inner = ExceptionGroup("inner", [anyio.BrokenResourceError()])
+    outer = ExceptionGroup("unhandled errors in a TaskGroup", [inner])
+    assert is_client_disconnect(outer)
+
+
+def test_exceptiongroup_with_real_bug_is_not_disconnect():
+    exc = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [anyio.ClosedResourceError(), RuntimeError("boom")],
+    )
+    assert is_client_disconnect(exc) is False
+
+
+def test_empty_exceptiongroup_is_not_disconnect():
+    with pytest.raises(ValueError):
+        ExceptionGroup("empty", [])
+
+
+def test_prepare_windows_stdio_loop_is_noop_off_windows(monkeypatch):
+    import asyncio
+
+    monkeypatch.setattr("lorekeep.stdio_errors.sys.platform", "linux")
+    called = []
+    monkeypatch.setattr(asyncio, "set_event_loop_policy", lambda p: called.append(p))
+    prepare_windows_stdio_loop()
+    assert called == []
+
+
+def test_prepare_windows_stdio_loop_sets_selector_policy(monkeypatch):
+    import asyncio
+
+    monkeypatch.setattr("lorekeep.stdio_errors.sys.platform", "win32")
+    set_policies: list[object] = []
+
+    class FakePolicy:
+        pass
+
+    monkeypatch.setattr(asyncio, "WindowsSelectorEventLoopPolicy", FakePolicy, raising=False)
+    monkeypatch.setattr(asyncio, "set_event_loop_policy", lambda p: set_policies.append(p))
+    prepare_windows_stdio_loop()
+    assert len(set_policies) == 1
+    assert isinstance(set_policies[0], FakePolicy)


### PR DESCRIPTION
## Why

Open `[auto]` issues #271 #272 #273 #274 are one Windows MCP stdio shutdown, reported twice per process:

1. `serve()` catches `ExceptionGroup` from `mcp.server.stdio` / anyio TaskGroup, logs `mcp.failed`, **re-raises**
2. `sys.excepthook` then logs `runtime.unhandled`

The inner error (redacted in the auto-issue) is a closed stdin pipe when the coding agent disconnects -- not a Lorekeep graph/compile bug.

## What

- Classify `ClosedResourceError` / `BrokenResourceError` / `BrokenPipeError` (including nested `ExceptionGroup`) as client disconnect
- Log `mcp.stop` at INFO and exit 0
- Unexpected serve errors still log `mcp.failed` but raise `typer.Exit(1)` so they do not also become `runtime.unhandled`
- On Windows stdio, switch to `WindowsSelectorEventLoopPolicy` so asyncio can wrap stdin pipes

## Tests

`uv run --locked pytest -q` -- 1640 passed, 2 skipped.

Fixes #271
Fixes #272
Fixes #273
Fixes #274